### PR TITLE
feat: Get Consignments per Trader

### DIFF
--- a/backend/cmd/server/main.go
+++ b/backend/cmd/server/main.go
@@ -90,6 +90,7 @@ func main() {
 	mux.HandleFunc("GET /api/hscodes", wm.HandleGetHSCodes)
 	mux.HandleFunc("GET /api/workflows/templates", wm.HandleGetWorkflowTemplate)
 	mux.HandleFunc("POST /api/consignments", wm.HandleCreateConsignment)
+	mux.HandleFunc("GET /api/consignments", wm.HandleGetConsignments)
 	mux.HandleFunc("GET /api/consignments/{consignmentID}", wm.HandleGetConsignment)
 
 	// Set up graceful shutdown

--- a/backend/internal/workflow/manager.go
+++ b/backend/internal/workflow/manager.go
@@ -109,3 +109,8 @@ func (m *Manager) HandleCreateConsignment(w http.ResponseWriter, r *http.Request
 func (m *Manager) HandleGetConsignment(w http.ResponseWriter, r *http.Request) {
 	m.wr.HandleGetConsignment(w, r)
 }
+
+// HandleGetConsignments handles GET requests to retrieve consignments
+func (m *Manager) HandleGetConsignments(w http.ResponseWriter, r *http.Request) {
+	m.wr.HandleGetConsignments(w, r)
+}

--- a/backend/internal/workflow/model/consignment_dto.go
+++ b/backend/internal/workflow/model/consignment_dto.go
@@ -14,3 +14,38 @@ type CreateConsignmentDTO struct {
 	Items     []CreateWorkflowForItemDTO `json:"items" binding:"required,dive,required"`           // List of items in the consignment
 	TraderID  *string                    `json:"traderId,omitempty"`                               // Reference to the Trader
 }
+
+// ConsignmentResponse represents the response data for a consignment.
+type ConsignmentResponse struct {
+	ID        uuid.UUID        `json:"id"`        // Consignment ID
+	TradeFlow TradeFlow        `json:"tradeFlow"` // Type of trade flow: IMPORT or EXPORT
+	Items     []Item           `json:"items"`     // List of items in the consignment
+	TraderID  string           `json:"traderId"`  // Reference to the Trader
+	State     ConsignmentState `json:"state"`     // IN_PROGRESS, REQUIRES_REWORK, FINISHED
+}
+
+// ToConsignmentResponse converts a Consignment model to a ConsignmentResponse DTO.
+func (c *Consignment) ToConsignmentResponse() ConsignmentResponse {
+	return ConsignmentResponse{
+		ID:        c.ID,
+		TradeFlow: c.TradeFlow,
+		Items:     c.Items,
+		TraderID:  c.TraderID,
+		State:     c.State,
+	}
+}
+
+// ConsignmentListResponseDTO represents the response data for a consignment.
+type ConsignmentListResponseDTO struct {
+	TotalCount int64                 `json:"totalCount"`
+	Items      []ConsignmentResponse `json:"items"`
+	Offset     int                   `json:"offset"`
+	Limit      int                   `json:"limit"`
+}
+
+// ConsignmentTraderFilter will be used when querying as batch
+type ConsignmentTraderFilter struct {
+	TraderID string `json:"traderId,omitempty"`
+	Offset   *int   `json:"offset,omitempty"`
+	Limit    *int   `json:"limit,omitempty"`
+}

--- a/backend/internal/workflow/model/hs_code.go
+++ b/backend/internal/workflow/model/hs_code.go
@@ -22,7 +22,7 @@ type HSCodeFilter struct {
 // HSCodeListResult represents the result of querying HS codes with pagination
 type HSCodeListResult struct {
 	TotalCount int64    `json:"totalCount"`
-	HSCodes    []HSCode `json:"hsCodes"`
+	Items      []HSCode `json:"items"`
 	Offset     int      `json:"offset"`
 	Limit      int      `json:"limit"`
 }

--- a/backend/utils/pagination.go
+++ b/backend/utils/pagination.go
@@ -1,0 +1,21 @@
+package utils
+
+const pageSizeDefault = 20
+const pageSizeMax = 100
+
+// GetPaginationParams calculates the offset and limit for pagination based on the provided values.
+// If offset or limit are nil, default values are used. The limit is capped at a maximum value.
+func GetPaginationParams(offset *int, limit *int) (int, int) {
+	finalOffset := 0
+	finalLimit := pageSizeDefault
+
+	if offset != nil && *offset >= 0 {
+		finalOffset = *offset
+	}
+
+	if limit != nil && *limit > 0 {
+		finalLimit = min(*limit, pageSizeMax)
+	}
+
+	return finalOffset, finalLimit
+}


### PR DESCRIPTION
## Summary

Implemented a new endpoint to retrieve consignments filtered by trader ID with pagination support, following consistent API patterns across the codebase.

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [x] Refactoring (no functional changes)
- [x] Performance improvement
- [ ] Other (please describe):

## Changes Made

New Endpoint
- GET `/api/consignments?traderId={traderId}&offset={offset}&limit={limit}`
     - Required query parameter: traderId
     - Optional query parameters: offset, limit
     - Returns paginated list of consignments for a specific trader

Updated `HSCodeListResult` DTO to use `Items` field for consistency with other paginated responses

## Testing

- [x] I have tested this change locally
- [ ] I have added unit tests for new functionality
- [ ] I have tested edge cases
- [ ] All existing tests pass

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have checked that there are no merge conflicts

## Related Issues

Closes #40 