### PR TITLE
feat: implement SAVE_AS_DRAFT and TraderSavedAsDraft state

### DIFF
--- a/backend/internal/task/plugin/simple_form.go
+++ b/backend/internal/task/plugin/simple_form.go
@@ -20,7 +20,7 @@ import (
 
 // SimpleFormAction represents the action to perform on the form
 const (
-	SimpleFormActionDraft     = "DRAFT_FORM"
+	SimpleFormActionDraft     = "SAVE_AS_DRAFT"
 	SimpleFormActionSubmit    = "SUBMIT_FORM"
 	SimpleFormActionOgaVerify = "OGA_VERIFICATION"
 )

--- a/backend/internal/task/plugin/simple_form_test.go
+++ b/backend/internal/task/plugin/simple_form_test.go
@@ -1,0 +1,151 @@
+package plugin
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+)
+
+// MockAPI is a mock implementation of the API interface for testing plugins
+type MockAPI struct {
+	mock.Mock
+}
+
+func (m *MockAPI) GetTaskID() uuid.UUID {
+	args := m.Called()
+	return args.Get(0).(uuid.UUID)
+}
+
+func (m *MockAPI) GetWorkflowID() uuid.UUID {
+	args := m.Called()
+	return args.Get(0).(uuid.UUID)
+}
+
+func (m *MockAPI) GetTaskState() State {
+	args := m.Called()
+	return args.Get(0).(State)
+}
+
+func (m *MockAPI) ReadFromGlobalStore(key string) (any, bool) {
+	args := m.Called(key)
+	return args.Get(0), args.Bool(1)
+}
+
+func (m *MockAPI) WriteToLocalStore(key string, value any) error {
+	args := m.Called(key, value)
+	return args.Error(0)
+}
+
+func (m *MockAPI) ReadFromLocalStore(key string) (any, error) {
+	args := m.Called(key)
+	return args.Get(0), args.Error(1)
+}
+
+func (m *MockAPI) GetPluginState() string {
+	args := m.Called()
+	return args.String(0)
+}
+
+func (m *MockAPI) CanTransition(action string) bool {
+	args := m.Called(action)
+	return args.Bool(0)
+}
+
+func (m *MockAPI) Transition(action string) error {
+	args := m.Called(action)
+	return args.Error(0)
+}
+
+func TestSimpleForm_Execute_SaveAsDraft(t *testing.T) {
+	t.Run("Success", func(t *testing.T) {
+		mockAPI := new(MockAPI)
+
+		// Create SimpleForm with empty config for testing
+		sf, err := NewSimpleForm(json.RawMessage(`{}`), nil, nil)
+		assert.NoError(t, err)
+
+		sf.Init(mockAPI)
+
+		data := map[string]interface{}{"field1": "value1"}
+		req := &ExecutionRequest{
+			Action:  SimpleFormActionDraft,
+			Content: data,
+		}
+
+		mockAPI.On("CanTransition", SimpleFormActionDraft).Return(true).Once()
+		mockAPI.On("WriteToLocalStore", "trader:form", data).Return(nil).Once()
+		mockAPI.On("Transition", SimpleFormActionDraft).Return(nil).Once()
+
+		resp, err := sf.Execute(context.Background(), req)
+
+		assert.NoError(t, err)
+		assert.NotNil(t, resp)
+		assert.NotNil(t, resp.ApiResponse)
+		assert.True(t, resp.ApiResponse.Success)
+
+		mockAPI.AssertExpectations(t)
+	})
+
+	t.Run("WriteToLocalStore Failure", func(t *testing.T) {
+		mockAPI := new(MockAPI)
+
+		sf, err := NewSimpleForm(json.RawMessage(`{}`), nil, nil)
+		assert.NoError(t, err)
+
+		sf.Init(mockAPI)
+
+		data := map[string]interface{}{"field1": "value1"}
+		req := &ExecutionRequest{
+			Action:  SimpleFormActionDraft,
+			Content: data,
+		}
+
+		mockLocalStoreErr := errors.New("local store error")
+
+		mockAPI.On("CanTransition", SimpleFormActionDraft).Return(true).Once()
+		mockAPI.On("WriteToLocalStore", "trader:form", data).Return(mockLocalStoreErr).Once()
+		// Transition shouldn't be called if WriteToLocalStore fails
+
+		resp, err := sf.Execute(context.Background(), req)
+
+		assert.Error(t, err)
+		assert.Equal(t, mockLocalStoreErr, err)
+		assert.NotNil(t, resp)
+		assert.NotNil(t, resp.ApiResponse)
+		assert.False(t, resp.ApiResponse.Success)
+		assert.Equal(t, "SAVE_DRAFT_FAILED", resp.ApiResponse.Error.Code)
+
+		mockAPI.AssertExpectations(t)
+	})
+
+	t.Run("Invalid Transition", func(t *testing.T) {
+		mockAPI := new(MockAPI)
+
+		sf, err := NewSimpleForm(json.RawMessage(`{}`), nil, nil)
+		assert.NoError(t, err)
+
+		sf.Init(mockAPI)
+
+		data := map[string]interface{}{"field1": "value1"}
+		req := &ExecutionRequest{
+			Action:  SimpleFormActionDraft,
+			Content: data,
+		}
+
+		mockAPI.On("CanTransition", SimpleFormActionDraft).Return(false).Once()
+		mockAPI.On("GetPluginState").Return(string(TraderSubmitted)).Once()
+
+		resp, err := sf.Execute(context.Background(), req)
+
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "not permitted in state")
+		assert.Nil(t, resp)
+
+		mockAPI.AssertExpectations(t)
+	})
+}

