### PR TITLE
feat: refactor TaskManager to separate HTTP handlers from core logic

### DIFF
--- a/backend/internal/app/bootstrap/app.go
+++ b/backend/internal/app/bootstrap/app.go
@@ -89,9 +89,11 @@ func Build(ctx context.Context, cfg *config.Config) (*App, error) {
 		return nil, fmt.Errorf("auth system health check failed: %w", err)
 	}
 
+	tmHandler := taskManager.NewHTTPHandler(tm)
+
 	mux := http.NewServeMux()
-	mux.HandleFunc("POST /api/v1/tasks", tm.HandleExecuteTask)
-	mux.HandleFunc("GET /api/v1/tasks/{id}", tm.HandleGetTask)
+	mux.HandleFunc("POST /api/v1/tasks", tmHandler.HandleExecuteTask)
+	mux.HandleFunc("GET /api/v1/tasks/{id}", tmHandler.HandleGetTask)
 	mux.HandleFunc("GET /api/v1/hscodes", hsCodeRouter.HandleGetAllHSCodes)
 	mux.HandleFunc("GET /api/v1/chas", chaRouter.HandleGetCHAs)
 	mux.HandleFunc("POST /api/v1/consignments", consignmentRouter.HandleCreateConsignment)

--- a/backend/internal/task/manager/http_handler.go
+++ b/backend/internal/task/manager/http_handler.go
@@ -1,0 +1,86 @@
+package manager
+
+import (
+	"encoding/json"
+	"log/slog"
+	"net/http"
+	"strings"
+)
+
+// HTTPHandler encapsulates the HTTP transport logic for TaskManager
+type HTTPHandler struct {
+	manager TaskManager
+}
+
+// NewHTTPHandler creates a new HTTPHandler for the task manager
+func NewHTTPHandler(manager TaskManager) *HTTPHandler {
+	return &HTTPHandler{manager: manager}
+}
+
+// HandleGetTask is an HTTP handler for fetching task information via GET request
+func (h *HTTPHandler) HandleGetTask(w http.ResponseWriter, r *http.Request) {
+	taskId := r.PathValue("id")
+	if taskId == "" {
+		writeJSONError(w, http.StatusBadRequest, "taskId is required")
+		return
+	}
+
+	result, err := h.manager.GetTaskRenderInfo(r.Context(), taskId)
+	if err != nil {
+		// Differentiate between invalid ID/NotFound and internal errors, if necessary.
+		status := http.StatusInternalServerError
+		if strings.HasPrefix(err.Error(), "taskID is invalid") {
+			status = http.StatusBadRequest
+		} else if strings.HasPrefix(err.Error(), "task ") {
+			status = http.StatusNotFound
+		}
+		writeJSONError(w, status, err.Error())
+		return
+	}
+
+	writeJSONResponse(w, http.StatusOK, result)
+}
+
+// HandleExecuteTask is an HTTP handler for executing a task via POST request
+func (h *HTTPHandler) HandleExecuteTask(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+
+	var req ExecuteTaskRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		writeJSONError(w, http.StatusBadRequest, "Invalid request body: "+err.Error())
+		return
+	}
+
+	result, err := h.manager.ExecuteTask(r.Context(), req)
+	if err != nil {
+		status := http.StatusInternalServerError
+		if string(err.Error()) == "task_id is required" {
+			status = http.StatusBadRequest
+		} else if len(err.Error()) >= 5 && string(err.Error()[:5]) == "task " {
+			status = http.StatusNotFound
+		}
+		writeJSONError(w, status, err.Error())
+		return
+	}
+
+	// Return success response
+	writeJSONResponse(w, http.StatusOK, result.ApiResponse)
+}
+
+func writeJSONResponse(w http.ResponseWriter, status int, data interface{}) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(status)
+	if err := json.NewEncoder(w).Encode(data); err != nil {
+		slog.Error("failed to encode JSON response", "error", err)
+	}
+}
+
+func writeJSONError(w http.ResponseWriter, status int, message string) {
+	writeJSONResponse(w, status, ExecuteTaskResponse{
+		Success: false,
+		Error:   message,
+	})
+}

