### PR TITLE
fix: use valid endpoint type HTTP instead of REST

### DIFF
--- a/backend/workload.yaml
+++ b/backend/workload.yaml
@@ -6,7 +6,7 @@ metadata:
 endpoints:
   - name: api
     port: 8080
-    type: REST
+    type: HTTP
     basePath: /api/v1
     visibility:
       - external


### PR DESCRIPTION
fixes invalid endpoint type in workload descriptor

`REST` isn't a valid `EndpointType` in the OpenChoreo workload schema. the valid enum values are `HTTP`, `gRPC`, `GraphQL`, `Websocket`, `TCP`, `UDP`. the descriptor passes the type straight through to the CR, so `REST` fails kubebuilder validation.

changes:
- `type: REST` → `type: HTTP` in `backend/workload.yaml`

found while validating the workload config against the [OpenChoreo workload types](https://github.com/openchoreo/openchoreo/blob/main/api/v1alpha1/workload_types.go#L135).