### PR TITLE
fix: use valid endpoint type HTTP instead of REST

### DIFF
--- a/oga/workload.yaml
+++ b/oga/workload.yaml
@@ -6,7 +6,7 @@ metadata:
 endpoints:
   - name: api
     port: 8081
-    type: REST
+    type: HTTP
     basePath: /
     visibility:
       - external


### PR DESCRIPTION
same as https://github.com/OpenNSW/nsw/pull/280 
- type: REST → type: HTTP in oga/workload.yaml