### PR TITLE
fix oga-app dockerfile to build jsonforms-renderers dependency first

### DIFF
--- a/portals/apps/oga-app/Dockerfile
+++ b/portals/apps/oga-app/Dockerfile
@@ -14,7 +14,7 @@ RUN pnpm install --frozen-lockfile
 
 COPY . .
 
-RUN pnpm --filter oga-app build
+RUN pnpm --filter @opennsw/jsonforms-renderers build && pnpm --filter oga-app build
 
 FROM nginx:1.27-alpine
 


### PR DESCRIPTION
## Summary
- oga-app build fails because `@opennsw/jsonforms-renderers` package needs to be built before oga-app can resolve it

## Changes
- Added `pnpm --filter @opennsw/jsonforms-renderers build` before `pnpm --filter oga-app build` in the Dockerfile

## Test
Verified on k3d OpenChoreo cluster, builds succeed after this fix.