--- a/portals/apps/trader-app/src/plugins/SimpleForm.tsx
+++ b/portals/apps/trader-app/src/plugins/SimpleForm.tsx
@@ -24,7 +24,7 @@ export type SimpleFormConfig = {
 }
 
 function TraderForm(props: { formInfo: TaskFormData, pluginState: string }) {
-  const {consignmentId, preConsignmentId, taskId} = useParams<{
+  const { consignmentId, preConsignmentId, taskId } = useParams<{
     consignmentId?: string
     preConsignmentId?: string
     taskId?: string
@@ -44,14 +44,13 @@ function TraderForm(props: { formInfo: TaskFormData, pluginState: string }) {
 
 
 
-  const handleSubmit = async (e: React.FormEvent) => {
-    e.preventDefault();
+  const handleFormAction = async (command: 'SUBMISSION' | 'SAVE_AS_DRAFT') => {
     if (!workflowId || !taskId) {
-      setSubmitError('Workflow ID or Task ID is missing.')
-      return
+      setSubmitError('Workflow ID or Task ID is missing.');
+      return;
     }
 
-    if (errors.length > 0) {
+    if (command === 'SUBMISSION' && errors.length > 0) {
       setSubmitError('Please fix validation errors before submitting.');
       return;
     }
@@ -59,30 +58,39 @@ function TraderForm(props: { formInfo: TaskFormData, pluginState: string }) {
     setIsSubmitting(true);
     setSubmitError(null);
 
-    try {
-      // Send form submission
-      const preparedData = data
+    const isDraft = command === 'SAVE_AS_DRAFT';
+    const actionText = isDraft ? 'save draft' : 'submit form';
+    const consoleActionText = isDraft ? 'saving draft' : 'submitting form';
 
+    try {
       const response = await sendTaskCommand({
-        command: 'SUBMISSION',
+        command,
         taskId,
         workflowId,
-        data: preparedData,
-      })
+        data,
+      });
 
       if (response.success) {
-        // Navigate back to appropriate workflow list
-        navigate(isPreConsignment ? '/pre-consignments' : `/consignments/${workflowId}`)
+        navigate(isPreConsignment ? '/pre-consignments' : `/consignments/${workflowId}`);
       } else {
-        setSubmitError(response.error?.message || 'Failed to submit form.')
+        setSubmitError(response.error?.message || `Failed to ${actionText}.`);
       }
     } catch (err) {
-      console.error('Error submitting form:', err)
-      setSubmitError('Failed to submit form. Please try again.')
+      console.error(`Error ${consoleActionText}:`, err);
+      setSubmitError(`Failed to ${actionText}. Please try again.`);
     } finally {
       setIsSubmitting(false);
     }
-  }
+  };
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+    handleFormAction('SUBMISSION');
+  };
+
+  const handleSaveAsDraft = () => {
+    handleFormAction('SAVE_AS_DRAFT');
+  };
 
   const handleAutoFill = useCallback(() => {
     const filledData = autoFillForm(props.formInfo.schema, data);
@@ -126,6 +134,16 @@ function TraderForm(props: { formInfo: TaskFormData, pluginState: string }) {
                 </Button>
               )}
               <Button
+                type="button"
+                variant="outline"
+                disabled={isSubmitting}
+                className={'flex-1!'}
+                size={"3"}
+                onClick={handleSaveAsDraft}
+              >
+                Save as Draft
+              </Button>
+              <Button
                 type="submit"
                 disabled={isSubmitting}
                 className={'flex-1!'}
@@ -154,7 +172,7 @@ function SubmissionResponseForm(props: { formInfo: TaskFormData }) {
       <div className="bg-emerald-50 px-6 py-4 flex items-center gap-3">
         <span className="inline-flex items-center justify-center w-7 h-7 rounded-full bg-emerald-100 text-emerald-700 shrink-0">
           <svg xmlns="http://www.w3.org/2000/svg" className="w-4 h-4" viewBox="0 0 20 20" fill="currentColor">
-            <path fillRule="evenodd" d="M16.707 5.293a1 1 0 010 1.414l-8 8a1 1 0 01-1.414 0l-4-4a1 1 0 011.414-1.414L8 12.586l7.293-7.293a1 1 0 011.414 0z" clipRule="evenodd"/>
+            <path fillRule="evenodd" d="M16.707 5.293a1 1 0 010 1.414l-8 8a1 1 0 01-1.414 0l-4-4a1 1 0 011.414-1.414L8 12.586l7.293-7.293a1 1 0 011.414 0z" clipRule="evenodd" />
           </svg>
         </span>
         <div>
@@ -184,8 +202,8 @@ function OgaReviewForm(props: { formInfo: TaskFormData }) {
       <div className="bg-indigo-700 px-6 py-4 flex items-center gap-3">
         <span className="inline-flex items-center justify-center w-7 h-7 rounded-full bg-indigo-600 text-indigo-100 shrink-0">
           <svg xmlns="http://www.w3.org/2000/svg" className="w-4 h-4" viewBox="0 0 20 20" fill="currentColor">
-            <path d="M9 2a1 1 0 000 2h2a1 1 0 100-2H9z"/>
-            <path fillRule="evenodd" d="M4 5a2 2 0 012-2 3 3 0 003 3h2a3 3 0 003-3 2 2 0 012 2v11a2 2 0 01-2 2H6a2 2 0 01-2-2V5zm3 4a1 1 0 000 2h.01a1 1 0 100-2H7zm3 0a1 1 0 000 2h3a1 1 0 100-2h-3zm-3 4a1 1 0 100 2h.01a1 1 0 100-2H7zm3 0a1 1 0 100 2h3a1 1 0 100-2h-3z" clipRule="evenodd"/>
+            <path d="M9 2a1 1 0 000 2h2a1 1 0 100-2H9z" />
+            <path fillRule="evenodd" d="M4 5a2 2 0 012-2 3 3 0 003 3h2a3 3 0 003-3 2 2 0 012 2v11a2 2 0 01-2 2H6a2 2 0 01-2-2V5zm3 4a1 1 0 000 2h.01a1 1 0 100-2H7zm3 0a1 1 0 000 2h3a1 1 0 100-2h-3zm-3 4a1 1 0 100 2h.01a1 1 0 100-2H7zm3 0a1 1 0 100 2h3a1 1 0 100-2h-3z" clipRule="evenodd" />
           </svg>
         </span>
         <div>
@@ -210,14 +228,14 @@ function OgaReviewForm(props: { formInfo: TaskFormData }) {
 export default function SimpleForm(props: { configs: SimpleFormConfig, pluginState: string }) {
   return (
     <div>
-      <TraderForm formInfo={props.configs.traderFormInfo} pluginState={props.pluginState}/>
+      <TraderForm formInfo={props.configs.traderFormInfo} pluginState={props.pluginState} />
 
       {props.configs.submissionResponseForm && (
-        <SubmissionResponseForm formInfo={props.configs.submissionResponseForm}/>
+        <SubmissionResponseForm formInfo={props.configs.submissionResponseForm} />
       )}
 
       {props.configs.ogaReviewForm && (
-        <OgaReviewForm formInfo={props.configs.ogaReviewForm}/>
+        <OgaReviewForm formInfo={props.configs.ogaReviewForm} />
       )}
     </div>
   )

--- a/portals/apps/trader-app/src/services/preConsignment.ts
+++ b/portals/apps/trader-app/src/services/preConsignment.ts
@@ -65,7 +65,7 @@ export interface CreatePreConsignmentRequest {
 }
 
 export interface TaskCommandRequest {
-    command: 'SUBMISSION' | 'SAVE_DRAFT'
+    command: 'SUBMISSION' | 'SAVE_AS_DRAFT'
     taskId: string
     workflowId: string
     data?: Record<string, unknown>
@@ -148,7 +148,7 @@ export async function submitPreConsignmentTask(
     request: TaskCommandRequest
 ): Promise<TaskCommandResponse> {
     return sendTaskCommand({
-        command: request.command === 'SAVE_DRAFT' ? 'DRAFT' : 'SUBMISSION',
+        command: request.command === 'SAVE_AS_DRAFT' ? 'SAVE_AS_DRAFT' : 'SUBMISSION',
         taskId: request.taskId,
         workflowId: request.workflowId,
         data: request.data || {}

--- a/portals/apps/trader-app/src/services/task.ts
+++ b/portals/apps/trader-app/src/services/task.ts
@@ -1,9 +1,9 @@
 import { apiGet, apiPost, type ApiResponse } from './api'
 import type { RenderInfo } from "../plugins";
 
-export type TaskAction = 'FETCH_FORM' | 'SUBMIT_FORM' | 'DRAFT'
+export type TaskAction = 'FETCH_FORM' | 'SUBMIT_FORM' | 'SAVE_AS_DRAFT'
 
-export type TaskCommand = 'SUBMISSION' | 'DRAFT'
+export type TaskCommand = 'SUBMISSION' | 'SAVE_AS_DRAFT'
 
 export interface TaskFormData {
   title: string
@@ -46,7 +46,7 @@ export async function sendTaskCommand(
   console.log(`Sending ${request.command} command for task: ${request.taskId}`, request)
 
   // Use POST /api/tasks with action type and submission data
-  const action: TaskAction = request.command === 'DRAFT' ? 'DRAFT' : 'SUBMIT_FORM'
+  const action: TaskAction = request.command === 'SAVE_AS_DRAFT' ? 'SAVE_AS_DRAFT' : 'SUBMIT_FORM'
 
   return apiPost<SendTaskCommandRequest, TaskCommandResponse>(TASKS_API_URL, {
     task_id: request.taskId,


### PR DESCRIPTION


https://github.com/user-attachments/assets/2cd0ba29-3261-4b59-b01c-7b07208f3f74

## Summary
Add "Save as Draft" functionality for tasks by establishing the SAVE_AS_DRAFT Task command structure spanning both the React frontend and the backend workflow engine


## Changes

#### Frontend
- add a "Save as Draft" button alongside the submit button in `SimpleForm.tsx`
- refactor form submission logic into a shared `sendCommand` helper to eliminate code duplication between `handleSubmit` and `handleSaveAsDraft`
- standardize the API action and local frontend Task Command to SAVE_AS_DRAFT across `task.ts` + `preConsignment.ts`

#### Backend
- rename the internal action in `simple_form.go` from DRAFT_FORM to SAVE_AS_DRAFT to map with the frontend command
- add new test swuite `TestSimpleForm_Execute_SaveAsDraft` in `simple_form_test.go` to cover draft execution paths including success, WriteToLocalStore failures, and invalid transition handling.
- handle out of sync testing environments: sync core test SQL mocks in `consignment_service_test.go` + `workflow_node_service_test.go` to properly account for new schema fields (outcome, unlock_configuration, end_node_id) introduced from the main branch

## Related Issues
Closes #102 