### PR TITLE
fix: Update seed data and correct SQL script execution order

### DIFF
--- a/backend/internal/database/migrations/006_insert_seed_data.sql
+++ b/backend/internal/database/migrations/006_insert_seed_data.sql
@@ -8,4 +8,4 @@ UPDATE workflow_node_templates SET config = '{"agency": "NPQS", "formId": "22222
 WHERE id = 'c0000003-0003-0003-0003-000000000003';
 
 UPDATE workflow_node_templates SET config = '{"agency": "EDB", "formId": "33333333-3333-3333-3333-333333333333", "service": "food-control-administration-unit", "callback": {"response": {"display": {"formId": "95d7e7fe-5be0-43cb-ac71-94bc70d3a01d"}}}, "submission": {"url": "http://localhost:8082/api/oga/inject"}}'::jsonb
-WHERE id = 'c0000003-0003-0003-0003-000000000002';
+WHERE id = 'c0000003-0003-0003-0003-000000000004';

--- a/backend/internal/database/migrations/run.sh
+++ b/backend/internal/database/migrations/run.sh
@@ -35,9 +35,9 @@ MIGRATIONS=(
     "002_insert_seed_data.sql"
     "003_initial_schema.sql"
     "003_insert_seed_data.sql"
-    "004_unify_task_parent_id.sql",
-    "005_insert_seed_data.sql",
-    "006_insert_seed_data.sql",
+    "004_unify_task_parent_id.sql"
+    "005_insert_seed_data.sql"
+    "006_insert_seed_data.sql"
 )
 
 echo "Starting database migrations..."


### PR DESCRIPTION
## Summary

Fix incorrect seed data target ID and remove trailing commas in the SQL migration script array that caused execution failures.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Other (please describe):

## Changes Made

- Fixed `006_insert_seed_data.sql` to update the correct workflow node template ID (`c0000003-0003-0003-0003-000000000004` instead of `c0000003-0003-0003-0003-000000000002`)
- Removed trailing commas from migration file entries in `run.sh` that broke the bash array

## Testing

- [ ] I have tested this change locally
- [ ] I have added unit tests for new functionality
- [ ] I have tested edge cases
- [ ] All existing tests pass

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have checked that there are no merge conflicts

## Related Issues

Fixes #131

## Screenshots/Demo

N/A

## Additional Notes

N/A

## Deployment Notes

Re-run migrations after deploying to apply the corrected seed data.