### PR TITLE
Add Workflow Node Outcome in TaskManager

### DIFF
--- a/backend/internal/task/manager/manager.go
+++ b/backend/internal/task/manager/manager.go
@@ -269,7 +269,7 @@ func (tm *taskManager) start(ctx context.Context, activeTask *container.Containe
 
 	// Notify the workflow manager of the initial state after starting the task (e.g., InProgress). This ensures that
 	//the workflow manager is aware of the task's state change immediately after initialization.
-	tm.notifyWorkflowManager(ctx, activeTask.TaskID, result.NewState, result.ExtendedState, result.AppendGlobalContext)
+	tm.notifyWorkflowManager(ctx, activeTask.TaskID, result.NewState, result.ExtendedState, result.AppendGlobalContext, result.Outcome)
 
 	return &InitTaskResponse{Success: true}, nil
 }
@@ -283,7 +283,7 @@ func (tm *taskManager) execute(ctx context.Context, activeTask *container.Contai
 	}
 
 	if result.NewState != nil {
-		tm.notifyWorkflowManager(ctx, activeTask.TaskID, result.NewState, result.ExtendedState, result.AppendGlobalContext)
+		tm.notifyWorkflowManager(ctx, activeTask.TaskID, result.NewState, result.ExtendedState, result.AppendGlobalContext, result.Outcome)
 	}
 
 	return result, nil
@@ -368,7 +368,7 @@ func (tm *taskManager) getTask(ctx context.Context, taskID uuid.UUID) (*containe
 }
 
 // notifyWorkflowManager sends notification to Workflow Manager via Go channel
-func (tm *taskManager) notifyWorkflowManager(ctx context.Context, taskID uuid.UUID, state *plugin.State, extendedState *string, appendGlobalContext map[string]any) {
+func (tm *taskManager) notifyWorkflowManager(ctx context.Context, taskID uuid.UUID, state *plugin.State, extendedState *string, appendGlobalContext map[string]any, outcome *string) {
 	if tm.completionChan == nil {
 		slog.WarnContext(ctx, "completion channel not configured, skipping notification",
 			"taskID", taskID,
@@ -384,6 +384,7 @@ func (tm *taskManager) notifyWorkflowManager(ctx context.Context, taskID uuid.UU
 		UpdatedState:        state,
 		ExtendedState:       extendedState,
 		AppendGlobalContext: appendGlobalContext,
+		Outcome:             outcome,
 	}
 
 	// Non-blocking send - if a channel is full, log warning but don't block

--- a/backend/internal/task/manager/manager_test.go
+++ b/backend/internal/task/manager/manager_test.go
@@ -469,7 +469,7 @@ func TestNotifyWorkflowManager(t *testing.T) {
 			completionChan: nil,
 		}
 		// Should not panic
-		tm.notifyWorkflowManager(context.Background(), uuid.New(), nil, nil, nil)
+		tm.notifyWorkflowManager(context.Background(), uuid.New(), nil, nil, nil, nil)
 	})
 
 	t.Run("Channel Default Send", func(t *testing.T) {
@@ -479,7 +479,7 @@ func TestNotifyWorkflowManager(t *testing.T) {
 		}
 		taskID := uuid.New()
 		state := plugin.Completed
-		tm.notifyWorkflowManager(context.Background(), taskID, &state, nil, nil)
+		tm.notifyWorkflowManager(context.Background(), taskID, &state, nil, nil, nil)
 
 		select {
 		case n := <-ch:
@@ -500,7 +500,7 @@ func TestNotifyWorkflowManager(t *testing.T) {
 
 		// Attempt verify non-blocking drop
 		taskID := uuid.New()
-		tm.notifyWorkflowManager(context.Background(), taskID, nil, nil, nil)
+		tm.notifyWorkflowManager(context.Background(), taskID, nil, nil, nil, nil)
 
 		assert.Len(t, ch, 1) // Should still have 1 item
 	})

--- a/backend/internal/task/plugin/plugin.go
+++ b/backend/internal/task/plugin/plugin.go
@@ -58,6 +58,7 @@ type GetRenderInfoResponse struct {
 type ExecutionResponse struct {
 	NewState            *State
 	ExtendedState       *string
+	Outcome             *string
 	AppendGlobalContext map[string]any
 	Message             string
 	ApiResponse         *ApiResponse


### PR DESCRIPTION
## Summary
Add `outcome` field through the TaskManager plugin execution pipeline. This enables task plugins to produce and communicate completion sub-states (like "APPROVED" or "REJECTED") back to the workflow manager, which is a requirement for evaluating conditional unlock rules (per those introduced in #174).

## Type of Change
- [x] New feature (non-breaking change which adds functionality

## Changes Made
- Add an optional `Outcome field (*string)` to plugin.ExecutionResponse
- Update `execute()` method in `manager.go` to extract the Outcome from the `ExecutionResponse` and pass it to the `notifyWorkflowManager()` function
- Update the signature of `notifyWorkflowManager()` in `manager.go` to accept the outcome parameter and updated `WorkflowManagerNotification` in `notification.go` to utilize this Outcome field

## Testing
`go test ./internal/task/manager/...` to verify all TaskManager tests pass with the updated method signatures