### PR TITLE
fix: Remove globalContext and traderId from consignment creation request payload

### DIFF
--- a/backend/internal/workflow/model/consignment.go
+++ b/backend/internal/workflow/model/consignment.go
@@ -63,10 +63,8 @@ type CreateConsignmentItemDTO struct {
 
 // CreateConsignmentDTO represents the data required to create a consignment.
 type CreateConsignmentDTO struct {
-	Flow          ConsignmentFlow            `json:"flow" binding:"required,oneof=IMPORT EXPORT"` // e.g., IMPORT, EXPORT
-	TraderID      *string                    `json:"traderId,omitempty"`                          // ID of the trader associated with the consignment (optional)
-	Items         []CreateConsignmentItemDTO `json:"items" binding:"required,dive,required"`      // Items in the consignment
-	GlobalContext map[string]any             `json:"globalContext,omitempty"`                     // Global context for the consignment (optional)
+	Flow  ConsignmentFlow            `json:"flow" binding:"required,oneof=IMPORT EXPORT"` // e.g., IMPORT, EXPORT
+	Items []CreateConsignmentItemDTO `json:"items" binding:"required,dive,required"`      // Items in the consignment
 }
 
 // UpdateConsignmentDTO represents the data required to update a consignment.

--- a/backend/internal/workflow/router/consignment_router.go
+++ b/backend/internal/workflow/router/consignment_router.go
@@ -33,20 +33,19 @@ func (c *ConsignmentRouter) HandleCreateConsignment(w http.ResponseWriter, r *ht
 	}
 
 	// TODO: Get trader ID from auth context
-	// For now, if traderId is not provided in the request, use a default
-	if req.TraderID == nil {
-		defaultTraderID := "trader-123"
-		req.TraderID = &defaultTraderID
-	}
+	// For now use a mock trader ID if not provided
+	traderId := "TRADER-001"
 
-	// Initialize global context if nil
-	if req.GlobalContext == nil {
-		req.GlobalContext = make(map[string]interface{})
+	// TODO: Inital global context should be get from auth context or other sources. For now, we will use mock data.
+	globalContext := map[string]any{
+		"roc:br:br_no":   "PV 00234567",
+		"ird:vat:vat_no": "114234222-7000",
+		"ird:tin:tin_no": "114234222",
 	}
 
 	// Create consignment through service
 	// Task registration happens within the transaction via pre-commit callback
-	consignment, _, err := c.cs.InitializeConsignment(r.Context(), &req)
+	consignment, _, err := c.cs.InitializeConsignment(r.Context(), &req, traderId, globalContext)
 	if err != nil {
 		http.Error(w, "failed to create consignment: "+err.Error(), http.StatusInternalServerError)
 		return


### PR DESCRIPTION
## Summary

This PR removes `globalContext` and `traderId` from the consignment creation request payload (`CreateConsignmentDTO`) and initializes them in the backend instead, addressing issue #94. These values are now set with mock data in the handler, with TODOs added to indicate they should eventually be retrieved from the authentication context.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Other (please describe):

## Changes Made

### API Contract Changes
- Removed `traderId` field from `CreateConsignmentDTO` 
- Removed `globalContext` field from `CreateConsignmentDTO`
- Simplified the POST `/api/v1/consignments` request payload to only include `flow` and `items`

### Backend Implementation
- Updated `HandleCreateConsignment` to initialize trader ID with mock value `TRADER-001`
- Updated `HandleCreateConsignment` to initialize global context with mock business and tax identifiers:
  - `roc:br:br_no`: Business registration number
  - `ird:vat:vat_no`: VAT number
  - `ird:tin:tin_no`: Tax identification number
- Modified `InitializeConsignment` method signature to accept `traderId` and `globalContext` as explicit parameters
- Updated `initializeConsignmentInTx` to use the provided parameters instead of extracting from DTO

### Documentation
- Added TODO comments indicating these values should be retrieved from authentication context in the future

## Testing

- [x] I have tested this change locally
- [ ] I have added unit tests for new functionality
- [x] I have tested edge cases
- [x] All existing tests pass

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have checked that there are no merge conflicts

## Related Issues

Closes #94