### PR TITLE
feat: standardize runtime env loading and local startup

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,68 @@
+# NSW local development (non-Docker)
+# Copy to .env and adjust values as needed.
+
+# -------------------------------------------------------------------
+# Ports
+# -------------------------------------------------------------------
+IDP_PORT=8090
+BACKEND_PORT=8080
+TRADER_APP_PORT=5173
+OGA_NPQS_PORT=8081
+OGA_FCAU_PORT=8082
+OGA_IRD_PORT=8083
+OGA_APP_NPQS_PORT=5174
+OGA_APP_FCAU_PORT=5175
+OGA_APP_IRD_PORT=5176
+
+# -------------------------------------------------------------------
+# Backend (Go + PostgreSQL)
+# -------------------------------------------------------------------
+DB_HOST=localhost
+DB_PORT=5432
+DB_NAME=nsw_db
+DB_USERNAME=postgres
+DB_PASSWORD=changeme
+DB_SSLMODE=disable
+
+SERVER_DEBUG=true
+SERVER_LOG_LEVEL=info
+
+# Include all local frontend origins used in development.
+CORS_ALLOWED_ORIGINS=http://localhost:3000,http://localhost:5173,http://localhost:5174,http://localhost:5175,http://localhost:5176
+
+# Auth settings used by backend token validation.
+AUTH_ISSUER=https://localhost:8090
+AUTH_JWKS_URL=https://localhost:8090/oauth2/jwks
+AUTH_CLIENT_ID=TRADER_PORTAL_APP
+AUTH_AUDIENCE=TRADER_PORTAL_APP
+AUTH_JWKS_INSECURE_SKIP_VERIFY=true
+
+# -------------------------------------------------------------------
+# Shared frontend auth
+# -------------------------------------------------------------------
+IDP_PUBLIC_URL=https://localhost:8090
+IDP_SCOPES=openid,profile,email
+IDP_PLATFORM=AsgardeoV2
+
+TRADER_IDP_CLIENT_ID=TRADER_PORTAL_APP
+NPQS_IDP_CLIENT_ID=OGA_PORTAL_APP_NPQS
+FCAU_IDP_CLIENT_ID=OGA_PORTAL_APP_FCAU
+IRD_IDP_CLIENT_ID=OGA_PORTAL_APP_IRD
+
+# Feature flags
+SHOW_AUTOFILL_BUTTON=true
+
+# -------------------------------------------------------------------
+# OGA backends (two local instances)
+# -------------------------------------------------------------------
+OGA_FORMS_PATH=./data/forms
+OGA_DEFAULT_FORM_ID=default
+OGA_ALLOWED_ORIGINS=http://localhost:5174,http://localhost:5175,http://localhost:5176
+
+OGA_NPQS_DB_PATH=./npqs.db
+OGA_FCAU_DB_PATH=./fcau.db
+OGA_IRD_DB_PATH=./ird.db
+# OGA frontend instance keys (normally do not need changes)
+OGA_APP_NPQS_INSTANCE_CONFIG=npqs
+OGA_APP_FCAU_INSTANCE_CONFIG=fcau
+OGA_APP_IRD_INSTANCE_CONFIG=ird

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -5,15 +5,15 @@ DB_USERNAME=postgres
 DB_PASSWORD=password
 DB_NAME=nsw_db
 DB_SSLMODE=disable # Use 'require' in production
-MAX_IDLE_CONNS=10
-MAX_OPEN_CONNS=100
-MAX_CONN_LIFETIME_SECONDS=3600
+DB_MAX_IDLE_CONNS=10
+DB_MAX_OPEN_CONNS=100
+DB_MAX_CONN_LIFETIME_SECONDS=3600
 
 # Server Configuration
 SERVER_PORT=8080
 SERVER_DEBUG=true
 SERVER_LOG_LEVEL=info
-SERVER_SERVICE_URL=http://localhost:8080
+SERVICE_URL=http://localhost:8080
 
 # CORS Configuration
 CORS_ALLOWED_ORIGINS=http://localhost:3000,http://localhost:5173

--- a/backend/internal/database/migrations/run.sh
+++ b/backend/internal/database/migrations/run.sh
@@ -1,14 +1,16 @@
 #!/bin/bash
 set -euo pipefail
 
-# Load environment variables from backend/.env file
-# This filters out comments and exports each line as a variable
-if [ -f ../../../.env ]; then
+# Load environment variables from env file
+# Default: backend/.env
+ENV_FILE_PATH="${ENV_FILE:-../../../.env}"
+
+if [ -f "$ENV_FILE_PATH" ]; then
     set -o allexport
-    source ../../../.env
+    source "$ENV_FILE_PATH"
     set +o allexport
 else
-    echo "Error: .env file not found."
+    echo "Error: env file not found: $ENV_FILE_PATH"
     exit 1
 fi
 
@@ -20,14 +22,21 @@ for VAR in DB_HOST DB_PORT DB_USERNAME DB_PASSWORD DB_NAME; do
     fi
 done
 
+MIGRATION_DB_HOST="${MIGRATION_DB_HOST:-$DB_HOST}"
+MIGRATION_DB_HOST="${MIGRATION_DB_HOST//host.docker.internal/localhost}"
+
+NPQS_OGA_SUBMISSION_URL="${NPQS_OGA_SUBMISSION_URL:-http://localhost:8081/api/oga/inject}"
+FCAU_OGA_SUBMISSION_URL="${FCAU_OGA_SUBMISSION_URL:-http://localhost:8082/api/oga/inject}"
+PRECONSIGNMENT_OGA_SUBMISSION_URL="${PRECONSIGNMENT_OGA_SUBMISSION_URL:-http://localhost:8083/api/oga/inject}"
+
 # Force disconnect other users and drop the database
 # Using the 'postgres' database as a maintenance DB to execute the drop
 echo "Dropping database $DB_NAME..."
-PGPASSWORD=$DB_PASSWORD psql -h "$DB_HOST" -p "$DB_PORT" -U "$DB_USERNAME" -d postgres -c "DROP DATABASE IF EXISTS $DB_NAME WITH (FORCE);"
+PGPASSWORD=$DB_PASSWORD psql -h "$MIGRATION_DB_HOST" -p "$DB_PORT" -U "$DB_USERNAME" -d postgres -c "DROP DATABASE IF EXISTS $DB_NAME WITH (FORCE);"
 
 # Recreate the database
 echo "Creating database $DB_NAME..."
