### PR TITLE
chore(oga): remove legacy dependency on github.com/google/uuid

### DIFF
--- a/oga/go.mod
+++ b/oga/go.mod
@@ -3,7 +3,6 @@ module github.com/OpenNSW/nsw/oga
 go 1.25
 
 require (
-	github.com/google/uuid v1.6.0
 	gorm.io/driver/sqlite v1.6.0
 	gorm.io/gorm v1.31.1
 )

--- a/oga/go.sum
+++ b/oga/go.sum
@@ -1,5 +1,3 @@
-github.com/google/uuid v1.6.0 h1:NIvaJDMOsjHA8n1jAhLSgzrAzy1Hgr+hNrb57e+94F0=
-github.com/google/uuid v1.6.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/jinzhu/inflection v1.0.0 h1:K317FqzuhWc8YvSVlFMCCUb36O/S9MCKRDI7QkRKD/E=
 github.com/jinzhu/inflection v1.0.0/go.mod h1:h+uFLlag+Qp1Va5pdKtLDYj+kHp5pxUVkryuEj+Srlc=
 github.com/jinzhu/now v1.1.5 h1:/o9tlHleP7gOFmsnYNz3RGnqzefHA47wQpKrrdTIwXQ=


### PR DESCRIPTION
## Summary

Remove legacy dependency on github.com/google/uuid from OGA backend

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)