--- a/backend/internal/task/manager/http_handler_test.go
+++ b/backend/internal/task/manager/http_handler_test.go
@@ -1,0 +1,64 @@
+package manager
+
+import (
+	"bytes"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestHTTPHandler_HandleExecuteTask(t *testing.T) {
+	t.Run("Invalid Method", func(t *testing.T) {
+		tm := &taskManager{}
+		handler := NewHTTPHandler(tm)
+		req := httptest.NewRequest(http.MethodGet, "/execute", nil)
+		w := httptest.NewRecorder()
+
+		handler.HandleExecuteTask(w, req)
+
+		resp := w.Result()
+		assert.Equal(t, http.StatusMethodNotAllowed, resp.StatusCode)
+	})
+
+	t.Run("Invalid Body", func(t *testing.T) {
+		tm := &taskManager{}
+		handler := NewHTTPHandler(tm)
+		req := httptest.NewRequest(http.MethodPost, "/execute", bytes.NewBufferString("invalid json"))
+		w := httptest.NewRecorder()
+
+		handler.HandleExecuteTask(w, req)
+
+		resp := w.Result()
+		assert.Equal(t, http.StatusBadRequest, resp.StatusCode)
+	})
+}
+
+func TestHTTPHandler_HandleGetTask(t *testing.T) {
+	t.Run("Missing TaskID", func(t *testing.T) {
+		tm, _, _, _ := setupTest(t)
+		handler := NewHTTPHandler(tm)
+		req := httptest.NewRequest(http.MethodGet, "/tasks/", nil)
+		// No path value set
+		w := httptest.NewRecorder()
+
+		handler.HandleGetTask(w, req)
+
+		resp := w.Result()
+		assert.Equal(t, http.StatusBadRequest, resp.StatusCode)
+	})
+
+	t.Run("Invalid TaskID string", func(t *testing.T) {
+		tm, _, _, _ := setupTest(t)
+		handler := NewHTTPHandler(tm)
+		req := httptest.NewRequest(http.MethodGet, "/tasks/invalid", nil)
+		req.SetPathValue("id", "invalid")
+		w := httptest.NewRecorder()
+
+		handler.HandleGetTask(w, req)
+
+		resp := w.Result()
+		assert.Equal(t, http.StatusBadRequest, resp.StatusCode)
+	})
+}

--- a/backend/internal/task/manager/manager.go
+++ b/backend/internal/task/manager/manager.go
@@ -5,8 +5,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"log/slog"
-	"net/http"
-	"strings"
 	"sync"
 
 	"github.com/google/uuid"
@@ -55,11 +53,6 @@ type TaskManager interface {
 	// Core Domain Methods
 	ExecuteTask(ctx context.Context, req ExecuteTaskRequest) (*plugin.ExecutionResponse, error)
 	GetTaskRenderInfo(ctx context.Context, taskID string) (*plugin.ApiResponse, error)
-	HandleEvent(ctx context.Context, taskID string, event string, payload map[string]any) error
-
-	// HTTP Transport Wrappers
-	HandleExecuteTask(w http.ResponseWriter, r *http.Request)
-	HandleGetTask(w http.ResponseWriter, r *http.Request)
 
 	// RegisterUpstreamCallback registers the callback used when task state changes.
 	RegisterUpstreamCallback(callback WorkflowUpdateHandler)
@@ -126,30 +119,6 @@ func (tm *taskManager) GetTaskRenderInfo(ctx context.Context, taskID string) (*p
 	return result, nil
 }
 
-// HandleGetTask is an HTTP handler for fetching task information via GET request
-func (tm *taskManager) HandleGetTask(w http.ResponseWriter, r *http.Request) {
-	taskId := r.PathValue("id")
-	if taskId == "" {
-		writeJSONError(w, http.StatusBadRequest, "taskId is required")
-		return
-	}
-
-	result, err := tm.GetTaskRenderInfo(r.Context(), taskId)
-	if err != nil {
-		// Differentiate between invalid ID/NotFound and internal errors, if necessary.
-		status := http.StatusInternalServerError
-		if strings.HasPrefix(err.Error(), "taskID is invalid") {
-			status = http.StatusBadRequest
-		} else if strings.HasPrefix(err.Error(), "task ") {
-			status = http.StatusNotFound
-		}
-		writeJSONError(w, status, err.Error())
-		return
-	}
-
-	writeJSONResponse(w, http.StatusOK, result)
-}
-
 // ExecuteTask is the core logic for executing a task
 func (tm *taskManager) ExecuteTask(ctx context.Context, req ExecuteTaskRequest) (*plugin.ExecutionResponse, error) {
 	if req.TaskID == uuid.Nil {
@@ -170,56 +139,6 @@ func (tm *taskManager) ExecuteTask(ctx context.Context, req ExecuteTaskRequest) 
 		return nil, fmt.Errorf("failed to execute task: %w", err)
 	}
 	return result, nil
-}
-
-// HandleEvent is a placeholder for handling events directed to tasks
-func (tm *taskManager) HandleEvent(ctx context.Context, taskID string, event string, payload map[string]any) error {
-	// TODO: Implement event handling logic
-	return fmt.Errorf("HandleEvent not implemented")
-}
-
-// HandleExecuteTask is an HTTP handler for executing a task via POST request
-func (tm *taskManager) HandleExecuteTask(w http.ResponseWriter, r *http.Request) {
-	if r.Method != http.MethodPost {
-		http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
-		return
-	}
-
-	var req ExecuteTaskRequest
-	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
-		writeJSONError(w, http.StatusBadRequest, "Invalid request body: "+err.Error())
-		return
-	}
-
-	result, err := tm.ExecuteTask(r.Context(), req)
-	if err != nil {
-		status := http.StatusInternalServerError
-		if err.Error() == "task_id is required" {
-			status = http.StatusBadRequest
-		} else if string(err.Error()[:5]) == "task " {
-			status = http.StatusNotFound
-		}
-		writeJSONError(w, status, err.Error())
-		return
-	}
-
-	// Return success response
-	writeJSONResponse(w, http.StatusOK, result.ApiResponse)
-}
-
-func writeJSONResponse(w http.ResponseWriter, status int, data interface{}) {
-	w.Header().Set("Content-Type", "application/json")
-	w.WriteHeader(status)
-	if err := json.NewEncoder(w).Encode(data); err != nil {
-		slog.Error("failed to encode JSON response", "error", err)
-	}
-}
-
-func writeJSONError(w http.ResponseWriter, status int, message string) {
-	writeJSONResponse(w, status, ExecuteTaskResponse{
-		Success: false,
-		Error:   message,
-	})
 }
 
 // InitTask initializes a new task container, creates its execution record,

--- a/backend/internal/task/manager/manager_test.go
+++ b/backend/internal/task/manager/manager_test.go
@@ -1,12 +1,9 @@
 package manager
 
 import (
-	"bytes"
 	"context"
 	"encoding/json"
 	"errors"
-	"net/http"
-	"net/http/httptest"
 	"testing"
 
 	"github.com/DATA-DOG/go-sqlmock"
@@ -372,139 +369,6 @@ func TestExecuteTask(t *testing.T) {
 		assert.Error(t, err)
 		assert.Nil(t, result)
 		assert.Contains(t, err.Error(), "task_id is required")
-	})
-}
-
-func TestHandleExecuteTask(t *testing.T) {
-	t.Run("Invalid Method", func(t *testing.T) {
-		tm := &taskManager{}
-		req := httptest.NewRequest(http.MethodGet, "/execute", nil)
-		w := httptest.NewRecorder()
-
-		tm.HandleExecuteTask(w, req)
-
-		resp := w.Result()
-		assert.Equal(t, http.StatusMethodNotAllowed, resp.StatusCode)
-	})
-
-	t.Run("Invalid Body", func(t *testing.T) {
-		tm := &taskManager{}
-		req := httptest.NewRequest(http.MethodPost, "/execute", bytes.NewBufferString("invalid json"))
-		w := httptest.NewRecorder()
-
-		tm.HandleExecuteTask(w, req)
-
-		resp := w.Result()
-		assert.Equal(t, http.StatusBadRequest, resp.StatusCode)
-	})
-}
-
-func TestGetTaskRenderInfo(t *testing.T) {
-	t.Run("Success", func(t *testing.T) {
-		tm, mockFactory, mockStore, mockPlugin := setupTest(t)
-
-		taskID := uuid.New()
-		workflowID := uuid.New()
-
-		// Mock GetTask (cache miss -> rebuild)
-		taskInfo := &persistence.TaskInfo{
-			ID:                     taskID,
-			WorkflowID:             workflowID,
-			WorkflowNodeTemplateID: uuid.New(),
-			Type:                   plugin.TaskTypeSimpleForm,
-			Config:                 json.RawMessage(`{}`),
-			GlobalContext:          json.RawMessage(`{}`),
-		}
-		mockStore.On("GetByID", taskID).Return(taskInfo, nil).Once()
-		mockFactory.On("BuildExecutor", mock.Anything, taskInfo.Type, taskInfo.Config).Return(plugin.Executor{Plugin: mockPlugin}, nil).Once()
-		mockStore.On("GetLocalState", taskID).Return(json.RawMessage(`{}`), nil).Once()
-		mockStore.On("GetPluginState", taskID).Return("", nil).Once()
-
-		mockPlugin.On("Init", mock.Anything).Return().Once()
-
-		renderInfo := &plugin.ApiResponse{
-			Success: true,
-			Data:    map[string]string{"foo": "bar"},
-		}
-		mockPlugin.On("GetRenderInfo", mock.Anything).Return(renderInfo, nil).Once()
-
-		result, err := tm.GetTaskRenderInfo(context.Background(), taskID.String())
-
-		assert.NoError(t, err)
-		assert.Equal(t, renderInfo, result)
-	})
-
-	t.Run("GetRenderInfo Error", func(t *testing.T) {
-		tm, mockFactory, mockStore, mockPlugin := setupTest(t)
-
-		taskID := uuid.New()
-
-		// Mock GetTask
-		taskInfo := &persistence.TaskInfo{
-			ID:     taskID,
-			Type:   plugin.TaskTypeSimpleForm,
-			Config: json.RawMessage(`{}`),
-		}
-		mockStore.On("GetByID", taskID).Return(taskInfo, nil).Once()
-		mockFactory.On("BuildExecutor", mock.Anything, taskInfo.Type, taskInfo.Config).Return(plugin.Executor{Plugin: mockPlugin}, nil).Once()
-		mockStore.On("GetLocalState", taskID).Return(json.RawMessage(`{}`), nil).Once()
-		mockStore.On("GetPluginState", taskID).Return("", nil).Once()
-		mockPlugin.On("Init", mock.Anything).Return().Once()
-
-		mockPlugin.On("GetRenderInfo", mock.Anything).Return(nil, errors.New("render error")).Once()
-
-		result, err := tm.GetTaskRenderInfo(context.Background(), taskID.String())
-
-		assert.Error(t, err)
-		assert.Nil(t, result)
-		assert.Contains(t, err.Error(), "render error")
-	})
-
-	t.Run("Task Not Found", func(t *testing.T) {
-		tm, _, mockStore, _ := setupTest(t)
-		taskID := uuid.New()
-
-		mockStore.On("GetByID", taskID).Return(nil, gorm.ErrRecordNotFound).Once()
-
-		result, err := tm.GetTaskRenderInfo(context.Background(), taskID.String())
-
-		assert.Error(t, err)
-		assert.Nil(t, result)
-	})
-
-	t.Run("Invalid Task ID Format", func(t *testing.T) {
-		tm, _, _, _ := setupTest(t)
-
-		result, err := tm.GetTaskRenderInfo(context.Background(), "invalid-uuid")
-
-		assert.Error(t, err)
-		assert.Nil(t, result)
-	})
-}
-
-func TestHandleGetTask(t *testing.T) {
-	t.Run("Missing TaskID", func(t *testing.T) {
-		tm, _, _, _ := setupTest(t)
-		req := httptest.NewRequest(http.MethodGet, "/tasks/", nil)
-		// No path value set
-		w := httptest.NewRecorder()
-
-		tm.HandleGetTask(w, req)
-
-		resp := w.Result()
-		assert.Equal(t, http.StatusBadRequest, resp.StatusCode)
-	})
-
-	t.Run("Invalid TaskID string", func(t *testing.T) {
-		tm, _, _, _ := setupTest(t)
-		req := httptest.NewRequest(http.MethodGet, "/tasks/invalid", nil)
-		req.SetPathValue("id", "invalid")
-		w := httptest.NewRecorder()
-
-		tm.HandleGetTask(w, req)
-
-		resp := w.Result()
-		assert.Equal(t, http.StatusBadRequest, resp.StatusCode)
 	})
 }
 

