### PR TITLE
add OpenChoreo workload descriptors

### DIFF
--- a/backend/workload.yaml
+++ b/backend/workload.yaml
@@ -13,6 +13,7 @@ endpoints:
 
 configurations:
   env:
+    # Database
     - name: DB_HOST
       valueFrom:
         secretKeyRef:
@@ -38,3 +39,39 @@ configurations:
         secretKeyRef:
           name: nsw-db-secrets
           key: database
+    - name: DB_SSLMODE
+      value: require
+    # Auth
+    - name: AUTH_JWKS_URL
+      valueFrom:
+        secretKeyRef:
+          name: nsw-auth-secrets
+          key: jwks-url
+    - name: AUTH_ISSUER
+      valueFrom:
+        secretKeyRef:
+          name: nsw-auth-secrets
+          key: issuer
+    - name: AUTH_CLIENT_ID
+      valueFrom:
+        secretKeyRef:
+          name: nsw-auth-secrets
+          key: client-id
+    - name: AUTH_AUDIENCE
+      valueFrom:
+        secretKeyRef:
+          name: nsw-auth-secrets
+          key: audience
+    # CORS
+    - name: CORS_ALLOWED_ORIGINS
+      valueFrom:
+        secretKeyRef:
+          name: nsw-backend-secrets
+          key: cors-allowed-origins
+    # Storage
+    - name: STORAGE_TYPE
+      value: local
+    - name: STORAGE_LOCAL_BASE_DIR
+      value: /data/uploads
+    - name: STORAGE_LOCAL_PUBLIC_URL
+      value: /bucket

--- a/oga/workload.yaml
+++ b/oga/workload.yaml
@@ -10,3 +10,15 @@ endpoints:
     basePath: /
     visibility:
       - external
+
+configurations:
+  env:
+    - name: OGA_PORT
+      value: "8081"
+    - name: OGA_DB_PATH
+      value: /data/oga_applications.db
+    - name: OGA_ALLOWED_ORIGINS
+      valueFrom:
+        secretKeyRef:
+          name: nsw-oga-secrets
+          key: allowed-origins

--- a/portals/apps/oga-app/workload.yaml
+++ b/portals/apps/oga-app/workload.yaml
@@ -10,3 +10,32 @@ endpoints:
     basePath: /
     visibility:
       - external
+
+configurations:
+  env:
+    - name: VITE_INSTANCE_CONFIG
+      value: npqs
+    - name: VITE_API_BASE_URL
+      valueFrom:
+        secretKeyRef:
+          name: nsw-oga-portal-secrets
+          key: api-base-url
+    - name: VITE_IDP_BASE_URL
+      valueFrom:
+        secretKeyRef:
+          name: nsw-oga-portal-secrets
+          key: idp-base-url
+    - name: VITE_IDP_CLIENT_ID
+      valueFrom:
+        secretKeyRef:
+          name: nsw-oga-portal-secrets
+          key: idp-client-id
+    - name: VITE_APP_URL
+      valueFrom:
+        secretKeyRef:
+          name: nsw-oga-portal-secrets
+          key: app-url
+    - name: VITE_IDP_SCOPES
+      value: openid,profile,email
+    - name: VITE_IDP_PLATFORM
+      value: AsgardeoV2

--- a/portals/apps/trader-app/workload.yaml
+++ b/portals/apps/trader-app/workload.yaml
@@ -10,3 +10,32 @@ endpoints:
     basePath: /
     visibility:
       - external
+
+configurations:
+  env:
+    - name: VITE_API_BASE_URL
+      valueFrom:
+        secretKeyRef:
+          name: nsw-trader-portal-secrets
+          key: api-base-url
+    - name: VITE_IDP_BASE_URL
+      valueFrom:
+        secretKeyRef:
+          name: nsw-trader-portal-secrets
+          key: idp-base-url
+    - name: VITE_IDP_CLIENT_ID
+      valueFrom:
+        secretKeyRef:
+          name: nsw-trader-portal-secrets
+          key: idp-client-id
+    - name: VITE_APP_URL
+      valueFrom:
+        secretKeyRef:
+          name: nsw-trader-portal-secrets
+          key: app-url
+    - name: VITE_IDP_SCOPES
+      value: openid,profile,email
+    - name: VITE_IDP_PLATFORM
+      value: AsgardeoV2
+    - name: VITE_SHOW_AUTOFILL_BUTTON
+      value: "false"


### PR DESCRIPTION
## Summary
- adds `workload.yaml` to `backend/`, `oga/`, `portals/apps/trader-app/`, and `portals/apps/oga-app/`
- these tell OpenChoreo which ports to expose and how to wire up secrets
- without them the build generates a bare workload with no endpoints, which fails the component type validation ("must have at least one endpoint")

backend gets DB secret references (`nsw-db-secrets`) for the five connection params it needs. the other three are simpler since they just need port/endpoint exposure.

## what each file does

- **backend/workload.yaml**: REST endpoint on 8080, DB credentials from `nsw-db-secrets` SecretReference
- **oga/workload.yaml**: REST endpoint on 8081 (shared by all OGA agency instances)
- **portals/apps/trader-app/workload.yaml**: HTTP on port 80
- **portals/apps/oga-app/workload.yaml**: HTTP on port 80 (shared by FCAU/IRD/NPQS portal instances)

## context
found during OpenChoreo deployment testing. builds succeed but the generated Workload CRs have no endpoint info, so the release controller can't render the deployment templates.