-PGPASSWORD=$DB_PASSWORD psql -h "$DB_HOST" -p "$DB_PORT" -U "$DB_USERNAME" -d postgres -c "CREATE DATABASE $DB_NAME;"
+PGPASSWORD=$DB_PASSWORD psql -h "$MIGRATION_DB_HOST" -p "$DB_PORT" -U "$DB_USERNAME" -d postgres -c "CREATE DATABASE $DB_NAME;"
 
 # Define the file paths
 MIGRATIONS=(
@@ -46,7 +55,12 @@ echo "Starting database migrations..."
 for FILE in "${MIGRATIONS[@]}"; do
     if [ -f "$FILE" ]; then
         echo "Executing: $FILE"
-        PGPASSWORD=$DB_PASSWORD psql -v ON_ERROR_STOP=1 -h "$DB_HOST" -p "$DB_PORT" -U "$DB_USERNAME" -d "$DB_NAME" -f "$FILE"
+        PGPASSWORD=$DB_PASSWORD psql \
+            -v ON_ERROR_STOP=1 \
+            -v NPQS_OGA_SUBMISSION_URL="$NPQS_OGA_SUBMISSION_URL" \
+            -v FCAU_OGA_SUBMISSION_URL="$FCAU_OGA_SUBMISSION_URL" \
+            -v PRECONSIGNMENT_OGA_SUBMISSION_URL="$PRECONSIGNMENT_OGA_SUBMISSION_URL" \
+            -h "$MIGRATION_DB_HOST" -p "$DB_PORT" -U "$DB_USERNAME" -d "$DB_NAME" -f "$FILE"
         
         if [ $? -ne 0 ]; then
             echo "Error executing $FILE. Aborting."

--- a/idp/.env.example
+++ b/idp/.env.example
@@ -10,4 +10,9 @@ THUNDER_API_BASE=http://thunder:8090
 
 # Public URL for Thunder (accessible from browser/clients)
 # In production, this should be your actual domain
-THUNDER_PUBLIC_URL=http://localhost:8090
+THUNDER_PUBLIC_URL=https://localhost:8443
+
+# CORS Configuration
+# Comma-separated list of allowed origins for CORS requests
+# Add the URLs where your frontend applications are hosted
+CORS_ALLOWED_ORIGINS=http://localhost:5173,http://localhost:5174,http://localhost:5175,http://localhost:5176  

--- a/idp/02-sample-resources.sh
+++ b/idp/02-sample-resources.sh
@@ -634,7 +634,7 @@ fi
 echo ""
 
 # ============================================================================
-# Create NPQS and FCAU resources
+# Create NPQS, FCAU, and IRD resources
 # ============================================================================
 
 create_oga_resources \
@@ -665,6 +665,20 @@ create_oga_resources \
     "FCAU" \
     "Officer"
 
+create_oga_resources \
+    "IRD" \
+    "ird" \
+    "Inland Revenue Department" \
+    "IRDOfficer" \
+    "IRDPortalApp" \
+    "OGA_PORTAL_APP_IRD" \
+    "5176" \
+    "ird_officer" \
+    "1234" \
+    "ird_officer@oga.dev" \
+    "IRD" \
+    "Officer"
+
 # ============================================================================
 # Summary
 # ============================================================================
@@ -673,4 +687,5 @@ log_success "Sample resources setup completed successfully!"
 log_info "Trader app client ID: TRADER_PORTAL_APP"
 log_info "NPQS app client ID: OGA_PORTAL_APP_NPQS"
 log_info "FCAU app client ID: OGA_PORTAL_APP_FCAU"
+log_info "IRD app client ID: OGA_PORTAL_APP_IRD"
 echo ""

--- a/idp/deployment.yaml
+++ b/idp/deployment.yaml
@@ -52,6 +52,8 @@ cors:
     - "http://localhost:5174"
     - "https://localhost:5175"
     - "http://localhost:5175"
+    - "https://localhost:5176"
+    - "http://localhost:5176"
 
 passkey:
   allowed_origins:

--- a/portals/Makefile
+++ b/portals/Makefile
@@ -1,4 +1,4 @@
-.PHONY: help setup install clean dev-oga dev-trader dev-all build build-oga build-trader build-ui lint format type-check test preview-oga preview-trader
+.PHONY: help setup install clean dev-oga dev-trader dev-all build build-oga build-trader build-ui lint format type-check preview-oga preview-trader
 
 # Default target
 help:
@@ -47,8 +47,8 @@ clean:
 	@echo "🧹 Cleaning workspace..."
 	@rm -rf node_modules
 	@rm -rf apps/*/node_modules
-	@rm -rf ui/node_modules
-	@rm -rf ui/dist apps/*/dist
+	@rm -rf packages/*/node_modules
+	@rm -rf packages/*/dist apps/*/dist
 	@rm -rf apps/*/.turbo
 	@echo "✅ Cleaned!"
 
@@ -80,7 +80,7 @@ build-trader:
 
 build-ui:
 	@echo "🏗️  Building UI library..."
-	@pnpm --filter @lsf/ui build
+	@pnpm --filter @opennsw/ui build
 
 # Linting and Formatting
 lint:

--- a/portals/README.md
+++ b/portals/README.md
@@ -40,9 +40,11 @@ portals/
 ├── pnpm-lock.yaml         # Single lock file for entire monorepo
 ├── package.json           # Root workspace configuration
 ├── tsconfig.json          # Shared TypeScript configuration
-├── ui/                    # Shared UI component library (@lsf/ui)
-│   └── src/
-│       └── components/    # Reusable components built on Radix UI
+├── packages/
+│   ├── ui/                # Shared UI component library (@opennsw/ui)
+│   │   └── src/
+│   │       └── components/ # Reusable components built on Radix UI
+│   └── jsonforms-renderers/ # Shared JSON Forms renderers
 └── apps/                  # Consumer applications
     ├── oga-app/           # OGA portal application
     └── trader-app/        # Trading application
@@ -50,7 +52,7 @@ portals/
 
 ## Overview
 
-### UI Library (`@lsf/ui`)
+### UI Library (`@opennsw/ui`)
 
 The `ui` package is a shared component library built from the ground up using [Radix UI](https://www.radix-ui.com/) primitives. It provides accessible, unstyled, and customizable components that can be consumed by any application in the monorepo.
 
@@ -66,7 +68,7 @@ The `ui` package is a shared component library built from the ground up using [R
 
 ### Apps
 
-The `apps/` directory contains applications that consume the shared UI library. Each app is a standalone project that imports components from `@lsf/ui`.
+The `apps/` directory contains applications that consume the shared UI library. Each app is a standalone project that imports components from `@opennsw/ui`.
 
 **Current apps:**
 - `oga-app` - OGA portal application
@@ -90,7 +92,7 @@ make build-ui       # Build UI library only
 
 # Code quality
 make lint           # Run linter
-make lint-fix       # Auto-fix linting issues
+make format         # Auto-fix linting issues
 ```
 
 ### Adding Dependencies
@@ -100,7 +102,7 @@ make lint-fix       # Auto-fix linting issues
 pnpm --filter oga-app add axios
 
 # To UI library
-pnpm --filter @lsf/ui add lodash
+pnpm --filter @opennsw/ui add lodash
 
 # To workspace root (dev dependencies)
 pnpm add -w prettier -D
@@ -110,10 +112,10 @@ pnpm add -w prettier -D
 
 ## Using the UI Library
 
-Import components from `@lsf/ui` in any app:
+Import components from `@opennsw/ui` in any app:
 
 ```tsx
-import { Button, Card } from '@lsf/ui'
+import { Button, Card } from '@opennsw/ui'
 
 function MyComponent() {
   return (
@@ -126,19 +128,19 @@ function MyComponent() {
 
 ## Adding New Components
 
-1. Create a new component in `ui/src/components/`
-2. Export it from `ui/src/index.ts`
+1. Create a new component in `packages/ui/src/components/`
+2. Export it from `packages/ui/src/index.ts`
 3. Rebuild the UI library
 
 ## Adding New Apps
 
 1. Create a new directory in `apps/`
 2. Initialize the app with your preferred framework
-3. Add `@lsf/ui` as a dependency in the app's `package.json`:
+3. Add `@opennsw/ui` as a dependency in the app's `package.json`:
    ```json
    {
      "dependencies": {
-       "@lsf/ui": "workspace:*"
+      "@opennsw/ui": "workspace:*"
      }
    }
    ```

--- a/portals/apps/oga-app/.env.example
+++ b/portals/apps/oga-app/.env.example
@@ -10,7 +10,7 @@ VITE_PORT=5174
 VITE_INSTANCE_CONFIG=npqs
 
 # Backend API Base URL
-VITE_OGA_API_BASE_URL=http://localhost:8081
+VITE_API_BASE_URL=http://localhost:8081
 
 # Identity Provider (Asgardeo/Thunder)
 VITE_IDP_BASE_URL=https://localhost:8090
@@ -30,7 +30,7 @@ VITE_APP_URL=http://localhost:5174
 
 # export VITE_PORT=5174
 # export VITE_INSTANCE_CONFIG="npqs"
-# export VITE_OGA_API_BASE_URL="http://localhost:8081"
+# export VITE_API_BASE_URL="http://localhost:8081"
 # export VITE_IDP_BASE_URL="https://localhost:8090"
 # export VITE_IDP_CLIENT_ID="OGA_PORTAL_APP_NPQS"
 # export VITE_APP_URL="http://localhost:5174"
@@ -42,10 +42,22 @@ VITE_APP_URL=http://localhost:5174
 
 # export VITE_PORT=5175
 # export VITE_INSTANCE_CONFIG="fcau"
-# export VITE_OGA_API_BASE_URL="http://localhost:8082"
+# export VITE_API_BASE_URL="http://localhost:8082"
 # export VITE_IDP_BASE_URL="https://localhost:8090"
 # export VITE_IDP_CLIENT_ID="OGA_PORTAL_APP_FCAU"
 # export VITE_APP_URL="http://localhost:5175"
+
+# pnpm run dev
+
+# -- IRD (Inland Revenue Department) ---
+# cd portals/apps/oga-app
+
+# export VITE_PORT=5176
+# export VITE_INSTANCE_CONFIG="ird"
+# export VITE_API_BASE_URL="http://localhost:8083"
+# export VITE_IDP_BASE_URL="https://localhost:8090"
+# export VITE_IDP_CLIENT_ID="OGA_PORTAL_APP_IRD"
+# export VITE_APP_URL="http://localhost:5176"
 
 # pnpm run dev
 ########################################################################

--- a/portals/apps/oga-app/README.md
+++ b/portals/apps/oga-app/README.md
@@ -6,6 +6,8 @@ This app uses Asgardeo/Thunder OIDC for sign-in.
 
 Required environment variables:
 
+- `VITE_INSTANCE_CONFIG`: OGA config id to load (`npqs`, `fcau`, ...)
+- `VITE_API_BASE_URL`: OGA backend API base URL (for example `http://localhost:8081`)
 - `VITE_IDP_BASE_URL`: IdP base URL (for example `https://localhost:8090`)
 - `VITE_IDP_CLIENT_ID`: OGA-specific IdP application client id
 - `VITE_APP_URL`: public URL of this OGA deployment

--- a/portals/apps/oga-app/index.html
+++ b/portals/apps/oga-app/index.html
@@ -8,6 +8,7 @@
   </head>
   <body>
     <div id="root"></div>
+    <script src="/runtime-env.js"></script>
     <script type="module" src="/src/main.tsx"></script>
   </body>
 </html>

--- a/portals/apps/oga-app/public/runtime-env.js
+++ b/portals/apps/oga-app/public/runtime-env.js
@@ -1,0 +1,1 @@
+window.__APP_CONFIG__ = window.__APP_CONFIG__ || {};

--- a/portals/apps/oga-app/src/api.ts
+++ b/portals/apps/oga-app/src/api.ts
@@ -1,7 +1,8 @@
 // API service for OGA Portal
 import type { JsonSchema, UISchemaElement } from '@jsonforms/core';
+import { getEnv } from './runtimeConfig';
 
-const API_BASE_URL = (import.meta.env.VITE_OGA_API_BASE_URL as string | undefined) ?? 'http://localhost:8081';
+const API_BASE_URL = getEnv('VITE_API_BASE_URL', 'http://localhost:8081')!;
 
 export type AccessTokenProvider = () => Promise<string | null | undefined>
 

--- a/portals/apps/oga-app/src/config.ts
+++ b/portals/apps/oga-app/src/config.ts
@@ -1,4 +1,5 @@
 import type {UIConfig} from "./configs/types.ts";
+import { getEnv } from './runtimeConfig';
 
 
 const configModules = import.meta.glob<{ config: UIConfig }>(
@@ -7,11 +8,11 @@ const configModules = import.meta.glob<{ config: UIConfig }>(
 );
 
 function loadConfig(): UIConfig {
-  const instance = import.meta.env.VITE_INSTANCE_CONFIG as string;
+  const instance = getEnv('VITE_INSTANCE_CONFIG');
 
   if (!instance) {
     throw new Error(
-      'VITE_INSTANCE environment variable is not set. ' +
+      'VITE_INSTANCE_CONFIG environment variable is not set. ' +
       'Please specify which instance to build (e.g., client-a, client-b)'
     );
   }

--- a/portals/apps/oga-app/src/configs/ird.config.ts
+++ b/portals/apps/oga-app/src/configs/ird.config.ts
@@ -1,0 +1,9 @@
+import type {UIConfig} from "./types.ts";
+
+export const config: UIConfig = {
+  branding: {
+    appName: "Inland Revenue Department (IRD)",
+    logoUrl: "",
+    favicon: ""
+  },
+}

--- a/portals/apps/oga-app/src/main.tsx
+++ b/portals/apps/oga-app/src/main.tsx
@@ -6,22 +6,23 @@ import { AsgardeoProvider } from '@asgardeo/react'
 import "@radix-ui/themes/styles.css"
 import './index.css'
 import App from './App.tsx'
+import { getEnv, getRequiredEnv } from './runtimeConfig'
 
-const getRequiredEnv = (name: keyof ImportMetaEnv): string => {
-  const value = import.meta.env[name]
-  if (!value || value.trim() === '') {
-    throw new Error(`Missing required environment variable: ${name}`)
+const normalizeIdpPlatform = (value: string): 'AsgardeoV2' | 'Asgardeo' | 'IdentityServer' | 'Unknown' => {
+  if (value === 'AsgardeoV2' || value === 'Asgardeo' || value === 'IdentityServer' || value === 'Unknown') {
+    return value
   }
 
-  return value
+  return 'AsgardeoV2'
 }
 
-const APP_URL = import.meta.env.VITE_APP_URL || window.location.origin
+const APP_URL = getEnv('VITE_APP_URL', window.location.origin)!
 const CLIENT_ID = getRequiredEnv('VITE_IDP_CLIENT_ID')
 const IDP_BASE_URL = getRequiredEnv('VITE_IDP_BASE_URL')
-const IDP_PLATFORM = import.meta.env.VITE_IDP_PLATFORM || 'AsgardeoV2'
-const IDP_SCOPES = import.meta.env.VITE_IDP_SCOPES
-  ? import.meta.env.VITE_IDP_SCOPES.split(',').map((scope: string) => scope.trim())
+const IDP_PLATFORM = normalizeIdpPlatform(getEnv('VITE_IDP_PLATFORM', 'AsgardeoV2')!)
+const rawScopes = getEnv('VITE_IDP_SCOPES')
+const IDP_SCOPES = rawScopes
+  ? rawScopes.split(',').map((scope: string) => scope.trim())
   : ['openid', 'profile', 'email']
 
 createRoot(document.getElementById('root')!).render(

--- a/portals/apps/oga-app/src/runtimeConfig.ts
+++ b/portals/apps/oga-app/src/runtimeConfig.ts
@@ -1,0 +1,40 @@
+type RuntimeConfigValue = string | undefined
+
+type RuntimeConfigMap = Record<string, RuntimeConfigValue>
+
+declare global {
+  interface Window {
+    __APP_CONFIG__?: RuntimeConfigMap
+  }
+}
+
+function resolveRuntimeConfig(): RuntimeConfigMap {
+  if (typeof window === 'undefined') {
+    return {}
+  }
+
+  return window.__APP_CONFIG__ ?? {}
+}
+
+export function getEnv(name: string, fallback?: string): string | undefined {
+  const runtimeValue = resolveRuntimeConfig()[name]
+  if (runtimeValue && runtimeValue.trim() !== '') {
+    return runtimeValue
+  }
+
+  const buildValue = (import.meta.env as Record<string, string | undefined>)[name]
+  if (buildValue && buildValue.trim() !== '') {
+    return buildValue
+  }
+
+  return fallback
+}
+
+export function getRequiredEnv(name: string): string {
+  const value = getEnv(name)
+  if (!value || value.trim() === '') {
+    throw new Error(`Missing required environment variable: ${name}`)
+  }
+
+  return value
+}

--- a/portals/apps/oga-app/src/services/upload.ts
+++ b/portals/apps/oga-app/src/services/upload.ts
@@ -1,6 +1,7 @@
 import type { ApiClient } from '../api'
+import { getEnv } from '../runtimeConfig'
 
-const API_BASE_URL = import.meta.env.VITE_API_BASE_URL as string || 'http://localhost:8080/api/v1'
+const API_BASE_URL = getEnv('VITE_API_BASE_URL', 'http://localhost:8081')!
 
 export interface FileMetadata {
   id: string

--- a/portals/apps/trader-app/.env.example
+++ b/portals/apps/trader-app/.env.example
@@ -1,5 +1,5 @@
 # API Configuration
-VITE_API_BASE_URL=http://localhost:8080/api
+VITE_API_BASE_URL=http://localhost:8080/api/v1
 
 # Identity Provider (Asgardeo/Thunder)
 VITE_IDP_BASE_URL=https://localhost:8090
@@ -14,7 +14,7 @@ VITE_APP_URL=http://localhost:5173
 VITE_SHOW_AUTOFILL_BUTTON=true
 
 # Development
-# VITE_API_BASE_URL=http://localhost:8080/api
+# VITE_API_BASE_URL=http://localhost:8080/api/v1
 
 # Production
 # VITE_API_BASE_URL=https://api.production.com

--- a/portals/apps/trader-app/index.html
+++ b/portals/apps/trader-app/index.html
@@ -8,6 +8,7 @@
   </head>
   <body>
     <div id="root"></div>
+    <script src="/runtime-env.js"></script>
     <script type="module" src="/src/main.tsx"></script>
   </body>
 </html>

--- a/portals/apps/trader-app/public/runtime-env.js
+++ b/portals/apps/trader-app/public/runtime-env.js
@@ -1,0 +1,1 @@
+window.__APP_CONFIG__ = window.__APP_CONFIG__ || {};

--- a/portals/apps/trader-app/src/constants/index.ts
+++ b/portals/apps/trader-app/src/constants/index.ts
@@ -2,12 +2,14 @@
  * Application-wide constants
  */
 
+import { getEnv } from '../runtimeConfig'
+
 // TODO: Replace with actual auth context
 export const DEFAULT_TRADER_ID = 'trader-123'
 
 // API Configuration
 export const API_CONFIG = {
-  BASE_URL: import.meta.env.VITE_API_BASE_URL || 'http://localhost:8080/api',
+  BASE_URL: getEnv('VITE_API_BASE_URL', 'http://localhost:8080/api/v1')!,
   TIMEOUT: 30000, // 30 seconds
 } as const
 

--- a/portals/apps/trader-app/src/main.tsx
+++ b/portals/apps/trader-app/src/main.tsx
@@ -7,13 +7,23 @@ import {BrowserRouter} from 'react-router-dom';
 import {Theme} from '@radix-ui/themes';
 import { ErrorBoundary } from './components/ErrorBoundary'
 import { AsgardeoProvider } from '@asgardeo/react'
+import { getEnv } from './runtimeConfig'
 
-const APP_URL = import.meta.env.VITE_APP_URL || window.location.origin
-const CLIENT_ID = import.meta.env.VITE_IDP_CLIENT_ID || 'TRADER_PORTAL_APP'
-const IDP_BASE_URL = import.meta.env.VITE_IDP_BASE_URL || 'https://localhost:8090'
-const IDP_PLATFORM = import.meta.env.VITE_IDP_PLATFORM || 'AsgardeoV2'
-const IDP_SCOPES = import.meta.env.VITE_IDP_SCOPES 
-  ? import.meta.env.VITE_IDP_SCOPES.split(',').map((s: string) => s.trim())
+const normalizeIdpPlatform = (value: string): 'AsgardeoV2' | 'Asgardeo' | 'IdentityServer' | 'Unknown' => {
+  if (value === 'AsgardeoV2' || value === 'Asgardeo' || value === 'IdentityServer' || value === 'Unknown') {
+    return value
+  }
+
+  return 'AsgardeoV2'
+}
+
+const APP_URL = getEnv('VITE_APP_URL', window.location.origin)!
+const CLIENT_ID = getEnv('VITE_IDP_CLIENT_ID', 'TRADER_PORTAL_APP')!
+const IDP_BASE_URL = getEnv('VITE_IDP_BASE_URL', 'https://localhost:8090')!
+const IDP_PLATFORM = normalizeIdpPlatform(getEnv('VITE_IDP_PLATFORM', 'AsgardeoV2')!)
+const rawScopes = getEnv('VITE_IDP_SCOPES')
+const IDP_SCOPES = rawScopes
+  ? rawScopes.split(',').map((s: string) => s.trim())
   : ["openid", "profile", "email"]
 
 createRoot(document.getElementById('root')!).render(

--- a/portals/apps/trader-app/src/plugins/SimpleForm.tsx
+++ b/portals/apps/trader-app/src/plugins/SimpleForm.tsx
@@ -8,6 +8,7 @@ import { useState, useCallback } from "react";
 import { Button } from "@radix-ui/themes";
 import type { JsonSchema, UISchemaElement } from '@jsonforms/core';
 import { autoFillForm } from "../utils/formUtils";
+import { getBooleanEnv } from '../runtimeConfig';
 
 
 
@@ -106,7 +107,7 @@ function TraderForm(props: { formInfo: TaskFormData, pluginState: string }) {
     setData(filledData);
   }, [props.formInfo.schema, data]);
 
-  const showAutoFillButton = import.meta.env.VITE_SHOW_AUTOFILL_BUTTON === 'true'
+  const showAutoFillButton = getBooleanEnv('VITE_SHOW_AUTOFILL_BUTTON', false)
 
   const isSubmissionFailed = props.pluginState === 'SUBMISSION_FAILED';
 

--- a/portals/apps/trader-app/src/runtimeConfig.ts
+++ b/portals/apps/trader-app/src/runtimeConfig.ts
@@ -1,0 +1,40 @@
+type RuntimeConfigValue = string | undefined
+
+type RuntimeConfigMap = Record<string, RuntimeConfigValue>
+
+declare global {
+  interface Window {
+    __APP_CONFIG__?: RuntimeConfigMap
+  }
+}
+
+function resolveRuntimeConfig(): RuntimeConfigMap {
+  if (typeof window === 'undefined') {
+    return {}
+  }
+
+  return window.__APP_CONFIG__ ?? {}
+}
+
+export function getEnv(name: string, fallback?: string): string | undefined {
+  const runtimeValue = resolveRuntimeConfig()[name]
+  if (runtimeValue && runtimeValue.trim() !== '') {
+    return runtimeValue
+  }
+
+  const buildValue = (import.meta.env as Record<string, string | undefined>)[name]
+  if (buildValue && buildValue.trim() !== '') {
+    return buildValue
+  }
+
+  return fallback
+}
+
+export function getBooleanEnv(name: string, fallback = false): boolean {
+  const value = getEnv(name)
+  if (!value) {
+    return fallback
+  }
+
+  return value.toLowerCase() === 'true'
+}

--- a/portals/apps/trader-app/src/services/api.ts
+++ b/portals/apps/trader-app/src/services/api.ts
@@ -1,4 +1,6 @@
-const API_BASE_URL = import.meta.env.VITE_API_BASE_URL || 'http://localhost:8080/api/v1'
+import { getEnv } from '../runtimeConfig'
+
+const API_BASE_URL = getEnv('VITE_API_BASE_URL', 'http://localhost:8080/api/v1')!
 
 export type QueryParams = Record<string, string | number | undefined>
 export type AccessTokenProvider = () => Promise<string | null | undefined>

--- a/portals/apps/trader-app/src/services/upload.ts
+++ b/portals/apps/trader-app/src/services/upload.ts
@@ -1,4 +1,6 @@
-const API_BASE_URL = import.meta.env.VITE_API_BASE_URL || 'http://localhost:8080/api/v1'
+import { getEnv } from '../runtimeConfig'
+
+const API_BASE_URL = getEnv('VITE_API_BASE_URL', 'http://localhost:8080/api/v1')!
 
 export interface FileMetadata {
   id: string

--- a/portals/docs/SETUP_WORKSPACE.md
+++ b/portals/docs/SETUP_WORKSPACE.md
@@ -98,7 +98,8 @@ pnpm install
 # - Root workspace
 # - apps/oga-app
 # - apps/trader-app
-# - ui package
+# - packages/ui
+# - packages/jsonforms-renderers
 ```
 
 **You may see a build scripts warning:**
@@ -129,7 +130,7 @@ This creates `.pnpm-build-scripts.json` (already in git) and allows these packag
 make build-ui
 
 # Or use pnpm directly
-pnpm --filter @lsf/ui build
+pnpm --filter @opennsw/ui build
 ```
 
 ### Step 7: Start Development
@@ -195,7 +196,7 @@ cd portals
 # Remove ALL node_modules (including nested)
 rm -rf node_modules
 rm -rf apps/*/node_modules
-rm -rf ui/node_modules
+rm -rf packages/*/node_modules
 
 # Remove old npm artifacts (if migrating from npm)
 rm -f package-lock.json
@@ -247,7 +248,7 @@ pnpm approve-builds
 make build-ui
 
 # Or manually
-pnpm --filter @lsf/ui build
+pnpm --filter @opennsw/ui build
 ```
 
 #### 7. Verify Lockfile Stability
@@ -343,7 +344,7 @@ pnpm --version
 # If wrong: npm install -g pnpm@10.28.1 OR corepack enable
 
 # 3. Clean install
-rm -rf node_modules apps/*/node_modules ui/node_modules
+rm -rf node_modules apps/*/node_modules packages/*/node_modules
 pnpm install
 
 # 4. Test stability
@@ -354,10 +355,10 @@ git diff pnpm-lock.yaml
 
 ---
 
-### Problem: `Cannot find module '@lsf/ui'`
+### Problem: `Cannot find module '@opennsw/ui'`
 
 **Symptoms:**
-- TypeScript or runtime errors about missing `@lsf/ui` module
+- TypeScript or runtime errors about missing `@opennsw/ui` module
 - Import statements fail
 
 **Solution:**
@@ -366,7 +367,7 @@ git diff pnpm-lock.yaml
 make build-ui
 
 # Or manually
-pnpm --filter @lsf/ui build
+pnpm --filter @opennsw/ui build
 ```
 
 ---
@@ -429,7 +430,7 @@ git diff pnpm-lock.yaml
 
 # 7. Verify workspace packages
 pnpm list --depth=0
-# ✅ Should list: oga-app, trader-app, @lsf/ui
+# ✅ Should list: oga-app, trader-app, @opennsw/ui
 
 # 8. Test build
 make build-ui
@@ -454,7 +455,7 @@ make dev-oga        # Start OGA app
 make dev-trader     # Start Trader app
 make build          # Build all packages
 make lint           # Run linter
-make lint-fix       # Auto-fix linting issues
+make format         # Auto-fix linting issues
 ```
 
 ---
@@ -480,7 +481,7 @@ Nuclear option if nothing else works:
 ```bash
 # 1. Remove everything
 cd portals
-rm -rf node_modules apps/*/node_modules ui/node_modules
+rm -rf node_modules apps/*/node_modules packages/*/node_modules
 rm -rf .pnpm-store pnpm-lock.yaml
 
 # 2. Reinstall Node/pnpm (start from scratch)
@@ -584,7 +585,7 @@ corepack enable
 npm install -g pnpm@10.28.2
 
 # Clean install
-rm -rf node_modules apps/*/node_modules ui/node_modules
+rm -rf node_modules apps/*/node_modules packages/*/node_modules
 pnpm install
 
 # Run tests
@@ -650,7 +651,7 @@ npm install -g pnpm@10.28.1
 git checkout main -- pnpm-lock.yaml
 
 # 5. Clean reinstall
-rm -rf node_modules apps/*/node_modules ui/node_modules
+rm -rf node_modules apps/*/node_modules packages/*/node_modules
 pnpm install
 ```
 

--- a/start-dev.sh
+++ b/start-dev.sh
@@ -1,0 +1,247 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ENV_FILE="${ENV_FILE:-$ROOT_DIR/.env}"
+RUN_IDP=true
+RUN_MIGRATIONS=true
+
+for arg in "$@"; do
+  case "$arg" in
+    --env-file=*)
+      ENV_FILE="${arg#*=}"
+      ;;
+    --skip-idp)
+      RUN_IDP=false
+      ;;
+    --skip-migrations)
+      RUN_MIGRATIONS=false
+      ;;
+    *)
+      echo "Unknown argument: $arg"
+      echo "Usage: ./start-dev.sh [--env-file=/path/to/.env] [--skip-idp] [--skip-migrations]"
+      exit 1
+      ;;
+  esac
+done
+
+if [[ ! -f "$ENV_FILE" ]]; then
+  echo "Env file not found: $ENV_FILE"
+  echo "Create one from: cp $ROOT_DIR/.env.example $ROOT_DIR/.env"
+  exit 1
+fi
+
+set -a
+source "$ENV_FILE"
+set +a
+
+for cmd in go pnpm docker; do
+  if ! command -v "$cmd" >/dev/null 2>&1; then
+    echo "$cmd is required but was not found in PATH"
+    exit 1
+  fi
+done
+
+if [[ "$RUN_IDP" == "true" ]]; then
+  echo "Starting IDP..."
+  (
+    cd "$ROOT_DIR/idp"
+    docker compose up -d
+  )
+fi
+
+IDP_PORT="${IDP_PORT:-8090}"
+BACKEND_PORT="${BACKEND_PORT:-8080}"
+TRADER_APP_PORT="${TRADER_APP_PORT:-5173}"
+OGA_NPQS_PORT="${OGA_NPQS_PORT:-8081}"
+OGA_FCAU_PORT="${OGA_FCAU_PORT:-8082}"
+OGA_IRD_PORT="${OGA_IRD_PORT:-8083}"
+OGA_APP_NPQS_PORT="${OGA_APP_NPQS_PORT:-5174}"
+OGA_APP_FCAU_PORT="${OGA_APP_FCAU_PORT:-5175}"
+OGA_APP_IRD_PORT="${OGA_APP_IRD_PORT:-5176}"
+
+
+if [[ "$RUN_MIGRATIONS" == "true" ]]; then
+  echo "Running backend migrations..."
+  (
+    cd "$ROOT_DIR/backend/internal/database/migrations"
+    ENV_FILE="$ENV_FILE" \
+      bash ./run.sh
+  )
+fi
+
+DB_HOST="${DB_HOST:-localhost}"
+DB_PORT="${DB_PORT:-5432}"
+DB_NAME="${DB_NAME:-nsw_db}"
+DB_USERNAME="${DB_USERNAME:-postgres}"
+DB_PASSWORD="${DB_PASSWORD:-changeme}"
+DB_SSLMODE="${DB_SSLMODE:-disable}"
+SERVER_DEBUG="${SERVER_DEBUG:-true}"
+SERVER_LOG_LEVEL="${SERVER_LOG_LEVEL:-info}"
+CORS_ALLOWED_ORIGINS="${CORS_ALLOWED_ORIGINS:-http://localhost:3000,http://localhost:5173,http://localhost:5174,http://localhost:5175,http://localhost:5176}"
+
+AUTH_ISSUER="${AUTH_ISSUER:-https://localhost:${IDP_PORT}}"
+AUTH_JWKS_URL="${AUTH_JWKS_URL:-https://localhost:${IDP_PORT}/oauth2/jwks}"
+AUTH_CLIENT_ID="${AUTH_CLIENT_ID:-TRADER_PORTAL_APP}"
+AUTH_AUDIENCE="${AUTH_AUDIENCE:-TRADER_PORTAL_APP}"
+AUTH_JWKS_INSECURE_SKIP_VERIFY="${AUTH_JWKS_INSECURE_SKIP_VERIFY:-true}"
+
+IDP_PUBLIC_URL="${IDP_PUBLIC_URL:-https://localhost:${IDP_PORT}}"
+TRADER_IDP_CLIENT_ID="${TRADER_IDP_CLIENT_ID:-TRADER_PORTAL_APP}"
+NPQS_IDP_CLIENT_ID="${NPQS_IDP_CLIENT_ID:-OGA_PORTAL_APP_NPQS}"
+FCAU_IDP_CLIENT_ID="${FCAU_IDP_CLIENT_ID:-OGA_PORTAL_APP_FCAU}"
+IRD_IDP_CLIENT_ID="${IRD_IDP_CLIENT_ID:-OGA_PORTAL_APP_IRD}"
+IDP_SCOPES="${IDP_SCOPES:-openid,profile,email}"
+IDP_PLATFORM="${IDP_PLATFORM:-AsgardeoV2}"
+SHOW_AUTOFILL_BUTTON="${SHOW_AUTOFILL_BUTTON:-true}"
+
+OGA_FORMS_PATH="${OGA_FORMS_PATH:-./data/forms}"
+OGA_DEFAULT_FORM_ID="${OGA_DEFAULT_FORM_ID:-default}"
+OGA_ALLOWED_ORIGINS="${OGA_ALLOWED_ORIGINS:-*}"
+
+OGA_NPQS_DB_PATH="${OGA_NPQS_DB_PATH:-./npqs.db}"
+OGA_FCAU_DB_PATH="${OGA_FCAU_DB_PATH:-./fcau.db}"
+OGA_IRD_DB_PATH="${OGA_IRD_DB_PATH:-./ird.db}"
+OGA_APP_NPQS_INSTANCE_CONFIG="${OGA_APP_NPQS_INSTANCE_CONFIG:-npqs}"
+OGA_APP_FCAU_INSTANCE_CONFIG="${OGA_APP_FCAU_INSTANCE_CONFIG:-fcau}"
+OGA_APP_IRD_INSTANCE_CONFIG="${OGA_APP_IRD_INSTANCE_CONFIG:-ird}"
+
+pids=()
+names=()
+
+cleanup() {
+  local code=$?
+  if [[ ${#pids[@]} -gt 0 ]]; then
+    echo
+    echo "Stopping services..."
+    for pid in "${pids[@]}"; do
+      kill "$pid" >/dev/null 2>&1 || true
+    done
+    wait >/dev/null 2>&1 || true
+  fi
+  exit "$code"
+}
+
+trap cleanup INT TERM
+
+start_service() {
+  local name="$1"
+  local dir="$2"
+  shift 2
+
+  (
+    cd "$dir"
+    "$@" 2>&1 | sed -u "s/^/[${name}] /"
+  ) &
+
+  pids+=("$!")
+  names+=("$name")
+}
+
+echo "Starting local development services (non-Docker)..."
+
+start_service "backend" "$ROOT_DIR/backend" env \
+  DB_HOST="$DB_HOST" \
+  DB_PORT="$DB_PORT" \
+  DB_NAME="$DB_NAME" \
+  DB_USERNAME="$DB_USERNAME" \
+  DB_PASSWORD="$DB_PASSWORD" \
+  DB_SSLMODE="$DB_SSLMODE" \
+  SERVER_PORT="$BACKEND_PORT" \
+  SERVER_DEBUG="$SERVER_DEBUG" \
+  SERVER_LOG_LEVEL="$SERVER_LOG_LEVEL" \
+  CORS_ALLOWED_ORIGINS="$CORS_ALLOWED_ORIGINS" \
+  AUTH_JWKS_URL="$AUTH_JWKS_URL" \
+  AUTH_ISSUER="$AUTH_ISSUER" \
+  AUTH_CLIENT_ID="$AUTH_CLIENT_ID" \
+  AUTH_AUDIENCE="$AUTH_AUDIENCE" \
+  AUTH_JWKS_INSECURE_SKIP_VERIFY="$AUTH_JWKS_INSECURE_SKIP_VERIFY" \
+  go run ./cmd/server/main.go
+
+start_service "oga-npqs" "$ROOT_DIR/oga" env \
+  OGA_PORT="$OGA_NPQS_PORT" \
+  OGA_DB_PATH="$OGA_NPQS_DB_PATH" \
+  OGA_FORMS_PATH="$OGA_FORMS_PATH" \
+  OGA_DEFAULT_FORM_ID="$OGA_DEFAULT_FORM_ID" \
+  OGA_ALLOWED_ORIGINS="$OGA_ALLOWED_ORIGINS" \
+  go run ./cmd/server
+
+start_service "oga-fcau" "$ROOT_DIR/oga" env \
+  OGA_PORT="$OGA_FCAU_PORT" \
+  OGA_DB_PATH="$OGA_FCAU_DB_PATH" \
+  OGA_FORMS_PATH="$OGA_FORMS_PATH" \
+  OGA_DEFAULT_FORM_ID="$OGA_DEFAULT_FORM_ID" \
+  OGA_ALLOWED_ORIGINS="$OGA_ALLOWED_ORIGINS" \
+  go run ./cmd/server
+
+start_service "oga-ird" "$ROOT_DIR/oga" env \
+  OGA_PORT="$OGA_IRD_PORT" \
+  OGA_DB_PATH="$OGA_IRD_DB_PATH" \
+  OGA_FORMS_PATH="$OGA_FORMS_PATH" \
+  OGA_DEFAULT_FORM_ID="$OGA_DEFAULT_FORM_ID" \
+  OGA_ALLOWED_ORIGINS="$OGA_ALLOWED_ORIGINS" \
+  go run ./cmd/server
+
+start_service "trader-app" "$ROOT_DIR/portals/apps/trader-app" env \
+  VITE_API_BASE_URL="http://localhost:${BACKEND_PORT}/api/v1" \
+  VITE_IDP_BASE_URL="$IDP_PUBLIC_URL" \
+  VITE_IDP_CLIENT_ID="$TRADER_IDP_CLIENT_ID" \
+  VITE_APP_URL="http://localhost:${TRADER_APP_PORT}" \
+  VITE_IDP_SCOPES="$IDP_SCOPES" \
+  VITE_IDP_PLATFORM="$IDP_PLATFORM" \
+  VITE_SHOW_AUTOFILL_BUTTON="$SHOW_AUTOFILL_BUTTON" \
+  pnpm run dev -- --port "$TRADER_APP_PORT"
+
+start_service "oga-app-npqs" "$ROOT_DIR/portals/apps/oga-app" env \
+  VITE_PORT="$OGA_APP_NPQS_PORT" \
+  VITE_INSTANCE_CONFIG="$OGA_APP_NPQS_INSTANCE_CONFIG" \
+  VITE_API_BASE_URL="http://localhost:${OGA_NPQS_PORT}" \
+  VITE_IDP_BASE_URL="$IDP_PUBLIC_URL" \
+  VITE_IDP_CLIENT_ID="$NPQS_IDP_CLIENT_ID" \
+  VITE_APP_URL="http://localhost:${OGA_APP_NPQS_PORT}" \
+  VITE_IDP_SCOPES="$IDP_SCOPES" \
+  VITE_IDP_PLATFORM="$IDP_PLATFORM" \
+  pnpm run dev
+
+start_service "oga-app-fcau" "$ROOT_DIR/portals/apps/oga-app" env \
+  VITE_PORT="$OGA_APP_FCAU_PORT" \
+  VITE_INSTANCE_CONFIG="$OGA_APP_FCAU_INSTANCE_CONFIG" \
+  VITE_API_BASE_URL="http://localhost:${OGA_FCAU_PORT}" \
+  VITE_IDP_BASE_URL="$IDP_PUBLIC_URL" \
+  VITE_IDP_CLIENT_ID="$FCAU_IDP_CLIENT_ID" \
+  VITE_APP_URL="http://localhost:${OGA_APP_FCAU_PORT}" \
+  VITE_IDP_SCOPES="$IDP_SCOPES" \
+  VITE_IDP_PLATFORM="$IDP_PLATFORM" \
+  pnpm run dev
+
+start_service "oga-app-ird" "$ROOT_DIR/portals/apps/oga-app" env \
+  VITE_PORT="$OGA_APP_IRD_PORT" \
+  VITE_INSTANCE_CONFIG="$OGA_APP_IRD_INSTANCE_CONFIG" \
+  VITE_API_BASE_URL="http://localhost:${OGA_IRD_PORT}" \
+  VITE_IDP_BASE_URL="$IDP_PUBLIC_URL" \
+  VITE_IDP_CLIENT_ID="$IRD_IDP_CLIENT_ID" \
+  VITE_APP_URL="http://localhost:${OGA_APP_IRD_PORT}" \
+  VITE_IDP_SCOPES="$IDP_SCOPES" \
+  VITE_IDP_PLATFORM="$IDP_PLATFORM" \
+  pnpm run dev
+
+cat <<EOF
+
+Started local services:
+  - backend       -> http://localhost:${BACKEND_PORT}
+  - trader-app    -> http://localhost:${TRADER_APP_PORT}
+  - oga-npqs      -> http://localhost:${OGA_NPQS_PORT}
+  - oga-fcau      -> http://localhost:${OGA_FCAU_PORT}
+  - oga-ird       -> http://localhost:${OGA_IRD_PORT}
+  - oga-app-npqs  -> http://localhost:${OGA_APP_NPQS_PORT}
+  - oga-app-fcau  -> http://localhost:${OGA_APP_FCAU_PORT}
+  - oga-app-ird   -> http://localhost:${OGA_APP_IRD_PORT}
+
+IDP start: $RUN_IDP
+Migrations run: $RUN_MIGRATIONS
+
+Press Ctrl+C to stop all services started by this script.
+EOF
+
+wait


### PR DESCRIPTION
## Summary

This PR standardizes runtime environment handling across `trader-app` and `oga-app`, adds a root-level local startup flow, and aligns workspace docs/tooling with the current monorepo layout. The goal is to make local development reproducible with a single command while keeping frontend runtime configuration explicit and instance-specific.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [x] Refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Other (please describe):

## Changes Made

- Added root-level `.env.example` for local non-Docker development defaults.
- Added root-level `start-dev.sh` to start local services end-to-end:
  - optional IDP startup (`--skip-idp` supported)
  - optional DB migrations (`--skip-migrations` supported)
  - backend, trader-app, OGA backends (NPQS/FCAU/IRD), and OGA apps (NPQS/FCAU/IRD)
- Introduced runtime env entry points for frontend apps (`public/runtime-env.js` + `runtimeConfig.ts`) so required `VITE_*` values are read consistently at runtime.
- Updated OGA app configuration to include IRD instance config.
- Updated Make/docs references to current workspace package naming and commands.
- Updated migration runner env handling (`ENV_FILE` support + host fallback behavior) to improve local script reliability.

## Testing

- [x] I have tested this change locally
- [ ] I have added unit tests for new functionality
- [x] I have tested edge cases
- [ ] All existing tests pass

### Local run steps (`start-dev.sh`)

1. `cp .env.example .env`
2. `chmod +x ./start-dev.sh`
3. `./start-dev.sh`

### Expected result

- IDP is started (unless `--skip-idp` is used).
- Migrations are executed (unless `--skip-migrations` is used).
- The following endpoints are available (with default ports):
  - backend: `http://localhost:8080`
  - trader-app: `http://localhost:5173`
  - oga-npqs: `http://localhost:8081`
  - oga-fcau: `http://localhost:8082`
  - oga-ird: `http://localhost:8083`
  - oga-app-npqs: `http://localhost:5174`
  - oga-app-fcau: `http://localhost:5175`
  - oga-app-ird: `http://localhost:5176`

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have checked that there are no merge conflicts

## Related Issues

Closes #227 

## Screenshots/Demo

N/A

## Additional Notes

- Scope of this PR focuses on local runtime configuration and local startup flow (`start-dev.sh`).
- Follow-up PRs will cover:
  - Docker-specific startup script and Dockerfile refinements (#228)
  - CI for validate all the docker files in each push to main branch(#218)
  - CD to publish docker images during the release (#230)
  - full docker-compose orchestration for the complete system (#201)

## Deployment Notes

- Ensure environment variables are aligned with `.env.example` before running local startup.
- No production deployment migration strategy changes are introduced in this PR.