--- a/backend/internal/workflow/manager/manager_test.go
+++ b/backend/internal/workflow/manager/manager_test.go
@@ -2,7 +2,6 @@ package manager
 
 import (
 	"context"
-	"net/http"
 	"testing"
 
 	"github.com/DATA-DOG/go-sqlmock"
@@ -44,14 +43,6 @@ type MockTaskManager struct {
 func (m *MockTaskManager) InitTask(ctx context.Context, req taskManager.InitTaskRequest) (*taskManager.InitTaskResponse, error) {
 	args := m.Called(ctx, req)
 	return args.Get(0).(*taskManager.InitTaskResponse), args.Error(1)
-}
-
-func (m *MockTaskManager) HandleExecuteTask(w http.ResponseWriter, r *http.Request) {
-	m.Called(w, r)
-}
-
-func (m *MockTaskManager) HandleGetTask(w http.ResponseWriter, r *http.Request) {
-	m.Called(w, r)
 }
 
 func (m *MockTaskManager) RegisterUpstreamCallback(_ taskManager.WorkflowUpdateHandler) {}


### PR DESCRIPTION
Closes #255 
## Summary
Refactor the Task Manager to decouple the HTTP transport layer from the core domain logic. By extracting the HTTP handlers (`HandleGetTask` and `HandleExecuteTask`) out of the `TaskManager` interface and into a dedicated `HTTPHandler` struct, we adhere to clean architecture principles. This allows other internal components (like the Workflow Engine) to consume the TaskManager as a pure domain service without initiating or mimicking HTTP requests

## Changes Made
#### `backend/internal/task/manager/manager.go`
* Interface Clean-up: remove HTTP-specific handlers (`HandleExecuteTask` and `HandleGetTask`) from the `TaskManager` interface and implementation to eliminate coupling with the `net/http` package
* Core Domain Methods: add pure domain methods `ExecuteTask(ctx, req)` and `GetTaskRenderInfo(ctx, taskID)` that process business logic using standard Go contexts and domain request objects

#### `backend/internal/task/manager/http_handler.go`
* New HTTP Wrapper: Created a dedicated `HTTPHandler` struct that wraps the `TaskManager` interface dependency
* Transport Logic: move the HTTP-specific logic into `HandleExecuteTask` and `HandleGetTask` inside this new handler. These methods now safely handle path variable extraction (`r.PathValue("id")`), JSON payload decoding, and mapping internal domain errors to appropriate HTTP status codes (e.g., `400 Bad Request` or `404 Not Found`)
* Response utilities: move private helper functions `writeJSONResponse` and `writeJSONError` here to standardize JSON encoding and error formatting for the task endpoints

#### `backend/internal/app/bootstrap/app.go`
* Dependency injection & routing: update the bootstrap wiring to instantiate the new HTTP handler (`tmHandler := taskManager.NewHTTPHandler(tm)`) and route requests directly to it.
* Route config: map the `POST /api/v1/tasks` and `GET /api/v1/tasks/{id}` endpoints to `tmHandler.HandleExecuteTask` and `tmHandler.HandleGetTask` respectively

## Testing 
Verify the refactors didn't cause downstream interface breaking within components like workflow/manager
```bash
go mod tidy
go test ./internal/...
```