### PR TITLE
fix: Handle empty cache in NewLocalStateManagerWithCache initialization

### DIFF
--- a/backend/internal/task/persistence/state_manager.go
+++ b/backend/internal/task/persistence/state_manager.go
@@ -39,13 +39,14 @@ func NewLocalStateManager(taskStore TaskStoreInterface, taskID uuid.UUID) (*Loca
 }
 
 func NewLocalStateManagerWithCache(taskStore TaskStoreInterface, taskID uuid.UUID, cache json.RawMessage) (*LocalStateManager, error) {
-	var cacheMap map[string]any
+	cacheMap := make(map[string]any)
 
-	err := json.Unmarshal(cache, &cacheMap)
-
-	if err != nil {
-		return nil, fmt.Errorf("failed to unmarshal local state: %w", err)
+	if len(cache) > 0 && string(cache) != "null" {
+		if err := json.Unmarshal(cache, &cacheMap); err != nil {
+			return nil, fmt.Errorf("failed to unmarshal local state: %w", err)
+		}
 	}
+
 	return &LocalStateManager{
 		taskStore: taskStore,
 		taskID:    taskID,


### PR DESCRIPTION
## Summary

There was a bug whenever a task didn't have `local_state` value, executing `HandleTask()` by calling the API causes issue when `json.Unmarshal`.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Other (please describe):

## Changes Made

- Initializes an empty `local_state` when there are no values in the db entry.

## Testing

- [x] I have tested this change locally
- [ ] I have added unit tests for new functionality
- [x] I have tested edge cases
- [ ] All existing tests pass

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have checked that there are no merge conflicts