### PR TITLE
fix(workflow): propagate plugin sub-state updates when task state is unchanged

### DIFF
--- a/backend/internal/workflow/service/state_machine.go
+++ b/backend/internal/workflow/service/state_machine.go
@@ -437,8 +437,10 @@ func (sm *WorkflowNodeStateMachine) canTransitionToFailed(currentState model.Wor
 // canTransitionToInProgress checks if a node can transition to IN_PROGRESS from its current state.
 func (sm *WorkflowNodeStateMachine) canTransitionToInProgress(currentState model.WorkflowNodeState) bool {
 	// Only READY or FAILED nodes can be moved to IN_PROGRESS
+	// And if already IN_PROGRESS also we allow transition to update extended state without error
 	return currentState == model.WorkflowNodeStateReady ||
-		currentState == model.WorkflowNodeStateFailed
+		currentState == model.WorkflowNodeStateFailed ||
+		currentState == model.WorkflowNodeStateInProgress
 }
 
 // sortNodesByID sorts workflow nodes by ID to ensure consistent ordering and prevent deadlocks.


### PR DESCRIPTION
## Summary

Fixes #220 by allowing plugin sub-state transitions (for example, NOTIFY_FAILED → NOTIFIED_SERVICE) even when the top-level task state remains IN_PROGRESS.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

- [x] I have tested this change locally
- [ ] I have added unit tests for new functionality
- [x] I have tested edge cases
- [x] All existing tests pass

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have checked that there are no merge conflicts