### PR TITLE
RBAC for Endpoints (Trader/CHA) & M2M allowance for Tasks/Upload

### DIFF
--- a/backend/internal/app/bootstrap/app.go
+++ b/backend/internal/app/bootstrap/app.go
@@ -162,7 +162,7 @@ func Build(ctx context.Context, cfg *config.Config) (*App, error) {
 		}
 
 		consignmentService := service.NewConsignmentService(db, templateService, nil, wmV2)
-		consignmentRouter = router.NewConsignmentRouter(consignmentService, chaService)
+		consignmentRouter = router.NewConsignmentRouter(consignmentService, chaService, &cfg.Auth)
 
 		// TODO: Pre-Consignment is commented out in new workflow for now
 		// preConsignmentService := service.NewPreConsignmentService(db, templateService, wmV2)
@@ -183,7 +183,7 @@ func Build(ctx context.Context, cfg *config.Config) (*App, error) {
 		consignmentService := service.NewConsignmentService(db, templateService, wm, nil)
 		preConsignmentService := service.NewPreConsignmentService(db, templateService, wm)
 
-		consignmentRouter = router.NewConsignmentRouter(consignmentService, chaService)
+		consignmentRouter = router.NewConsignmentRouter(consignmentService, chaService, &cfg.Auth)
 		preConsignmentRouter = router.NewPreConsignmentRouter(preConsignmentService)
 	}
 
@@ -196,7 +196,7 @@ func Build(ctx context.Context, cfg *config.Config) (*App, error) {
 		return nil, fmt.Errorf("failed to initialize storage: %w", err)
 	}
 	uploadService := uploads.NewUploadService(storageDriver)
-	uploadHandler := uploads.NewHTTPHandler(uploadService)
+	uploadHandler := uploads.NewHTTPHandler(uploadService, &cfg.Auth)
 
 	paymentHandler := payments.NewHTTPHandler(paymentService)
 
@@ -212,7 +212,7 @@ func Build(ctx context.Context, cfg *config.Config) (*App, error) {
 		return nil, fmt.Errorf("auth system health check failed: %w", err)
 	}
 
-	tmHandler := taskManager.NewHTTPHandler(tm)
+	tmHandler := taskManager.NewHTTPHandler(tm, &cfg.Auth)
 
 	// withAuth wraps an individual handler with the authentication middleware.
 	withAuth := authManager.Middleware()

--- a/backend/internal/auth/auth_test.go
+++ b/backend/internal/auth/auth_test.go
@@ -40,7 +40,7 @@ func TestTokenExtractor_ExtractClaimsFromHeader(t *testing.T) {
 	}))
 	defer jwksServer.Close()
 
-	extractor, err := NewTokenExtractor(jwksServer.URL, "https://localhost:8090/oauth2/token", "TRADER_PORTAL_APP", "TRADER_PORTAL_APP")
+	extractor, err := NewTokenExtractor(jwksServer.URL, "https://localhost:8090/oauth2/token", "TRADER_PORTAL_APP", "TRADER_PORTAL_APP", "INTERNAL_CLIENT")
 	if err != nil {
 		t.Fatalf("failed to create token extractor: %v", err)
 	}
@@ -233,8 +233,8 @@ func TestTokenExtractor_ExtractClaimsFromHeader(t *testing.T) {
 				return
 			}
 			got := ""
-			if claims != nil {
-				got = claims.UserID
+			if claims != nil && claims.UserID != nil {
+				got = *claims.UserID
 			}
 			if got != tt.want {
 				t.Errorf("ExtractClaimsFromHeader() got UserID = %v, want %v", got, tt.want)
@@ -289,12 +289,13 @@ func TestAuthContextCreation(t *testing.T) {
 		UserContext: contextJSON,
 	}
 
+	userID := "TRADER-TEST"
 	authCtx := &AuthContext{
-		UserID:      "TRADER-TEST",
+		UserID:      &userID,
 		UserContext: uc,
 	}
 
-	if authCtx.UserID != "TRADER-TEST" {
+	if authCtx.UserID == nil || *authCtx.UserID != "TRADER-TEST" {
 		t.Errorf("AuthContext.UserID got = %v, want TRADER-TEST", authCtx.UserID)
 	}
 
@@ -342,7 +343,7 @@ func BenchmarkTokenExtraction(b *testing.B) {
 		b.Fatalf("failed to sign token: %v", err)
 	}
 
-	extractor, err := NewTokenExtractor(jwksServer.URL, "https://localhost:8090/oauth2/token", "TRADER_PORTAL_APP", "TRADER_PORTAL_APP")
+	extractor, err := NewTokenExtractor(jwksServer.URL, "https://localhost:8090/oauth2/token", "TRADER_PORTAL_APP", "TRADER_PORTAL_APP", "INTERNAL_CLIENT")
 	if err != nil {
 		b.Fatalf("failed to create token extractor: %v", err)
 	}
@@ -396,7 +397,7 @@ func TestTokenExtractor_JWKSIsCached(t *testing.T) {
 		t.Fatalf("failed to sign token: %v", err)
 	}
 
-	extractor, err := NewTokenExtractor(jwksServer.URL, "https://localhost:8090/oauth2/token", "TRADER_PORTAL_APP", "TRADER_PORTAL_APP")
+	extractor, err := NewTokenExtractor(jwksServer.URL, "https://localhost:8090/oauth2/token", "TRADER_PORTAL_APP", "TRADER_PORTAL_APP", "INTERNAL_CLIENT")
 	if err != nil {
 		t.Fatalf("failed to create token extractor: %v", err)
 	}
@@ -480,7 +481,7 @@ func TestTokenExtractor_RefreshesJWKSOnUnknownKid(t *testing.T) {
 		t.Fatalf("failed to sign new token: %v", err)
 	}
 
-	extractor, err := NewTokenExtractor(jwksServer.URL, "https://localhost:8090/oauth2/token", "TRADER_PORTAL_APP", "TRADER_PORTAL_APP")
+	extractor, err := NewTokenExtractor(jwksServer.URL, "https://localhost:8090/oauth2/token", "TRADER_PORTAL_APP", "TRADER_PORTAL_APP", "INTERNAL_CLIENT")
 	if err != nil {
 		t.Fatalf("failed to create token extractor: %v", err)
 	}
@@ -514,7 +515,7 @@ func TestNewTokenExtractor_InvalidConfig(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			extractor, err := NewTokenExtractor(tt.jwksURL, tt.issuer, tt.audience, tt.expectedClientID)
+			extractor, err := NewTokenExtractor(tt.jwksURL, tt.issuer, tt.audience, tt.expectedClientID, "INTERNAL_CLIENT")
 			if err == nil {
 				t.Fatalf("expected constructor error, got extractor: %#v", extractor)
 			}

--- a/backend/internal/auth/auth_test.go
+++ b/backend/internal/auth/auth_test.go
@@ -243,6 +243,47 @@ func TestTokenExtractor_ExtractClaimsFromHeader(t *testing.T) {
 	}
 }
 
+// TestTokenExtractor_FailOpenPrevention verifies that empty expected client IDs do not cause a fail-open
+func TestTokenExtractor_FailOpenPrevention(t *testing.T) {
+	privateKey, _ := rsa.GenerateKey(rand.Reader, 2048)
+	jwksServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]interface{}{"keys": []map[string]interface{}{{"kid": "test-kid", "kty": "RSA", "alg": "RS256", "use": "sig", "n": base64.RawURLEncoding.EncodeToString(privateKey.N.Bytes()), "e": base64.RawURLEncoding.EncodeToString(big.NewInt(int64(privateKey.PublicKey.E)).Bytes())}}})
+	}))
+	defer jwksServer.Close()
+
+	// Initialized with empty internal client ID
+	extractor, _ := NewTokenExtractor(jwksServer.URL, "iss", "aud", "human-client", "")
+
+	mintToken := func(clientID string) string {
+		token := jwt.NewWithClaims(jwt.SigningMethodRS256, jwt.MapClaims{
+			"sub":       "user",
+			"iss":       "iss",
+			"aud":       "aud",
+			"client_id": clientID,
+			"iat":       time.Now().Unix(),
+			"exp":       time.Now().Add(time.Hour).Unix(),
+		})
+		token.Header["kid"] = "test-kid"
+		s, _ := token.SignedString(privateKey)
+		return s
+	}
+
+	// Token with empty client_id should be REJECTED even though expectedInternalClientID is also empty
+	emptyClientIDToken := mintToken("")
+	_, err := extractor.ExtractClaimsFromHeader("Bearer " + emptyClientIDToken)
+	if err == nil {
+		t.Error("expected error for empty client_id claim when expectedInternalClientID is empty, but got nil")
+	}
+
+	// Token with correct client_id should be ACCEPTED
+	validToken := mintToken("human-client")
+	_, err = extractor.ExtractClaimsFromHeader("Bearer " + validToken)
+	if err != nil {
+		t.Errorf("expected success for valid client_id, but got error: %v", err)
+	}
+}
+
 // TestUserContextModel tests the UserContext model structure
 func TestUserContextModel(t *testing.T) {
 	tests := []struct {
@@ -501,21 +542,22 @@ func TestTokenExtractor_RefreshesJWKSOnUnknownKid(t *testing.T) {
 
 func TestNewTokenExtractor_InvalidConfig(t *testing.T) {
 	tests := []struct {
-		name             string
-		jwksURL          string
-		issuer           string
-		audience         string
-		expectedClientID string
+		name                     string
+		jwksURL                  string
+		issuer                   string
+		audience                 string
+		expectedClientID         string
+		expectedInternalClientID string
 	}{
-		{name: "missing jwks url", issuer: "iss", audience: "aud", expectedClientID: "client"},
-		{name: "missing issuer", jwksURL: "https://localhost/jwks", audience: "aud", expectedClientID: "client"},
-		{name: "missing audience", jwksURL: "https://localhost/jwks", issuer: "iss", expectedClientID: "client"},
-		{name: "missing client id", jwksURL: "https://localhost/jwks", issuer: "iss", audience: "aud"},
+		{name: "missing jwks url", issuer: "iss", audience: "aud", expectedClientID: "client", expectedInternalClientID: "internal"},
+		{name: "missing issuer", jwksURL: "https://localhost/jwks", audience: "aud", expectedClientID: "client", expectedInternalClientID: "internal"},
+		{name: "missing audience", jwksURL: "https://localhost/jwks", issuer: "iss", expectedClientID: "client", expectedInternalClientID: "internal"},
+		{name: "missing both client ids", jwksURL: "https://localhost/jwks", issuer: "iss", audience: "aud"},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			extractor, err := NewTokenExtractor(tt.jwksURL, tt.issuer, tt.audience, tt.expectedClientID, "INTERNAL_CLIENT")
+			extractor, err := NewTokenExtractor(tt.jwksURL, tt.issuer, tt.audience, tt.expectedClientID, tt.expectedInternalClientID)
 			if err == nil {
 				t.Fatalf("expected constructor error, got extractor: %#v", extractor)
 			}

--- a/backend/internal/auth/context.go
+++ b/backend/internal/auth/context.go
@@ -15,48 +15,52 @@ func (t *UserContext) TableName() string {
 	return "user_contexts"
 }
 
-// AuthContext is the transient authentication context injected into each request
-// by the auth middleware. UserID is always set (from the JWT sub claim).
-// UserContext is nullable — CHAs and other non-trader roles may not have a DB entry.
+type ContextKey string
+
+const AuthContextKey ContextKey = "auth_context"
+
 type AuthContext struct {
-	UserID      string       `json:"userId"`
-	Email       string       `json:"email"`
-	OUHandle    string       `json:"ouHandle"`
-	UserContext *UserContext `json:"userContext,omitempty"`
+	UserID      *string      // nil if M2M
+	Email       string       // optional/empty for M2M
+	OUHandle    string       // optional/empty for M2M
+	ClientID    string       // Always present
+	Groups      []string     // e.g., ["Trader", "CHA"]
+	IsM2M       bool         // True if Client Credentials grant
+	UserContext *UserContext // Extended internal nsw database record
 }
 
-// GetUserContextMap returns the stored user context as a map.
-// Returns an empty map when no context is available.
-func (ac *AuthContext) GetUserContextMap() (map[string]any, error) {
+func (c *AuthContext) HasGroup(group string) bool {
+	if c == nil {
+		return false
+	}
+	for _, g := range c.Groups {
+		if g == group {
+			return true
+		}
+	}
+	return false
+}
+
+func (c *AuthContext) GetUserContextMap() (map[string]any, error) {
 	m := make(map[string]any)
-	if ac == nil || ac.UserContext == nil || len(ac.UserContext.UserContext) == 0 {
+	if c == nil || c.UserContext == nil || len(c.UserContext.UserContext) == 0 {
 		return m, nil
 	}
-	if err := json.Unmarshal(ac.UserContext.UserContext, &m); err != nil {
+	if err := json.Unmarshal(c.UserContext.UserContext, &m); err != nil {
 		return nil, err
 	}
 	return m, nil
 }
 
-// ContextKey is a custom type for context keys to avoid collisions.
-type ContextKey string
-
-const AuthContextKey ContextKey = "authContext"
-
-// GetAuthContext extracts the AuthContext from a request context.
-// Returns nil if no auth context is available (request had no valid token).
-//
-// Usage in handlers:
-//
-//	authCtx := auth.GetAuthContext(r.Context())
-//	if authCtx == nil {
-//	    // Handle unauthorized request
-//	}
-//	userID := authCtx.UserID
 func GetAuthContext(ctx context.Context) *AuthContext {
 	authCtx, ok := ctx.Value(AuthContextKey).(*AuthContext)
 	if !ok {
 		return nil
 	}
 	return authCtx
+}
+
+func FromContext(ctx context.Context) (*AuthContext, bool) {
+	authCtx, ok := ctx.Value(AuthContextKey).(*AuthContext)
+	return authCtx, ok
 }

--- a/backend/internal/auth/context.go
+++ b/backend/internal/auth/context.go
@@ -19,14 +19,19 @@ type ContextKey string
 
 const AuthContextKey ContextKey = "auth_context"
 
+const (
+	RoleQueryTrader = "trader"
+	RoleQueryCHA    = "cha"
+)
+
 type AuthContext struct {
-	UserID      *string      // nil if M2M
-	Email       string       // optional/empty for M2M
-	OUHandle    string       // optional/empty for M2M
-	ClientID    string       // Always present
-	Groups      []string     // e.g., ["Trader", "CHA"]
-	IsM2M       bool         // True if Client Credentials grant
-	UserContext *UserContext // Extended internal nsw database record
+	UserID      *string      `json:"userId"`
+	Email       string       `json:"email"`
+	OUHandle    string       `json:"ouHandle"`
+	UserContext *UserContext `json:"userContext,omitempty"`
+	ClientID    string       `json:"clientId"`
+	Groups      []string     `json:"groups"` // e.g. ["Trader", "CHA"]
+	IsM2M       bool         `json:"isM2M"`  // True if Client Credentials grant
 }
 
 func (c *AuthContext) HasGroup(group string) bool {
@@ -52,6 +57,16 @@ func (c *AuthContext) GetUserContextMap() (map[string]any, error) {
 	return m, nil
 }
 
+// GetAuthContext extracts the AuthContext from a request context.
+// Returns nil if no auth context is available (request had no valid token).
+//
+// Usage in handlers:
+//
+//	authCtx := auth.GetAuthContext(r.Context())
+//	if authCtx == nil {
+//	    // Handle unauthorized request
+//	}
+//	userID := authCtx.UserID
 func GetAuthContext(ctx context.Context) *AuthContext {
 	authCtx, ok := ctx.Value(AuthContextKey).(*AuthContext)
 	if !ok {

--- a/backend/internal/auth/manager.go
+++ b/backend/internal/auth/manager.go
@@ -51,7 +51,7 @@ func NewManager(db *gorm.DB, authConfig config.AuthConfig) (*Manager, error) {
 	}
 
 	tokenExtractor, err := NewTokenExtractorWithClient(
-		authConfig.JWKSURL, authConfig.Issuer, authConfig.Audience, authConfig.ClientID, httpClient,
+		authConfig.JWKSURL, authConfig.Issuer, authConfig.Audience, authConfig.ClientID, authConfig.InternalClientID, httpClient,
 	)
 	if err != nil {
 		return nil, fmt.Errorf("failed to initialize token extractor: %w", err)
@@ -131,6 +131,9 @@ func (m *Manager) OptionalAuthMiddleware() func(http.Handler) http.Handler { ret
 //
 // For request-based operations, use auth.GetAuthContext(r.Context()) in handlers instead.
 func (m *Manager) GetUserContext(userID string) (*UserContext, error) {
+	if userID == "" {
+		return nil, nil // No context for empty/M2M ID
+	}
 	return m.service.GetUserContext(userID)
 }
 
@@ -145,6 +148,9 @@ func (m *Manager) GetUserContext(userID string) (*UserContext, error) {
 //
 // For request-based operations, use a handler with auth context instead.
 func (m *Manager) UpdateUserContext(userID string, ctx interface{}) error {
+	if userID == "" {
+		return fmt.Errorf("user id cannot be empty")
+	}
 	var data []byte
 	var err error
 	switch v := ctx.(type) {

--- a/backend/internal/auth/middleware.go
+++ b/backend/internal/auth/middleware.go
@@ -64,21 +64,26 @@ func Middleware(authService *AuthService, tokenExtractor *TokenExtractor) func(h
 				UserID:   claims.UserID,
 				Email:    claims.Email,
 				OUHandle: claims.OUHandle,
+				Groups:   claims.Groups,
+				ClientID: claims.ClientID,
+				IsM2M:    claims.IsM2M,
 			}
 
-			userCtx, err := authService.GetUserContext(claims.UserID)
-			if err != nil {
-				if errors.Is(err, gorm.ErrRecordNotFound) {
-					slog.Debug("no stored user context, proceeding with nil UserContext",
-						"user_id", claims.UserID)
+			if !claims.IsM2M && claims.UserID != nil {
+				userCtx, err := authService.GetUserContext(*claims.UserID)
+				if err != nil {
+					if errors.Is(err, gorm.ErrRecordNotFound) {
+						slog.Debug("no stored user context, proceeding with nil UserContext",
+							"user_id", *claims.UserID)
+					} else {
+						slog.Warn("failed to get user context from database",
+							"user_id", *claims.UserID, "error", err)
+						next.ServeHTTP(w, r)
+						return
+					}
 				} else {
-					slog.Warn("failed to get user context from database",
-						"user_id", claims.UserID, "error", err)
-					next.ServeHTTP(w, r)
-					return
+					authCtx.UserContext = userCtx
 				}
-			} else {
-				authCtx.UserContext = userCtx
 			}
 
 			ctx := context.WithValue(r.Context(), AuthContextKey, authCtx)

--- a/backend/internal/auth/middleware_test.go
+++ b/backend/internal/auth/middleware_test.go
@@ -20,7 +20,8 @@ func TestGetAuthContext_FromRequest(t *testing.T) {
 		UserID:      "TRADER-001",
 		UserContext: json.RawMessage(`{"test": "data"}`),
 	}
-	authCtx := &AuthContext{UserID: "TRADER-001", UserContext: uc}
+	userID := "TRADER-001"
+	authCtx := &AuthContext{UserID: &userID, UserContext: uc}
 	ctx := context.WithValue(context.Background(), AuthContextKey, authCtx)
 
 	// Retrieve context
@@ -29,8 +30,8 @@ func TestGetAuthContext_FromRequest(t *testing.T) {
 		t.Error("expected to retrieve auth context")
 		return
 	}
-	if retrieved.UserID != "TRADER-001" {
-		t.Errorf("got trader id %s, want TRADER-001", retrieved.UserID)
+	if retrieved.UserID == nil || *retrieved.UserID != "TRADER-001" {
+		t.Errorf("got trader id %v, want TRADER-001", retrieved.UserID)
 	}
 }
 
@@ -131,7 +132,7 @@ func TestAuthMiddleware_UninitializedDependencies(t *testing.T) {
 		w.WriteHeader(http.StatusOK)
 	})
 
-	tokenExtractor, err := NewTokenExtractor("https://localhost:8090/oauth2/jwks", "https://localhost:8090/oauth2/token", "TRADER_PORTAL_APP", "TRADER_PORTAL_APP")
+	tokenExtractor, err := NewTokenExtractor("https://localhost:8090/oauth2/jwks", "https://localhost:8090/oauth2/token", "TRADER_PORTAL_APP", "TRADER_PORTAL_APP", "INTERNAL_CLIENT")
 	if err != nil {
 		t.Fatalf("failed to create token extractor: %v", err)
 	}
@@ -160,7 +161,7 @@ func TestAuthMiddleware_InvalidToken(t *testing.T) {
 		w.WriteHeader(http.StatusOK)
 	})
 
-	tokenExtractor, err := NewTokenExtractor("https://localhost:8090/oauth2/jwks", "https://localhost:8090/oauth2/token", "TRADER_PORTAL_APP", "TRADER_PORTAL_APP")
+	tokenExtractor, err := NewTokenExtractor("https://localhost:8090/oauth2/jwks", "https://localhost:8090/oauth2/token", "TRADER_PORTAL_APP", "TRADER_PORTAL_APP", "INTERNAL_CLIENT")
 	if err != nil {
 		t.Fatalf("failed to create token extractor: %v", err)
 	}

--- a/backend/internal/auth/token_parser.go
+++ b/backend/internal/auth/token_parser.go
@@ -154,27 +154,37 @@ func (te *TokenExtractor) ExtractClaimsFromHeader(authHeader string) (*Extracted
 		return nil, fmt.Errorf("invalid jwt token")
 	}
 
-	// Validate ClientID against whitelist
-	if claims.ClientID != te.expectedClientID && claims.ClientID != te.expectedInternalClientID {
+	// Validate ClientID against whitelist, only allow non-empty expected IDs to match
+	isAuthorizedClient := (te.expectedClientID != "" && claims.ClientID == te.expectedClientID) ||
+		(te.expectedInternalClientID != "" && claims.ClientID == te.expectedInternalClientID)
+
+	if !isAuthorizedClient {
 		return nil, fmt.Errorf("unauthorized client: %s", claims.ClientID)
 	}
 
 	// Detect M2M
-	// In WSO2 client credentials grant, `sub` is typically set to `client_id@tenant` or just `client_id` or is empty.
-	isM2M := claims.Subject == "" || claims.Subject == claims.ClientID || strings.HasPrefix(claims.Subject, claims.ClientID+"@")
+	// A token is M2M ONLY if it comes from the internal client and has a matching M2M subject pattern.
+	isM2M := false
+	if te.expectedInternalClientID != "" && claims.ClientID == te.expectedInternalClientID {
+		if claims.Subject == "" || claims.Subject == claims.ClientID || strings.HasPrefix(claims.Subject, claims.ClientID+"@") {
+			isM2M = true
+		}
+	}
+
+	if !isM2M && claims.Subject == "" {
+		return nil, fmt.Errorf("missing 'sub' claim in human token")
+	}
 
 	var userID *string
 	if !isM2M {
 		sub := claims.Subject
-		if sub != "" {
-			userID = &sub
-		}
+		userID = &sub
 	}
 
 	return &ExtractedClaims{
 		UserID:   userID,
-		Email:    claims.Email,
-		OUHandle: claims.OUHandle,
+		Email:    strings.TrimSpace(claims.Email),
+		OUHandle: strings.TrimSpace(claims.OUHandle),
 		ClientID: claims.ClientID,
 		Groups:   claims.Groups,
 		IsM2M:    isM2M,

--- a/backend/internal/auth/token_parser.go
+++ b/backend/internal/auth/token_parser.go
@@ -16,15 +16,19 @@ import (
 
 type tokenClaims struct {
 	jwt.RegisteredClaims
-	ClientID string `json:"client_id"`
-	Email    string `json:"email"`
-	OUHandle string `json:"ouHandle"`
+	ClientID string   `json:"client_id"`
+	Email    string   `json:"email"`
+	OUHandle string   `json:"ouHandle"`
+	Groups   []string `json:"groups"` // Assuming WSO2 sends this
 }
 
 type ExtractedClaims struct {
-	UserID   string `json:"userId"`
-	Email    string `json:"email"`
-	OUHandle string `json:"ouHandle"`
+	UserID   *string  `json:"userId"`
+	Email    string   `json:"email"`
+	OUHandle string   `json:"ouHandle"`
+	ClientID string   `json:"clientId"`
+	Groups   []string `json:"groups"`
+	IsM2M    bool     `json:"isM2M"`
 }
 
 type jwksResponse struct {
@@ -45,11 +49,12 @@ const defaultJWKSCacheTTL = 5 * time.Minute
 // TokenExtractor handles token extraction and parsing from HTTP headers.
 // It validates JWT signatures using JWKS and maps the `sub` claim to TraderID.
 type TokenExtractor struct {
-	jwksURL          string
-	issuer           string
-	audience         string
-	expectedClientID string
-	httpClient       *http.Client
+	jwksURL                  string
+	issuer                   string
+	audience                 string
+	expectedClientID         string
+	expectedInternalClientID string
+	httpClient               *http.Client
 
 	cacheMu       sync.RWMutex
 	cachedJWKS    *jwksResponse
@@ -57,13 +62,14 @@ type TokenExtractor struct {
 	jwksCacheTTL  time.Duration
 }
 
-func NewTokenExtractor(jwksURL, issuer, audience, expectedClientID string) (*TokenExtractor, error) {
+func NewTokenExtractor(jwksURL, issuer, audience, expectedClientID, expectedInternalClientID string) (*TokenExtractor, error) {
 	extractor := &TokenExtractor{
-		jwksURL:          strings.TrimSpace(jwksURL),
-		issuer:           strings.TrimSpace(issuer),
-		audience:         strings.TrimSpace(audience),
-		expectedClientID: strings.TrimSpace(expectedClientID),
-		jwksCacheTTL:     defaultJWKSCacheTTL,
+		jwksURL:                  strings.TrimSpace(jwksURL),
+		issuer:                   strings.TrimSpace(issuer),
+		audience:                 strings.TrimSpace(audience),
+		expectedClientID:         strings.TrimSpace(expectedClientID),
+		expectedInternalClientID: strings.TrimSpace(expectedInternalClientID),
+		jwksCacheTTL:             defaultJWKSCacheTTL,
 		httpClient: &http.Client{
 			Timeout: 10 * time.Second,
 		},
@@ -76,18 +82,19 @@ func NewTokenExtractor(jwksURL, issuer, audience, expectedClientID string) (*Tok
 	return extractor, nil
 }
 
-func NewTokenExtractorWithClient(jwksURL, issuer, audience, expectedClientID string, httpClient *http.Client) (*TokenExtractor, error) {
+func NewTokenExtractorWithClient(jwksURL, issuer, audience, expectedClientID, expectedInternalClientID string, httpClient *http.Client) (*TokenExtractor, error) {
 	if httpClient == nil {
-		return NewTokenExtractor(jwksURL, issuer, audience, expectedClientID)
+		return NewTokenExtractor(jwksURL, issuer, audience, expectedClientID, expectedInternalClientID)
 	}
 
 	extractor := &TokenExtractor{
-		jwksURL:          strings.TrimSpace(jwksURL),
-		issuer:           strings.TrimSpace(issuer),
-		audience:         strings.TrimSpace(audience),
-		expectedClientID: strings.TrimSpace(expectedClientID),
-		jwksCacheTTL:     defaultJWKSCacheTTL,
-		httpClient:       httpClient,
+		jwksURL:                  strings.TrimSpace(jwksURL),
+		issuer:                   strings.TrimSpace(issuer),
+		audience:                 strings.TrimSpace(audience),
+		expectedClientID:         strings.TrimSpace(expectedClientID),
+		expectedInternalClientID: strings.TrimSpace(expectedInternalClientID),
+		jwksCacheTTL:             defaultJWKSCacheTTL,
+		httpClient:               httpClient,
 	}
 
 	if err := extractor.validateConfig(); err != nil {
@@ -107,8 +114,8 @@ func (te *TokenExtractor) validateConfig() error {
 	if te.audience == "" {
 		return fmt.Errorf("audience is not configured")
 	}
-	if te.expectedClientID == "" {
-		return fmt.Errorf("client id is not configured")
+	if te.expectedClientID == "" && te.expectedInternalClientID == "" {
+		return fmt.Errorf("at least one client id must be configured")
 	}
 	if te.httpClient == nil {
 		return fmt.Errorf("http client is not configured")
@@ -147,26 +154,30 @@ func (te *TokenExtractor) ExtractClaimsFromHeader(authHeader string) (*Extracted
 		return nil, fmt.Errorf("invalid jwt token")
 	}
 
-	if claims.ExpiresAt == nil {
-		return nil, fmt.Errorf("jwt missing exp claim")
+	// Validate ClientID against whitelist
+	if claims.ClientID != te.expectedClientID && claims.ClientID != te.expectedInternalClientID {
+		return nil, fmt.Errorf("unauthorized client: %s", claims.ClientID)
 	}
 
-	userID := strings.TrimSpace(claims.Subject)
-	if len(userID) == 0 {
-		return nil, fmt.Errorf("jwt missing sub claim")
-	}
+	// Detect M2M
+	// In WSO2 client credentials grant, `sub` is typically set to `client_id@tenant` or just `client_id` or is empty.
+	isM2M := claims.Subject == "" || claims.Subject == claims.ClientID || strings.HasPrefix(claims.Subject, claims.ClientID+"@")
 
-	if strings.TrimSpace(claims.ClientID) == "" {
-		return nil, fmt.Errorf("jwt missing client_id claim")
-	}
-	if strings.TrimSpace(claims.ClientID) != te.expectedClientID {
-		return nil, fmt.Errorf("jwt client_id does not match expected client id")
+	var userID *string
+	if !isM2M {
+		sub := claims.Subject
+		if sub != "" {
+			userID = &sub
+		}
 	}
 
 	return &ExtractedClaims{
 		UserID:   userID,
-		Email:    strings.TrimSpace(claims.Email),
-		OUHandle: strings.TrimSpace(claims.OUHandle),
+		Email:    claims.Email,
+		OUHandle: claims.OUHandle,
+		ClientID: claims.ClientID,
+		Groups:   claims.Groups,
+		IsM2M:    isM2M,
 	}, nil
 }
 

--- a/backend/internal/config/config.go
+++ b/backend/internal/config/config.go
@@ -62,12 +62,14 @@ type StorageConfig struct {
 	S3UseSSL       bool
 	S3PublicURL    string
 }
-
 type AuthConfig struct {
 	JWKSURL               string
 	Issuer                string
 	Audience              string
 	ClientID              string
+	InternalClientID      string
+	TraderGroup           string
+	CHAGroup              string
 	InsecureSkipTLSVerify bool
 }
 
@@ -129,6 +131,9 @@ func Load() (*Config, error) {
 			Issuer:                getEnvOrDefault("AUTH_ISSUER", "https://localhost:8090"),
 			Audience:              getEnvOrDefault("AUTH_AUDIENCE", "TRADER_PORTAL_APP"),
 			ClientID:              getEnvOrDefault("AUTH_CLIENT_ID", "TRADER_PORTAL_APP"),
+			InternalClientID:      getEnvOrDefault("AUTH_INTERNAL_CLIENT_ID", "OGA_M2M_APP"),
+			TraderGroup:           getEnvOrDefault("AUTH_TRADER_GROUP", "NSW_TRADER"),
+			CHAGroup:              getEnvOrDefault("AUTH_CHA_GROUP", "NSW_CHA"),
 			InsecureSkipTLSVerify: getBoolOrDefault("AUTH_JWKS_INSECURE_SKIP_VERIFY", defaultInsecureJWKS),
 		},
 		UseWorkflowManagerV2: getBoolOrDefault("USE_WORKFLOW_MANAGER_V2", false),

--- a/backend/internal/task/manager/http_handler.go
+++ b/backend/internal/task/manager/http_handler.go
@@ -29,6 +29,7 @@ func (h *HTTPHandler) HandleGetTask(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	var requestorID string
 	if !authCtx.IsM2M {
 		// For Phase 1, we allow Trader and CHA to view tasks
 		// If they don't have either group, they are forbidden.
@@ -36,6 +37,12 @@ func (h *HTTPHandler) HandleGetTask(w http.ResponseWriter, r *http.Request) {
 			writeJSONError(w, http.StatusForbidden, "Forbidden: Insufficient privileges")
 			return
 		}
+		// Safely extract the UserID for human users
+		if authCtx.UserID == nil {
+			writeJSONError(w, http.StatusUnauthorized, "Unauthorized: Human context required")
+			return
+		}
+		requestorID = *authCtx.UserID
 	}
 	// TODO (else): Implement granular M2M permission check (e.g. RequiredScope("tasks:read"))
 
@@ -45,7 +52,7 @@ func (h *HTTPHandler) HandleGetTask(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	result, err := h.manager.GetTaskRenderInfo(r.Context(), taskId)
+	result, err := h.manager.GetTaskRenderInfo(r.Context(), taskId, requestorID, authCtx.IsM2M)
 	if err != nil {
 		// Differentiate between invalid ID/NotFound and internal errors, if necessary.
 		status := http.StatusInternalServerError
@@ -69,6 +76,7 @@ func (h *HTTPHandler) HandleExecuteTask(w http.ResponseWriter, r *http.Request) 
 		return
 	}
 
+	var requestorID string
 	if !authCtx.IsM2M {
 		// For Phase 1, we only allow CHA to execute tasks
 		// (Assuming core workflow tasks are managed by CHAs)
@@ -76,6 +84,12 @@ func (h *HTTPHandler) HandleExecuteTask(w http.ResponseWriter, r *http.Request) 
 			writeJSONError(w, http.StatusForbidden, "Forbidden: Only CHAs or Systems can execute tasks")
 			return
 		}
+		// Safely extract the UserID for human users
+		if authCtx.UserID == nil {
+			writeJSONError(w, http.StatusUnauthorized, "Unauthorized: Human context required")
+			return
+		}
+		requestorID = *authCtx.UserID
 	}
 	// TODO (else): Implement granular M2M permission check (e.g. RequiredScope("tasks:execute"))
 
@@ -89,6 +103,9 @@ func (h *HTTPHandler) HandleExecuteTask(w http.ResponseWriter, r *http.Request) 
 		writeJSONError(w, http.StatusBadRequest, "Invalid request body: "+err.Error())
 		return
 	}
+
+	req.RequestorID = requestorID
+	req.IsSystem = authCtx.IsM2M
 
 	result, err := h.manager.ExecuteTask(r.Context(), req)
 	if err != nil {

--- a/backend/internal/task/manager/http_handler.go
+++ b/backend/internal/task/manager/http_handler.go
@@ -5,20 +5,40 @@ import (
 	"log/slog"
 	"net/http"
 	"strings"
+
+	"github.com/OpenNSW/nsw/internal/auth"
+	"github.com/OpenNSW/nsw/internal/config"
 )
 
 // HTTPHandler encapsulates the HTTP transport logic for TaskManager
 type HTTPHandler struct {
 	manager TaskManager
+	config  *config.AuthConfig
 }
 
 // NewHTTPHandler creates a new HTTPHandler for the task manager
-func NewHTTPHandler(manager TaskManager) *HTTPHandler {
-	return &HTTPHandler{manager: manager}
+func NewHTTPHandler(manager TaskManager, cfg *config.AuthConfig) *HTTPHandler {
+	return &HTTPHandler{manager: manager, config: cfg}
 }
 
 // HandleGetTask is an HTTP handler for fetching task information via GET request
 func (h *HTTPHandler) HandleGetTask(w http.ResponseWriter, r *http.Request) {
+	authCtx, ok := auth.FromContext(r.Context())
+	if !ok {
+		writeJSONError(w, http.StatusUnauthorized, "Unauthorized")
+		return
+	}
+
+	if !authCtx.IsM2M {
+		// For Phase 1, we allow Trader and CHA to view tasks
+		// If they don't have either group, they are forbidden.
+		if !authCtx.HasGroup(h.config.TraderGroup) && !authCtx.HasGroup(h.config.CHAGroup) {
+			writeJSONError(w, http.StatusForbidden, "Forbidden: Insufficient privileges")
+			return
+		}
+	}
+	// TODO (else): Implement granular M2M permission check (e.g. RequiredScope("tasks:read"))
+
 	taskId := r.PathValue("id")
 	if taskId == "" {
 		writeJSONError(w, http.StatusBadRequest, "taskId is required")
@@ -43,6 +63,22 @@ func (h *HTTPHandler) HandleGetTask(w http.ResponseWriter, r *http.Request) {
 
 // HandleExecuteTask is an HTTP handler for executing a task via POST request
 func (h *HTTPHandler) HandleExecuteTask(w http.ResponseWriter, r *http.Request) {
+	authCtx, ok := auth.FromContext(r.Context())
+	if !ok {
+		writeJSONError(w, http.StatusUnauthorized, "Unauthorized")
+		return
+	}
+
+	if !authCtx.IsM2M {
+		// For Phase 1, we only allow CHA to execute tasks
+		// (Assuming core workflow tasks are managed by CHAs)
+		if !authCtx.HasGroup(h.config.CHAGroup) {
+			writeJSONError(w, http.StatusForbidden, "Forbidden: Only CHAs or Systems can execute tasks")
+			return
+		}
+	}
+	// TODO (else): Implement granular M2M permission check (e.g. RequiredScope("tasks:execute"))
+
 	if r.Method != http.MethodPost {
 		http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
 		return

--- a/backend/internal/task/manager/http_handler_test.go
+++ b/backend/internal/task/manager/http_handler_test.go
@@ -2,35 +2,52 @@ package manager
 
 import (
 	"bytes"
+	"context"
+	"encoding/json"
 	"errors"
 	"net/http"
 	"net/http/httptest"
 	"testing"
 
+	"github.com/OpenNSW/nsw/internal/auth"
+	"github.com/OpenNSW/nsw/internal/config"
+	"github.com/OpenNSW/nsw/internal/task/persistence"
+	"github.com/OpenNSW/nsw/internal/task/plugin"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
 )
 
 func TestHTTPHandler_HandleExecuteTask(t *testing.T) {
 	t.Run("Invalid Method", func(t *testing.T) {
-		tm := &taskManager{}
-		handler := NewHTTPHandler(tm)
+		tm, _, _, _ := setupTest(t)
+		handler := NewHTTPHandler(tm, &config.AuthConfig{TraderGroup: "Trader", CHAGroup: "CHA"})
 		req := httptest.NewRequest(http.MethodGet, "/execute", nil)
+
+		userID := "cha-1"
+		ctx := context.WithValue(req.Context(), auth.AuthContextKey, &auth.AuthContext{
+			UserID: &userID, Groups: []string{"CHA"}, IsM2M: false,
+		})
+		req = req.WithContext(ctx)
+
 		w := httptest.NewRecorder()
-
 		handler.HandleExecuteTask(w, req)
-
 		resp := w.Result()
 		assert.Equal(t, http.StatusMethodNotAllowed, resp.StatusCode)
 	})
 
 	t.Run("Invalid Body", func(t *testing.T) {
-		tm := &taskManager{}
-		handler := NewHTTPHandler(tm)
+		tm, _, _, _ := setupTest(t)
+		handler := NewHTTPHandler(tm, &config.AuthConfig{TraderGroup: "Trader", CHAGroup: "CHA"})
 		req := httptest.NewRequest(http.MethodPost, "/execute", bytes.NewBufferString("invalid json"))
+
+		userID := "cha-1"
+		ctx := context.WithValue(req.Context(), auth.AuthContextKey, &auth.AuthContext{
+			UserID: &userID, Groups: []string{"CHA"}, IsM2M: false,
+		})
+		req = req.WithContext(ctx)
+
 		w := httptest.NewRecorder()
-
 		handler.HandleExecuteTask(w, req)
-
 		resp := w.Result()
 		assert.Equal(t, http.StatusBadRequest, resp.StatusCode)
 	})
@@ -39,22 +56,34 @@ func TestHTTPHandler_HandleExecuteTask(t *testing.T) {
 func TestHTTPHandler_HandleGetTask(t *testing.T) {
 	t.Run("Missing TaskID", func(t *testing.T) {
 		tm, _, _, _ := setupTest(t)
-		handler := NewHTTPHandler(tm)
+		handler := NewHTTPHandler(tm, &config.AuthConfig{TraderGroup: "Trader", CHAGroup: "CHA"})
 		req := httptest.NewRequest(http.MethodGet, "/tasks/", nil)
+
+		userID := "trader-1"
+		ctx := context.WithValue(req.Context(), auth.AuthContextKey, &auth.AuthContext{
+			UserID: &userID, Groups: []string{"Trader"}, IsM2M: false,
+		})
+		req = req.WithContext(ctx)
+
 		// No path value set
 		w := httptest.NewRecorder()
-
 		handler.HandleGetTask(w, req)
-
 		resp := w.Result()
 		assert.Equal(t, http.StatusBadRequest, resp.StatusCode)
 	})
 
 	t.Run("Invalid TaskID string", func(t *testing.T) {
 		tm, _, mockStore, _ := setupTest(t)
-		handler := NewHTTPHandler(tm)
+		handler := NewHTTPHandler(tm, &config.AuthConfig{TraderGroup: "Trader", CHAGroup: "CHA"})
 		req := httptest.NewRequest(http.MethodGet, "/tasks/invalid", nil)
 		req.SetPathValue("id", "invalid")
+
+		userID := "trader-1"
+		ctx := context.WithValue(req.Context(), auth.AuthContextKey, &auth.AuthContext{
+			UserID: &userID, Groups: []string{"Trader"}, IsM2M: false,
+		})
+		req = req.WithContext(ctx)
+
 		w := httptest.NewRecorder()
 
 		mockStore.On("GetByID", "invalid").Return(nil, errors.New("not found")).Once()
@@ -64,4 +93,42 @@ func TestHTTPHandler_HandleGetTask(t *testing.T) {
 		resp := w.Result()
 		assert.Equal(t, http.StatusNotFound, resp.StatusCode)
 	})
+}
+func withM2MContext(ctx context.Context, clientID string) context.Context {
+	authCtx := &auth.AuthContext{
+		ClientID: clientID,
+		IsM2M:    true,
+	}
+	return context.WithValue(ctx, auth.AuthContextKey, authCtx)
+}
+
+func TestHTTPHandler_M2M_Bypass(t *testing.T) {
+	tm, mockFactory, mockStore, mockPlugin := setupTest(t)
+	handler := NewHTTPHandler(tm, &config.AuthConfig{TraderGroup: "Trader", CHAGroup: "CHA"})
+
+	taskID := "task-1"
+	req := httptest.NewRequest(http.MethodGet, "/tasks/"+taskID, nil)
+	req.SetPathValue("id", taskID)
+	req = req.WithContext(withM2MContext(req.Context(), "internal-client"))
+
+	// Mock necessary for getTask to succeed past RBAC
+	taskInfo := &persistence.TaskInfo{
+		ID:    taskID,
+		Type:  plugin.TaskTypeSimpleForm,
+		State: plugin.InProgress,
+	}
+	mockStore.On("GetByID", taskID).Return(taskInfo, nil).Once()
+	mockFactory.On("BuildExecutor", mock.Anything, taskInfo.Type, mock.Anything).Return(plugin.Executor{Plugin: mockPlugin}, nil).Once()
+	mockStore.On("GetLocalState", taskID).Return(json.RawMessage(`{}`), nil).Once()
+	mockStore.On("GetPluginState", taskID).Return("", nil).Once()
+	mockPlugin.On("Init", mock.Anything).Return().Once()
+
+	// Mock RenderInfo
+	mockPlugin.On("GetRenderInfo", mock.Anything).Return(&plugin.ApiResponse{Success: true}, nil).Once()
+
+	w := httptest.NewRecorder()
+	handler.HandleGetTask(w, req)
+
+	// Should be 200 OK because RBAC was bypassed and logic succeeded
+	assert.Equal(t, http.StatusOK, w.Code)
 }

--- a/backend/internal/task/manager/http_handler_test.go
+++ b/backend/internal/task/manager/http_handler_test.go
@@ -132,3 +132,71 @@ func TestHTTPHandler_M2M_Bypass(t *testing.T) {
 	// Should be 200 OK because RBAC was bypassed and logic succeeded
 	assert.Equal(t, http.StatusOK, w.Code)
 }
+func TestHTTPHandler_HandleExecuteTask_RBAC(t *testing.T) {
+	t.Run("Trader Forbidden", func(t *testing.T) {
+		tm, _, _, _ := setupTest(t)
+		handler := NewHTTPHandler(tm, &config.AuthConfig{TraderGroup: "Trader", CHAGroup: "CHA"})
+		
+		req := httptest.NewRequest(http.MethodPost, "/execute", bytes.NewBufferString(`{"task_id":"t1"}`))
+		userID := "trader-1"
+		ctx := context.WithValue(req.Context(), auth.AuthContextKey, &auth.AuthContext{
+			UserID: &userID, Groups: []string{"Trader"}, IsM2M: false,
+		})
+		req = req.WithContext(ctx)
+
+		w := httptest.NewRecorder()
+		handler.HandleExecuteTask(w, req)
+		assert.Equal(t, http.StatusForbidden, w.Code)
+	})
+
+	t.Run("CHA Allowed", func(t *testing.T) {
+		tm, mockFactory, mockStore, mockPlugin := setupTest(t)
+		handler := NewHTTPHandler(tm, &config.AuthConfig{TraderGroup: "Trader", CHAGroup: "CHA"})
+		
+		taskID := "task-1"
+		req := httptest.NewRequest(http.MethodPost, "/execute", bytes.NewBufferString(`{"task_id":"`+taskID+`"}`))
+		userID := "cha-1"
+		ctx := context.WithValue(req.Context(), auth.AuthContextKey, &auth.AuthContext{
+			UserID: &userID, Groups: []string{"CHA"}, IsM2M: false,
+		})
+		req = req.WithContext(ctx)
+
+		// Mock expectations for successful execution
+		taskInfo := &persistence.TaskInfo{ID: taskID, Type: plugin.TaskTypeSimpleForm}
+		mockStore.On("GetByID", taskID).Return(taskInfo, nil).Once()
+		mockStore.On("CheckOwnership", taskID, userID).Return(true, nil).Once()
+		mockFactory.On("BuildExecutor", mock.Anything, taskInfo.Type, mock.Anything).Return(plugin.Executor{Plugin: mockPlugin}, nil).Once()
+		mockStore.On("GetLocalState", taskID).Return(json.RawMessage(`{}`), nil).Once()
+		mockStore.On("GetPluginState", taskID).Return("", nil).Once()
+		mockPlugin.On("Init", mock.Anything).Return().Once()
+		
+		newState := plugin.Completed
+		mockPlugin.On("Execute", mock.Anything, mock.Anything).Return(&plugin.ExecutionResponse{
+			NewState: &newState, ApiResponse: &plugin.ApiResponse{Success: true},
+		}, nil).Once()
+		mockStore.On("UpdateStatus", taskID, &newState).Return(nil).Once()
+
+		w := httptest.NewRecorder()
+		handler.HandleExecuteTask(w, req)
+		assert.Equal(t, http.StatusOK, w.Code)
+	})
+}
+
+func TestHTTPHandler_HandleGetTask_RBAC(t *testing.T) {
+	t.Run("Other Group Forbidden", func(t *testing.T) {
+		tm, _, _, _ := setupTest(t)
+		handler := NewHTTPHandler(tm, &config.AuthConfig{TraderGroup: "Trader", CHAGroup: "CHA"})
+		
+		req := httptest.NewRequest(http.MethodGet, "/tasks/t1", nil)
+		req.SetPathValue("id", "t1")
+		userID := "other-1"
+		ctx := context.WithValue(req.Context(), auth.AuthContextKey, &auth.AuthContext{
+			UserID: &userID, Groups: []string{"OTHER"}, IsM2M: false,
+		})
+		req = req.WithContext(ctx)
+
+		w := httptest.NewRecorder()
+		handler.HandleGetTask(w, req)
+		assert.Equal(t, http.StatusForbidden, w.Code)
+	})
+}

--- a/backend/internal/task/manager/manager.go
+++ b/backend/internal/task/manager/manager.go
@@ -60,7 +60,7 @@ type TaskManager interface {
 
 	// Core Domain Methods
 	ExecuteTask(ctx context.Context, req ExecuteTaskRequest) (*plugin.ExecutionResponse, error)
-	GetTaskRenderInfo(ctx context.Context, taskID string) (*plugin.ApiResponse, error)
+	GetTaskRenderInfo(ctx context.Context, taskID string, requestorID string, isSystem bool) (*plugin.ApiResponse, error)
 
 	// Used by Old WorkflowManager
 	// RegisterUpstreamCallback registers the callback used for task updates.
@@ -78,9 +78,11 @@ type TaskManager interface {
 
 // ExecuteTaskRequest represents the request body for task execution
 type ExecuteTaskRequest struct {
-	WorkflowID string                   `json:"workflow_id"`
-	TaskID     string                   `json:"task_id"`
-	Payload    *plugin.ExecutionRequest `json:"payload,omitempty"`
+	WorkflowID  string                   `json:"workflow_id"`
+	TaskID      string                   `json:"task_id"`
+	Payload     *plugin.ExecutionRequest `json:"payload,omitempty"`
+	RequestorID string                   `json:"-"`
+	IsSystem    bool                     `json:"-"`
 }
 
 type taskManager struct {
@@ -130,9 +132,19 @@ func (tm *taskManager) RegisterUpstreamDoneCallback(callback WorkflowDoneHandler
 }
 
 // GetTaskRenderInfo retrieves task rendering info (core logic)
-func (tm *taskManager) GetTaskRenderInfo(ctx context.Context, taskID string) (*plugin.ApiResponse, error) {
+func (tm *taskManager) GetTaskRenderInfo(ctx context.Context, taskID string, requestorID string, isSystem bool) (*plugin.ApiResponse, error) {
 	if taskID == "" {
 		return nil, fmt.Errorf("taskID is required")
+	}
+
+	if !isSystem {
+		hasAccess, err := tm.store.CheckOwnership(taskID, requestorID)
+		if err != nil {
+			return nil, fmt.Errorf("error checking ownership: %w", err)
+		}
+		if !hasAccess {
+			return nil, fmt.Errorf("task %s not found", taskID) // 404 to avoid leaking existence
+		}
 	}
 
 	activeTask, err := tm.getTask(ctx, taskID)
@@ -165,6 +177,16 @@ func (tm *taskManager) GetTaskWorkflowID(ctx context.Context, taskID string) (st
 func (tm *taskManager) ExecuteTask(ctx context.Context, req ExecuteTaskRequest) (*plugin.ExecutionResponse, error) {
 	if req.TaskID == "" {
 		return nil, fmt.Errorf("task_id is required")
+	}
+
+	if !req.IsSystem {
+		hasAccess, err := tm.store.CheckOwnership(req.TaskID, req.RequestorID)
+		if err != nil {
+			return nil, fmt.Errorf("error checking ownership: %w", err)
+		}
+		if !hasAccess {
+			return nil, fmt.Errorf("task %s not found", req.TaskID)
+		}
 	}
 
 	activeTask, err := tm.getTask(ctx, req.TaskID)

--- a/backend/internal/task/manager/manager.go
+++ b/backend/internal/task/manager/manager.go
@@ -71,6 +71,9 @@ type TaskManager interface {
 	RegisterUpstreamDoneCallback(callback WorkflowDoneHandler)
 	// RegisterUpstreamUpdateCallback registers the callback used when task state changes.
 	RegisterUpstreamUpdateCallback(callback WorkflowUpdateHandler)
+
+	// GetTaskWorkflowID retrieves the workflow ID (consignment ID) associated with a task
+	GetTaskWorkflowID(ctx context.Context, taskID string) (string, error)
 }
 
 // ExecuteTaskRequest represents the request body for task execution
@@ -143,6 +146,19 @@ func (tm *taskManager) GetTaskRenderInfo(ctx context.Context, taskID string) (*p
 	}
 
 	return result, nil
+}
+
+func (tm *taskManager) GetTaskWorkflowID(ctx context.Context, taskID string) (string, error) {
+	if taskID == "" {
+		return "", fmt.Errorf("taskID is required")
+	}
+
+	execution, err := tm.store.GetByID(taskID)
+	if err != nil {
+		return "", err
+	}
+
+	return execution.WorkflowID, nil
 }
 
 // ExecuteTask is the core logic for executing a task

--- a/backend/internal/task/manager/manager_test.go
+++ b/backend/internal/task/manager/manager_test.go
@@ -49,6 +49,10 @@ func (m *MockTaskStore) GetByID(id string) (*persistence.TaskInfo, error) {
 	return args.Get(0).(*persistence.TaskInfo), args.Error(1)
 }
 
+func (m *MockTaskStore) CheckOwnership(id string, requestorID string) (bool, error) {
+	return true, nil // Always true for tests unless explicitly tested
+}
+
 func (m *MockTaskStore) UpdateStatus(id string, status *plugin.State) error {
 	args := m.Called(id, status)
 	return args.Error(0)

--- a/backend/internal/task/persistence/store.go
+++ b/backend/internal/task/persistence/store.go
@@ -38,6 +38,7 @@ type TaskStore struct {
 type TaskStoreInterface interface {
 	Create(*TaskInfo) error
 	GetByID(string) (*TaskInfo, error)
+	CheckOwnership(string, string) (bool, error)
 	UpdateStatus(string, *plugin.State) error
 	Update(*TaskInfo) error
 	Delete(string) error
@@ -70,6 +71,21 @@ func (s *TaskStore) GetByID(id string) (*TaskInfo, error) {
 		return nil, err
 	}
 	return &taskRecord, nil
+}
+
+// CheckOwnership verifies if a task belongs to a consignment owned by the requestor
+func (s *TaskStore) CheckOwnership(id string, requestorID string) (bool, error) {
+	var count int64
+	err := s.db.Table("task_infos").
+		Joins("JOIN consignments ON task_infos.workflow_id = consignments.id").
+		Where("task_infos.id = ?", id).
+		Where("(consignments.trader_id = ? OR consignments.cha_id = ?)", requestorID, requestorID).
+		Count(&count).Error
+
+	if err != nil {
+		return false, err
+	}
+	return count > 0, nil
 }
 
 // UpdateStatus updates the status of a task execution

--- a/backend/internal/uploads/http_handler.go
+++ b/backend/internal/uploads/http_handler.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"github.com/OpenNSW/nsw/internal/auth"
+	"github.com/OpenNSW/nsw/internal/config"
 	"github.com/OpenNSW/nsw/internal/uploads/drivers"
 )
 
@@ -36,10 +37,11 @@ func isAllowedContentType(ct string) bool {
 
 type HTTPHandler struct {
 	Service *UploadService
+	Config  *config.AuthConfig
 }
 
-func NewHTTPHandler(service *UploadService) *HTTPHandler {
-	return &HTTPHandler{Service: service}
+func NewHTTPHandler(service *UploadService, cfg *config.AuthConfig) *HTTPHandler {
+	return &HTTPHandler{Service: service, Config: cfg}
 }
 
 // writeJSONError sets Content-Type: application/json and writes a consistent JSON error body.
@@ -50,11 +52,22 @@ func writeJSONError(w http.ResponseWriter, status int, message string) {
 }
 
 func (h *HTTPHandler) Upload(w http.ResponseWriter, r *http.Request) {
-	if auth.GetAuthContext(r.Context()) == nil {
+	authCtx, ok := auth.FromContext(r.Context())
+	if !ok {
 		slog.WarnContext(r.Context(), "authentication required but not provided for upload")
 		writeJSONError(w, http.StatusUnauthorized, "Unauthorized")
 		return
 	}
+
+	if !authCtx.IsM2M {
+		// Traders and CHAs can upload
+		if !authCtx.HasGroup(h.Config.TraderGroup) && !authCtx.HasGroup(h.Config.CHAGroup) {
+			writeJSONError(w, http.StatusForbidden, "Forbidden: Insufficient privileges")
+			return
+		}
+	}
+	// TODO (else): Implement granular M2M permission check (e.g. RequiredScope("uploads:write"))
+
 	r.Body = http.MaxBytesReader(w, r.Body, 32<<20)
 
 	if err := r.ParseMultipartForm(32 << 20); err != nil {
@@ -106,12 +119,21 @@ func (h *HTTPHandler) Upload(w http.ResponseWriter, r *http.Request) {
 }
 
 func (h *HTTPHandler) Download(w http.ResponseWriter, r *http.Request) {
-	// TODO: Uncomment when M2M AUTH Implemented.
-	//if auth.GetAuthContext(r.Context()) == nil {
-	//	slog.WarnContext(r.Context(), "authentication required but not provided for download")
-	//	writeJSONError(w, http.StatusUnauthorized, "Unauthorized")
-	//	return
-	//}
+	authCtx, ok := auth.FromContext(r.Context())
+	if !ok {
+		slog.WarnContext(r.Context(), "authentication required but not provided for download")
+		writeJSONError(w, http.StatusUnauthorized, "Unauthorized")
+		return
+	}
+
+	if !authCtx.IsM2M {
+		// Traders and CHAs can download
+		if !authCtx.HasGroup(h.Config.TraderGroup) && !authCtx.HasGroup(h.Config.CHAGroup) {
+			writeJSONError(w, http.StatusForbidden, "Forbidden: Insufficient privileges")
+			return
+		}
+	}
+	// TODO (else): Implement granular M2M permission check (e.g. RequiredScope("uploads:read"))
 
 	key := r.PathValue("key")
 	if key == "" {
@@ -189,10 +211,19 @@ func (h *HTTPHandler) DownloadContent(w http.ResponseWriter, r *http.Request) {
 }
 
 func (h *HTTPHandler) Delete(w http.ResponseWriter, r *http.Request) {
-	if auth.GetAuthContext(r.Context()) == nil {
+	authCtx, ok := auth.FromContext(r.Context())
+	if !ok {
 		slog.WarnContext(r.Context(), "authentication required but not provided for delete")
 		writeJSONError(w, http.StatusUnauthorized, "Unauthorized")
 		return
+	}
+
+	if !authCtx.IsM2M {
+		// For Phase 1, we allow both roles to attempt delete (business logic handles ownership if needed).
+		if !authCtx.HasGroup(h.Config.TraderGroup) && !authCtx.HasGroup(h.Config.CHAGroup) {
+			writeJSONError(w, http.StatusForbidden, "Forbidden: Insufficient privileges")
+			return
+		}
 	}
 	key := r.PathValue("key")
 	if key == "" {

--- a/backend/internal/uploads/http_handler_test.go
+++ b/backend/internal/uploads/http_handler_test.go
@@ -11,6 +11,7 @@ import (
 	"testing"
 
 	"github.com/OpenNSW/nsw/internal/auth"
+	"github.com/OpenNSW/nsw/internal/config"
 	"github.com/OpenNSW/nsw/internal/uploads/drivers"
 )
 
@@ -20,7 +21,7 @@ func TestDownloadContent_LocalDriver_Success(t *testing.T) {
 	tempDir := t.TempDir()
 	driver, _ := drivers.NewLocalFSDriver(tempDir, "/api/v1/uploads")
 	service := NewUploadService(driver)
-	handler := NewHTTPHandler(service)
+	handler := NewHTTPHandler(service, &config.AuthConfig{TraderGroup: "Trader", CHAGroup: "CHA"})
 
 	ctx := context.Background()
 	key := "550e8400-e29b-41d4-a716-446655440000.pdf"
@@ -55,12 +56,13 @@ func withAuthContext(ctx context.Context, ac *auth.AuthContext) context.Context 
 }
 
 func TestDownload_MissingKey(t *testing.T) {
-	handler := NewHTTPHandler(NewUploadService(&MockDriver{}))
+	handler := NewHTTPHandler(NewUploadService(&MockDriver{}), &config.AuthConfig{TraderGroup: "Trader", CHAGroup: "CHA"})
 
 	req := httptest.NewRequest(http.MethodGet, "/files/", nil)
 	// Auth present, but no path value for "key".
+	userID := "trader-1"
 	ctx := withAuthContext(req.Context(), &auth.AuthContext{
-		UserID: "trader-1", UserContext: &auth.UserContext{UserID: "trader-1"},
+		UserID: &userID, Groups: []string{"Trader"}, UserContext: &auth.UserContext{UserID: "trader-1"},
 	})
 	req = req.WithContext(ctx)
 	rec := httptest.NewRecorder()
@@ -74,15 +76,16 @@ func TestDownload_MissingKey(t *testing.T) {
 
 func TestDownload_Success(t *testing.T) {
 	mock := &MockDriver{}
-	handler := NewHTTPHandler(NewUploadService(mock))
+	handler := NewHTTPHandler(NewUploadService(mock), &config.AuthConfig{TraderGroup: "Trader", CHAGroup: "CHA"})
 
 	// Build request with auth context and path value.
 	mux := http.NewServeMux()
 	mux.HandleFunc("GET /files/{key}", handler.Download)
 
 	req := httptest.NewRequest(http.MethodGet, "/files/550e8400-e29b-41d4-a716-446655440000.pdf", nil)
+	userID := "trader-1"
 	ctx := withAuthContext(req.Context(), &auth.AuthContext{
-		UserID: "trader-1", UserContext: &auth.UserContext{UserID: "trader-1"},
+		UserID: &userID, Groups: []string{"Trader"}, UserContext: &auth.UserContext{UserID: "trader-1"},
 	})
 	req = req.WithContext(ctx)
 	rec := httptest.NewRecorder()
@@ -115,14 +118,15 @@ func TestDownload_GenerateURLError(t *testing.T) {
 	mock := &MockDriver{
 		GenerateURLErr: errors.New("presign failure"),
 	}
-	handler := NewHTTPHandler(NewUploadService(mock))
+	handler := NewHTTPHandler(NewUploadService(mock), &config.AuthConfig{TraderGroup: "Trader", CHAGroup: "CHA"})
 
 	mux := http.NewServeMux()
 	mux.HandleFunc("GET /files/{key}", handler.Download)
 
 	req := httptest.NewRequest(http.MethodGet, "/files/550e8400-e29b-41d4-a716-446655440000", nil)
+	userID := "trader-1"
 	ctx := withAuthContext(req.Context(), &auth.AuthContext{
-		UserID: "trader-1", UserContext: &auth.UserContext{UserID: "trader-1"},
+		UserID: &userID, Groups: []string{"Trader"}, UserContext: &auth.UserContext{UserID: "trader-1"},
 	})
 	req = req.WithContext(ctx)
 	rec := httptest.NewRecorder()
@@ -140,15 +144,16 @@ func TestDownload_GenerateURLError(t *testing.T) {
 }
 
 func TestDownload_InvalidKeyFormat(t *testing.T) {
-	handler := NewHTTPHandler(NewUploadService(&MockDriver{}))
+	handler := NewHTTPHandler(NewUploadService(&MockDriver{}), &config.AuthConfig{TraderGroup: "Trader", CHAGroup: "CHA"})
 
 	mux := http.NewServeMux()
 	mux.HandleFunc("GET /files/{key}", handler.Download)
 
 	// Key that is not UUID or UUID.ext (validStorageKey rejects it)
 	req := httptest.NewRequest(http.MethodGet, "/files/invalid-key-format", nil)
+	userID := "trader-1"
 	ctx := withAuthContext(req.Context(), &auth.AuthContext{
-		UserID: "trader-1", UserContext: &auth.UserContext{UserID: "trader-1"},
+		UserID: &userID, Groups: []string{"Trader"}, UserContext: &auth.UserContext{UserID: "trader-1"},
 	})
 	req = req.WithContext(ctx)
 	rec := httptest.NewRecorder()
@@ -161,7 +166,7 @@ func TestDownload_InvalidKeyFormat(t *testing.T) {
 }
 
 func TestUpload_Unauthorized(t *testing.T) {
-	handler := NewHTTPHandler(NewUploadService(&MockDriver{}))
+	handler := NewHTTPHandler(NewUploadService(&MockDriver{}), &config.AuthConfig{TraderGroup: "Trader", CHAGroup: "CHA"})
 
 	var buf bytes.Buffer
 	w := multipart.NewWriter(&buf)
@@ -195,7 +200,7 @@ func TestUpload_Unauthorized(t *testing.T) {
 }
 
 func TestDelete_Unauthorized(t *testing.T) {
-	handler := NewHTTPHandler(NewUploadService(&MockDriver{}))
+	handler := NewHTTPHandler(NewUploadService(&MockDriver{}), &config.AuthConfig{TraderGroup: "Trader", CHAGroup: "CHA"})
 
 	req := httptest.NewRequest(http.MethodDelete, "/uploads/550e8400-e29b-41d4-a716-446655440000.pdf", nil)
 	req.SetPathValue("key", "550e8400-e29b-41d4-a716-446655440000.pdf")
@@ -210,7 +215,7 @@ func TestDelete_Unauthorized(t *testing.T) {
 
 func TestDownloadContent_NonLocalDriver_NotFound(t *testing.T) {
 	// For non-local drivers, DownloadContent should be disabled and return 404
-	handler := NewHTTPHandler(NewUploadService(&MockDriver{}))
+	handler := NewHTTPHandler(NewUploadService(&MockDriver{}), &config.AuthConfig{TraderGroup: "Trader", CHAGroup: "CHA"})
 
 	req := httptest.NewRequest(http.MethodGet, "/uploads/550e8400-e29b-41d4-a716-446655440000.pdf/content", nil)
 	req.SetPathValue("key", "550e8400-e29b-41d4-a716-446655440000.pdf")

--- a/backend/internal/workflow/router/consignment_router.go
+++ b/backend/internal/workflow/router/consignment_router.go
@@ -78,12 +78,8 @@ func (c *ConsignmentRouter) HandleGetConsignments(w http.ResponseWriter, r *http
 	}
 
 	// RBAC: Authorize the requested role against the token's groups
-	isAuthorized := false
-	if role == auth.RoleQueryTrader && authCtx.HasGroup(c.cfg.TraderGroup) {
-		isAuthorized = true
-	} else if role == auth.RoleQueryCHA && authCtx.HasGroup(c.cfg.CHAGroup) {
-		isAuthorized = true
-	}
+	isAuthorized := (role == auth.RoleQueryTrader && authCtx.HasGroup(c.cfg.TraderGroup)) ||
+		(role == auth.RoleQueryCHA && authCtx.HasGroup(c.cfg.CHAGroup))
 
 	if !isAuthorized {
 		http.Error(w, "Forbidden: Insufficient privileges for requested role", http.StatusForbidden)
@@ -243,10 +239,7 @@ func (c *ConsignmentRouter) HandleGetConsignmentByID(w http.ResponseWriter, r *h
 	}
 
 	// Ownership verification: ensure the user is either the Trader owner or the assigned CHA
-	isAuthorized := false
-	if authCtx.HasGroup(c.cfg.TraderGroup) && consignment.TraderID == *authCtx.UserID {
-		isAuthorized = true
-	}
+	isAuthorized := authCtx.HasGroup(c.cfg.TraderGroup) && consignment.TraderID == *authCtx.UserID
 	if !isAuthorized && authCtx.HasGroup(c.cfg.CHAGroup) {
 		userCHA, err := c.cha.GetCHAByEmail(r.Context(), authCtx.Email)
 		if err == nil && consignment.ChaID == userCHA.ID {

--- a/backend/internal/workflow/router/consignment_router.go
+++ b/backend/internal/workflow/router/consignment_router.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 
 	"github.com/OpenNSW/nsw/internal/auth"
+	"github.com/OpenNSW/nsw/internal/config"
 	"github.com/OpenNSW/nsw/internal/workflow/model"
 	"github.com/OpenNSW/nsw/internal/workflow/service"
 	"github.com/OpenNSW/nsw/utils"
@@ -14,10 +15,11 @@ import (
 type ConsignmentRouter struct {
 	cs  *service.ConsignmentService
 	cha *service.CHAService
+	cfg *config.AuthConfig
 }
 
-func NewConsignmentRouter(cs *service.ConsignmentService, cha *service.CHAService) *ConsignmentRouter {
-	return &ConsignmentRouter{cs: cs, cha: cha}
+func NewConsignmentRouter(cs *service.ConsignmentService, cha *service.CHAService, cfg *config.AuthConfig) *ConsignmentRouter {
+	return &ConsignmentRouter{cs: cs, cha: cha, cfg: cfg}
 }
 
 // HandleCreateConsignment handles POST /api/v1/consignments
@@ -25,8 +27,14 @@ func NewConsignmentRouter(cs *service.ConsignmentService, cha *service.CHAServic
 // Legacy: body { flow, items } → creates and initializes workflow
 func (c *ConsignmentRouter) HandleCreateConsignment(w http.ResponseWriter, r *http.Request) {
 	authCtx := auth.GetAuthContext(r.Context())
-	if authCtx == nil {
-		http.Error(w, "Unauthorized", http.StatusUnauthorized)
+	if authCtx == nil || authCtx.IsM2M || authCtx.UserID == nil {
+		http.Error(w, "Unauthorized: Human context required", http.StatusUnauthorized)
+		return
+	}
+
+	// RBAC: Only Traders can create consignments
+	if c.cfg != nil && !authCtx.HasGroup(c.cfg.TraderGroup) {
+		http.Error(w, "Forbidden: Only Traders can create consignments", http.StatusForbidden)
 		return
 	}
 
@@ -36,7 +44,7 @@ func (c *ConsignmentRouter) HandleCreateConsignment(w http.ResponseWriter, r *ht
 		return
 	}
 
-	traderID := authCtx.UserID
+	traderID := *authCtx.UserID
 	// Stage 1: create shell only
 	consignment, err := c.cs.CreateConsignmentShell(r.Context(), req.Flow, req.ChaID, traderID)
 	if err != nil {
@@ -58,15 +66,33 @@ func (c *ConsignmentRouter) HandleCreateConsignment(w http.ResponseWriter, r *ht
 func (c *ConsignmentRouter) HandleGetConsignments(w http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
 	authCtx := auth.GetAuthContext(ctx)
-	if authCtx == nil {
-		http.Error(w, "Unauthorized", http.StatusUnauthorized)
+	if authCtx == nil || authCtx.IsM2M || authCtx.UserID == nil {
+		http.Error(w, "Unauthorized: Human context required", http.StatusUnauthorized)
 		return
 	}
 
-	// TODO: Proper AuthZ need to be implemented.
+
 	role := r.URL.Query().Get("role")
 	if role == "" {
 		role = "trader"
+	}
+
+	// RBAC: Authorize the requested role against the token's groups
+	isAuthorized := false
+	if c.cfg != nil {
+		if role == "trader" && authCtx.HasGroup(c.cfg.TraderGroup) {
+			isAuthorized = true
+		} else if role == "cha" && authCtx.HasGroup(c.cfg.CHAGroup) {
+			isAuthorized = true
+		}
+	} else {
+		// If config is missing, default to lenient for now (or strict if preferred)
+		isAuthorized = true
+	}
+
+	if !isAuthorized {
+		http.Error(w, "Forbidden: Insufficient privileges for requested role", http.StatusForbidden)
+		return
 	}
 	offset, limit, err := utils.ParsePaginationParams(r)
 	if err != nil {
@@ -91,14 +117,20 @@ func (c *ConsignmentRouter) HandleGetConsignments(w http.ResponseWriter, r *http
 	// Role-Based Identity Resolution
 	switch role {
 	case "cha":
-		cha, err := c.cha.GetCHAByEmail(ctx, authCtx.Email)
-		if err != nil {
-			http.Error(w, "failed to resolve default CHA profile", http.StatusForbidden)
-			return
+		// Check if UI sent a specific ID to filter by
+		if chaIDStr := r.URL.Query().Get("cha_id"); chaIDStr != "" {
+			filter.ChaID = &chaIDStr
+		} else {
+			// Fallback: Default to the user's own profile if no specific ID requested
+			cha, err := c.cha.GetCHAByEmail(ctx, authCtx.Email)
+			if err != nil {
+				http.Error(w, "failed to resolve default CHA profile", http.StatusForbidden)
+				return
+			}
+			filter.ChaID = &cha.ID
 		}
-		filter.ChaID = &cha.ID
 	case "trader":
-		filter.TraderID = &authCtx.UserID
+		filter.TraderID = authCtx.UserID
 	default:
 		http.Error(w, "query param role must be trader or cha", http.StatusBadRequest)
 		return
@@ -118,8 +150,14 @@ func (c *ConsignmentRouter) HandleGetConsignments(w http.ResponseWriter, r *http
 // Body: InitializeConsignmentDTO { hsCodeIds: []uuid }. Response: ConsignmentDetailDTO.
 func (c *ConsignmentRouter) HandleInitializeConsignment(w http.ResponseWriter, r *http.Request) {
 	authCtx := auth.GetAuthContext(r.Context())
-	if authCtx == nil {
-		http.Error(w, "Unauthorized", http.StatusUnauthorized)
+	if authCtx == nil || authCtx.IsM2M || authCtx.UserID == nil {
+		http.Error(w, "Unauthorized: Human context required", http.StatusUnauthorized)
+		return
+	}
+
+	// RBAC: Only CHAs can initialize consignments
+	if c.cfg != nil && !authCtx.HasGroup(c.cfg.CHAGroup) {
+		http.Error(w, "Forbidden: Only CHAs can initialize consignments", http.StatusForbidden)
 		return
 	}
 
@@ -129,8 +167,25 @@ func (c *ConsignmentRouter) HandleInitializeConsignment(w http.ResponseWriter, r
 		return
 	}
 	consignmentID := consignmentIDStr
-	// TODO: Need to Call GetConsignmentByID and check whether the Consignment.ChaID and authContext.UserID are equal
-	// Otherwise Forbidden
+
+	// Ownership check: Fetch consignment and verify CHA ownership
+	existing, err := c.cs.GetConsignmentByID(r.Context(), consignmentID)
+	if err != nil {
+		http.Error(w, "consignment not found", http.StatusNotFound)
+		return
+	}
+
+	// Resolve the current user's CHA profile
+	userCHA, err := c.cha.GetCHAByEmail(r.Context(), *authCtx.UserID)
+	if err != nil {
+		http.Error(w, "failed to resolve CHA profile", http.StatusForbidden)
+		return
+	}
+
+	if existing.ChaID != userCHA.ID {
+		http.Error(w, "Forbidden: You do not own this consignment", http.StatusForbidden)
+		return
+	}
 	var req model.InitializeConsignmentDTO
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
 		http.Error(w, "invalid request body: "+err.Error(), http.StatusBadRequest)

--- a/backend/internal/workflow/router/consignment_router.go
+++ b/backend/internal/workflow/router/consignment_router.go
@@ -28,12 +28,12 @@ func NewConsignmentRouter(cs *service.ConsignmentService, cha *service.CHAServic
 func (c *ConsignmentRouter) HandleCreateConsignment(w http.ResponseWriter, r *http.Request) {
 	authCtx := auth.GetAuthContext(r.Context())
 	if authCtx == nil || authCtx.IsM2M || authCtx.UserID == nil {
-		http.Error(w, "Unauthorized: Human context required", http.StatusUnauthorized)
+		http.Error(w, "Forbidden: User context required", http.StatusForbidden)
 		return
 	}
 
 	// RBAC: Only Traders can create consignments
-	if c.cfg != nil && !authCtx.HasGroup(c.cfg.TraderGroup) {
+	if c.cfg == nil || !authCtx.HasGroup(c.cfg.TraderGroup) {
 		http.Error(w, "Forbidden: Only Traders can create consignments", http.StatusForbidden)
 		return
 	}
@@ -67,27 +67,27 @@ func (c *ConsignmentRouter) HandleGetConsignments(w http.ResponseWriter, r *http
 	ctx := r.Context()
 	authCtx := auth.GetAuthContext(ctx)
 	if authCtx == nil || authCtx.IsM2M || authCtx.UserID == nil {
-		http.Error(w, "Unauthorized: Human context required", http.StatusUnauthorized)
+		http.Error(w, "Forbidden: User context required", http.StatusForbidden)
 		return
 	}
 
 
 	role := r.URL.Query().Get("role")
 	if role == "" {
-		role = "trader"
+		role = auth.RoleQueryTrader
 	}
 
 	// RBAC: Authorize the requested role against the token's groups
 	isAuthorized := false
 	if c.cfg != nil {
-		if role == "trader" && authCtx.HasGroup(c.cfg.TraderGroup) {
+		if role == auth.RoleQueryTrader && authCtx.HasGroup(c.cfg.TraderGroup) {
 			isAuthorized = true
-		} else if role == "cha" && authCtx.HasGroup(c.cfg.CHAGroup) {
+		} else if role == auth.RoleQueryCHA && authCtx.HasGroup(c.cfg.CHAGroup) {
 			isAuthorized = true
 		}
 	} else {
-		// If config is missing, default to lenient for now (or strict if preferred)
-		isAuthorized = true
+		// If config is missing
+		isAuthorized = false
 	}
 
 	if !isAuthorized {
@@ -116,7 +116,7 @@ func (c *ConsignmentRouter) HandleGetConsignments(w http.ResponseWriter, r *http
 
 	// Role-Based Identity Resolution
 	switch role {
-	case "cha":
+	case auth.RoleQueryCHA:
 		// Check if UI sent a specific ID to filter by
 		if chaIDStr := r.URL.Query().Get("cha_id"); chaIDStr != "" {
 			filter.ChaID = &chaIDStr
@@ -129,7 +129,7 @@ func (c *ConsignmentRouter) HandleGetConsignments(w http.ResponseWriter, r *http
 			}
 			filter.ChaID = &cha.ID
 		}
-	case "trader":
+	case auth.RoleQueryTrader:
 		filter.TraderID = authCtx.UserID
 	default:
 		http.Error(w, "query param role must be trader or cha", http.StatusBadRequest)
@@ -151,12 +151,12 @@ func (c *ConsignmentRouter) HandleGetConsignments(w http.ResponseWriter, r *http
 func (c *ConsignmentRouter) HandleInitializeConsignment(w http.ResponseWriter, r *http.Request) {
 	authCtx := auth.GetAuthContext(r.Context())
 	if authCtx == nil || authCtx.IsM2M || authCtx.UserID == nil {
-		http.Error(w, "Unauthorized: Human context required", http.StatusUnauthorized)
+		http.Error(w, "Forbidden: User context required", http.StatusForbidden)
 		return
 	}
 
 	// RBAC: Only CHAs can initialize consignments
-	if c.cfg != nil && !authCtx.HasGroup(c.cfg.CHAGroup) {
+	if c.cfg == nil || !authCtx.HasGroup(c.cfg.CHAGroup) {
 		http.Error(w, "Forbidden: Only CHAs can initialize consignments", http.StatusForbidden)
 		return
 	}
@@ -221,6 +221,13 @@ func (c *ConsignmentRouter) HandleInitializeConsignment(w http.ResponseWriter, r
 // Path param: id (required)
 // Response: ConsignmentDetailDTO
 func (c *ConsignmentRouter) HandleGetConsignmentByID(w http.ResponseWriter, r *http.Request) {
+	// Require authentication
+	authCtx := auth.GetAuthContext(r.Context())
+	if authCtx == nil {
+		http.Error(w, "Unauthorized", http.StatusUnauthorized)
+		return
+	}
+
 	// Extract consignment ID from path
 	consignmentIDStr := r.PathValue("id")
 	if consignmentIDStr == "" {

--- a/backend/internal/workflow/router/consignment_router.go
+++ b/backend/internal/workflow/router/consignment_router.go
@@ -28,12 +28,12 @@ func NewConsignmentRouter(cs *service.ConsignmentService, cha *service.CHAServic
 func (c *ConsignmentRouter) HandleCreateConsignment(w http.ResponseWriter, r *http.Request) {
 	authCtx := auth.GetAuthContext(r.Context())
 	if authCtx == nil || authCtx.IsM2M || authCtx.UserID == nil {
-		http.Error(w, "Forbidden: User context required", http.StatusForbidden)
+		http.Error(w, "Unauthorized: Human context required", http.StatusUnauthorized)
 		return
 	}
 
 	// RBAC: Only Traders can create consignments
-	if c.cfg == nil || !authCtx.HasGroup(c.cfg.TraderGroup) {
+	if !authCtx.HasGroup(c.cfg.TraderGroup) {
 		http.Error(w, "Forbidden: Only Traders can create consignments", http.StatusForbidden)
 		return
 	}
@@ -67,7 +67,7 @@ func (c *ConsignmentRouter) HandleGetConsignments(w http.ResponseWriter, r *http
 	ctx := r.Context()
 	authCtx := auth.GetAuthContext(ctx)
 	if authCtx == nil || authCtx.IsM2M || authCtx.UserID == nil {
-		http.Error(w, "Forbidden: User context required", http.StatusForbidden)
+		http.Error(w, "Unauthorized: Human context required", http.StatusUnauthorized)
 		return
 	}
 
@@ -79,15 +79,10 @@ func (c *ConsignmentRouter) HandleGetConsignments(w http.ResponseWriter, r *http
 
 	// RBAC: Authorize the requested role against the token's groups
 	isAuthorized := false
-	if c.cfg != nil {
-		if role == auth.RoleQueryTrader && authCtx.HasGroup(c.cfg.TraderGroup) {
-			isAuthorized = true
-		} else if role == auth.RoleQueryCHA && authCtx.HasGroup(c.cfg.CHAGroup) {
-			isAuthorized = true
-		}
-	} else {
-		// If config is missing
-		isAuthorized = false
+	if role == auth.RoleQueryTrader && authCtx.HasGroup(c.cfg.TraderGroup) {
+		isAuthorized = true
+	} else if role == auth.RoleQueryCHA && authCtx.HasGroup(c.cfg.CHAGroup) {
+		isAuthorized = true
 	}
 
 	if !isAuthorized {
@@ -117,18 +112,20 @@ func (c *ConsignmentRouter) HandleGetConsignments(w http.ResponseWriter, r *http
 	// Role-Based Identity Resolution
 	switch role {
 	case auth.RoleQueryCHA:
-		// Check if UI sent a specific ID to filter by
-		if chaIDStr := r.URL.Query().Get("cha_id"); chaIDStr != "" {
-			filter.ChaID = &chaIDStr
-		} else {
-			// Fallback: Default to the user's own profile if no specific ID requested
-			cha, err := c.cha.GetCHAByEmail(ctx, authCtx.Email)
-			if err != nil {
-				http.Error(w, "failed to resolve default CHA profile", http.StatusForbidden)
-				return
-			}
-			filter.ChaID = &cha.ID
+		// Resolve the current user's CHA profile
+		cha, err := c.cha.GetCHAByEmail(ctx, authCtx.Email)
+		if err != nil {
+			http.Error(w, "failed to resolve CHA profile", http.StatusForbidden)
+			return
 		}
+
+		// Optional: If they explicitly requested a cha_id, ensure it matches their own
+		if requestedChaID := r.URL.Query().Get("cha_id"); requestedChaID != "" && requestedChaID != cha.ID {
+			http.Error(w, "Forbidden: Cannot query consignments for another CHA", http.StatusForbidden)
+			return
+		}
+
+		filter.ChaID = &cha.ID
 	case auth.RoleQueryTrader:
 		filter.TraderID = authCtx.UserID
 	default:
@@ -151,12 +148,12 @@ func (c *ConsignmentRouter) HandleGetConsignments(w http.ResponseWriter, r *http
 func (c *ConsignmentRouter) HandleInitializeConsignment(w http.ResponseWriter, r *http.Request) {
 	authCtx := auth.GetAuthContext(r.Context())
 	if authCtx == nil || authCtx.IsM2M || authCtx.UserID == nil {
-		http.Error(w, "Forbidden: User context required", http.StatusForbidden)
+		http.Error(w, "Unauthorized: Human context required", http.StatusUnauthorized)
 		return
 	}
 
 	// RBAC: Only CHAs can initialize consignments
-	if c.cfg == nil || !authCtx.HasGroup(c.cfg.CHAGroup) {
+	if !authCtx.HasGroup(c.cfg.CHAGroup) {
 		http.Error(w, "Forbidden: Only CHAs can initialize consignments", http.StatusForbidden)
 		return
 	}
@@ -176,7 +173,7 @@ func (c *ConsignmentRouter) HandleInitializeConsignment(w http.ResponseWriter, r
 	}
 
 	// Resolve the current user's CHA profile
-	userCHA, err := c.cha.GetCHAByEmail(r.Context(), *authCtx.UserID)
+	userCHA, err := c.cha.GetCHAByEmail(r.Context(), authCtx.Email)
 	if err != nil {
 		http.Error(w, "failed to resolve CHA profile", http.StatusForbidden)
 		return
@@ -223,8 +220,8 @@ func (c *ConsignmentRouter) HandleInitializeConsignment(w http.ResponseWriter, r
 func (c *ConsignmentRouter) HandleGetConsignmentByID(w http.ResponseWriter, r *http.Request) {
 	// Require authentication
 	authCtx := auth.GetAuthContext(r.Context())
-	if authCtx == nil {
-		http.Error(w, "Unauthorized", http.StatusUnauthorized)
+	if authCtx == nil || authCtx.IsM2M || authCtx.UserID == nil {
+		http.Error(w, "Unauthorized: Human context required", http.StatusUnauthorized)
 		return
 	}
 
@@ -242,6 +239,23 @@ func (c *ConsignmentRouter) HandleGetConsignmentByID(w http.ResponseWriter, r *h
 	consignment, err := c.cs.GetConsignmentByID(r.Context(), consignmentID)
 	if err != nil {
 		http.Error(w, "failed to retrieve consignment: "+err.Error(), http.StatusInternalServerError)
+		return
+	}
+
+	// Ownership verification: ensure the user is either the Trader owner or the assigned CHA
+	isAuthorized := false
+	if authCtx.HasGroup(c.cfg.TraderGroup) && consignment.TraderID == *authCtx.UserID {
+		isAuthorized = true
+	}
+	if !isAuthorized && authCtx.HasGroup(c.cfg.CHAGroup) {
+		userCHA, err := c.cha.GetCHAByEmail(r.Context(), authCtx.Email)
+		if err == nil && consignment.ChaID == userCHA.ID {
+			isAuthorized = true
+		}
+	}
+
+	if !isAuthorized {
+		http.Error(w, "Forbidden: You do not own this consignment", http.StatusForbidden)
 		return
 	}
 

--- a/backend/internal/workflow/router/pre_consignment_router.go
+++ b/backend/internal/workflow/router/pre_consignment_router.go
@@ -30,7 +30,7 @@ func (r *PreConsignmentRouter) HandleGetTraderPreConsignments(w http.ResponseWri
 	// Require authentication
 	authCtx := auth.GetAuthContext(req.Context())
 	if authCtx == nil || authCtx.UserID == nil {
-		http.Error(w, "Unauthorized: Human context required", http.StatusUnauthorized)
+		http.Error(w, "Forbidden: User context required", http.StatusForbidden)
 		return
 	}
 
@@ -61,7 +61,7 @@ func (r *PreConsignmentRouter) HandleCreatePreConsignment(w http.ResponseWriter,
 	// Require authentication
 	authCtx := auth.GetAuthContext(req.Context())
 	if authCtx == nil || authCtx.UserID == nil {
-		http.Error(w, "Unauthorized: Human context required", http.StatusUnauthorized)
+		http.Error(w, "Forbidden: User context required", http.StatusForbidden)
 		return
 	}
 
@@ -97,8 +97,8 @@ func (r *PreConsignmentRouter) HandleCreatePreConsignment(w http.ResponseWriter,
 func (r *PreConsignmentRouter) HandleGetPreConsignmentsByTraderID(w http.ResponseWriter, req *http.Request) {
 	// Require authentication
 	authCtx := auth.GetAuthContext(req.Context())
-	if authCtx == nil {
-		http.Error(w, "Unauthorized", http.StatusUnauthorized)
+	if authCtx == nil || authCtx.UserID == nil {
+		http.Error(w, "Forbidden: User context required", http.StatusForbidden)
 		return
 	}
 

--- a/backend/internal/workflow/router/pre_consignment_router.go
+++ b/backend/internal/workflow/router/pre_consignment_router.go
@@ -30,7 +30,7 @@ func (r *PreConsignmentRouter) HandleGetTraderPreConsignments(w http.ResponseWri
 	// Require authentication
 	authCtx := auth.GetAuthContext(req.Context())
 	if authCtx == nil || authCtx.UserID == nil {
-		http.Error(w, "Forbidden: User context required", http.StatusForbidden)
+		http.Error(w, "Unauthorized: Human context required", http.StatusUnauthorized)
 		return
 	}
 
@@ -61,7 +61,7 @@ func (r *PreConsignmentRouter) HandleCreatePreConsignment(w http.ResponseWriter,
 	// Require authentication
 	authCtx := auth.GetAuthContext(req.Context())
 	if authCtx == nil || authCtx.UserID == nil {
-		http.Error(w, "Forbidden: User context required", http.StatusForbidden)
+		http.Error(w, "Unauthorized: Human context required", http.StatusUnauthorized)
 		return
 	}
 
@@ -98,7 +98,7 @@ func (r *PreConsignmentRouter) HandleGetPreConsignmentsByTraderID(w http.Respons
 	// Require authentication
 	authCtx := auth.GetAuthContext(req.Context())
 	if authCtx == nil || authCtx.UserID == nil {
-		http.Error(w, "Forbidden: User context required", http.StatusForbidden)
+		http.Error(w, "Unauthorized: Human context required", http.StatusUnauthorized)
 		return
 	}
 

--- a/backend/internal/workflow/router/pre_consignment_router.go
+++ b/backend/internal/workflow/router/pre_consignment_router.go
@@ -29,12 +29,12 @@ func NewPreConsignmentRouter(pcs *service.PreConsignmentService) *PreConsignment
 func (r *PreConsignmentRouter) HandleGetTraderPreConsignments(w http.ResponseWriter, req *http.Request) {
 	// Require authentication
 	authCtx := auth.GetAuthContext(req.Context())
-	if authCtx == nil {
-		http.Error(w, "Unauthorized", http.StatusUnauthorized)
+	if authCtx == nil || authCtx.UserID == nil {
+		http.Error(w, "Unauthorized: Human context required", http.StatusUnauthorized)
 		return
 	}
 
-	traderID := authCtx.UserID
+	traderID := *authCtx.UserID
 
 	offset, limit, err := utils.ParsePaginationParams(req)
 	if err != nil {
@@ -60,8 +60,8 @@ func (r *PreConsignmentRouter) HandleGetTraderPreConsignments(w http.ResponseWri
 func (r *PreConsignmentRouter) HandleCreatePreConsignment(w http.ResponseWriter, req *http.Request) {
 	// Require authentication
 	authCtx := auth.GetAuthContext(req.Context())
-	if authCtx == nil {
-		http.Error(w, "Unauthorized", http.StatusUnauthorized)
+	if authCtx == nil || authCtx.UserID == nil {
+		http.Error(w, "Unauthorized: Human context required", http.StatusUnauthorized)
 		return
 	}
 
@@ -71,7 +71,7 @@ func (r *PreConsignmentRouter) HandleCreatePreConsignment(w http.ResponseWriter,
 		return
 	}
 
-	traderId := authCtx.UserID
+	traderId := *authCtx.UserID
 	traderContext, err := authCtx.GetUserContextMap()
 	if err != nil {
 		http.Error(w, "failed to parse trader context", http.StatusInternalServerError)
@@ -102,7 +102,7 @@ func (r *PreConsignmentRouter) HandleGetPreConsignmentsByTraderID(w http.Respons
 		return
 	}
 
-	traderID := authCtx.UserID
+	traderID := *authCtx.UserID
 
 	preConsignments, err := r.pcs.GetPreConsignmentsByTraderID(req.Context(), traderID)
 	if err != nil {

--- a/backend/internal/workflow/router/router_test.go
+++ b/backend/internal/workflow/router/router_test.go
@@ -19,6 +19,7 @@ import (
 	"gorm.io/gorm/logger"
 
 	"github.com/OpenNSW/nsw/internal/auth"
+	"github.com/OpenNSW/nsw/internal/config"
 	taskManager "github.com/OpenNSW/nsw/internal/task/manager"
 	workflowManagerV1 "github.com/OpenNSW/nsw/internal/workflow/manager"
 	"github.com/OpenNSW/nsw/internal/workflow/model"
@@ -149,13 +150,22 @@ func setupRouterTestDB(t *testing.T) (*gorm.DB, sqlmock.Sqlmock) {
 	return db, sqlMock
 }
 
-func withAuthContext(ctx context.Context, userID string) context.Context {
+func withAuthContext(ctx context.Context, userID string, groups ...string) context.Context {
 	authCtx := &auth.AuthContext{
-		UserID: userID,
+		UserID: &userID,
+		Groups: groups,
 		UserContext: &auth.UserContext{
 			UserID:      userID,
 			UserContext: json.RawMessage(`{}`),
 		},
+	}
+	return context.WithValue(ctx, auth.AuthContextKey, authCtx)
+}
+
+func withM2MContext(ctx context.Context, clientID string) context.Context {
+	authCtx := &auth.AuthContext{
+		ClientID: clientID,
+		IsM2M:    true,
 	}
 	return context.WithValue(ctx, auth.AuthContextKey, authCtx)
 }
@@ -166,7 +176,7 @@ func TestConsignmentRouter_HandleGetConsignmentByID(t *testing.T) {
 	// TODO: Add tests for workflow manager v2
 	// MockWMV2 := new(MockWMV2)
 	svc := service.NewConsignmentService(db, nil, mockWM, nil)
-	r := NewConsignmentRouter(svc, nil)
+	r := NewConsignmentRouter(svc, nil, &config.AuthConfig{TraderGroup: "Trader", CHAGroup: "CHA"})
 
 	consignmentID := uuid.NewString()
 	sqlMock.MatchExpectationsInOrder(false)
@@ -182,6 +192,7 @@ func TestConsignmentRouter_HandleGetConsignmentByID(t *testing.T) {
 
 	req, _ := http.NewRequest("GET", "/api/v1/consignments/"+consignmentID, nil)
 	req.SetPathValue("id", consignmentID)
+	req = req.WithContext(withAuthContext(req.Context(), "trader1", "Trader"))
 
 	w := httptest.NewRecorder()
 	r.HandleGetConsignmentByID(w, req)
@@ -191,7 +202,7 @@ func TestConsignmentRouter_HandleGetConsignmentByID(t *testing.T) {
 func TestConsignmentRouter_HandleGetConsignments(t *testing.T) {
 	db, sqlMock := setupRouterTestDB(t)
 	svc := service.NewConsignmentService(db, nil, nil, nil)
-	r := NewConsignmentRouter(svc, nil)
+	r := NewConsignmentRouter(svc, nil, &config.AuthConfig{TraderGroup: "Trader", CHAGroup: "CHA"})
 
 	traderID := "trader1"
 	sqlMock.MatchExpectationsInOrder(false)
@@ -201,7 +212,7 @@ func TestConsignmentRouter_HandleGetConsignments(t *testing.T) {
 	sqlMock.ExpectQuery("(?i)SELECT .* FROM \"workflows\"").WillReturnRows(sqlmock.NewRows([]string{"id", "end_node_id"}))
 
 	req, _ := http.NewRequest("GET", "/api/v1/consignments?role=trader", nil)
-	req = req.WithContext(withAuthContext(req.Context(), traderID))
+	req = req.WithContext(withAuthContext(req.Context(), traderID, "Trader"))
 	w := httptest.NewRecorder()
 	r.HandleGetConsignments(w, req)
 	assert.Equal(t, http.StatusOK, w.Code)
@@ -210,7 +221,7 @@ func TestConsignmentRouter_HandleGetConsignments(t *testing.T) {
 func TestConsignmentRouter_HandleCreateConsignment(t *testing.T) {
 	db, sqlMock := setupRouterTestDB(t)
 	svc := service.NewConsignmentService(db, nil, nil, nil)
-	r := NewConsignmentRouter(svc, nil)
+	r := NewConsignmentRouter(svc, nil, &config.AuthConfig{TraderGroup: "Trader", CHAGroup: "CHA"})
 
 	traderID := "trader1"
 	chaID := uuid.NewString()
@@ -234,7 +245,7 @@ func TestConsignmentRouter_HandleCreateConsignment(t *testing.T) {
 	)
 
 	req, _ := http.NewRequest("POST", "/api/v1/consignments", bytes.NewBuffer(body))
-	req = req.WithContext(withAuthContext(req.Context(), traderID))
+	req = req.WithContext(withAuthContext(req.Context(), traderID, "Trader"))
 	w := httptest.NewRecorder()
 	r.HandleCreateConsignment(w, req)
 	assert.Equal(t, http.StatusCreated, w.Code)
@@ -360,7 +371,7 @@ func TestPreConsignmentRouter_HandleCreatePreConsignment(t *testing.T) {
 	}, nil)
 
 	req, _ := http.NewRequest("POST", "/api/v1/pre-consignments", bytes.NewBuffer(body))
-	req = req.WithContext(withAuthContext(req.Context(), traderID))
+	req = req.WithContext(withAuthContext(req.Context(), traderID, "Trader"))
 	w := httptest.NewRecorder()
 	r.HandleCreatePreConsignment(w, req)
 	assert.Equal(t, http.StatusCreated, w.Code)
@@ -372,7 +383,7 @@ func TestPreConsignmentRouter_HandleCreatePreConsignment_InvalidPayload(t *testi
 	r := NewPreConsignmentRouter(svc)
 
 	req, _ := http.NewRequest("POST", "/api/v1/pre-consignments", bytes.NewBufferString("invalid json"))
-	req = req.WithContext(withAuthContext(req.Context(), "trader1"))
+	req = req.WithContext(withAuthContext(req.Context(), "trader1", "Trader"))
 	w := httptest.NewRecorder()
 	r.HandleCreatePreConsignment(w, req)
 	assert.Equal(t, http.StatusBadRequest, w.Code)
@@ -381,7 +392,7 @@ func TestPreConsignmentRouter_HandleCreatePreConsignment_InvalidPayload(t *testi
 func TestConsignmentRouter_HandleGetConsignmentByID_InvalidID(t *testing.T) {
 	db, _ := setupRouterTestDB(t)
 	svc := service.NewConsignmentService(db, nil, nil, nil)
-	r := NewConsignmentRouter(svc, nil)
+	r := NewConsignmentRouter(svc, nil, &config.AuthConfig{TraderGroup: "Trader", CHAGroup: "CHA"})
 
 	req, _ := http.NewRequest("GET", "/api/v1/consignments/invalid-uuid", nil)
 	req.SetPathValue("id", "invalid-uuid")
@@ -393,10 +404,10 @@ func TestConsignmentRouter_HandleGetConsignmentByID_InvalidID(t *testing.T) {
 func TestConsignmentRouter_HandleGetConsignments_PaginationError(t *testing.T) {
 	db, _ := setupRouterTestDB(t)
 	svc := service.NewConsignmentService(db, nil, nil, nil)
-	r := NewConsignmentRouter(svc, nil)
+	r := NewConsignmentRouter(svc, nil, &config.AuthConfig{TraderGroup: "Trader", CHAGroup: "CHA"})
 
 	req, _ := http.NewRequest("GET", "/api/v1/consignments?limit=invalid", nil)
-	req = req.WithContext(withAuthContext(req.Context(), "trader1"))
+	req = req.WithContext(withAuthContext(req.Context(), "trader1", "Trader"))
 
 	w := httptest.NewRecorder()
 	r.HandleGetConsignments(w, req)
@@ -407,7 +418,7 @@ func TestConsignmentRouter_HandleGetConsignments_PaginationError(t *testing.T) {
 func TestConsignmentRouter_HandleGetConsignmentByID_ServiceError(t *testing.T) {
 	db, sqlMock := setupRouterTestDB(t)
 	svc := service.NewConsignmentService(db, nil, nil, nil)
-	r := NewConsignmentRouter(svc, nil)
+	r := NewConsignmentRouter(svc, nil, &config.AuthConfig{TraderGroup: "Trader", CHAGroup: "CHA"})
 
 	id := uuid.NewString()
 	sqlMock.ExpectQuery("(?i)SELECT .* FROM \"consignments\"").WillReturnError(fmt.Errorf("db error"))
@@ -426,7 +437,7 @@ func TestPreConsignmentRouter_HandleGetTraderPreConsignments_PaginationError(t *
 	r := NewPreConsignmentRouter(svc)
 
 	req, _ := http.NewRequest("GET", "/api/v1/pre-consignments/templates?limit=invalid", nil)
-	req = req.WithContext(withAuthContext(req.Context(), "trader1"))
+	req = req.WithContext(withAuthContext(req.Context(), "trader1", "Trader"))
 
 	w := httptest.NewRecorder()
 	r.HandleGetTraderPreConsignments(w, req)
@@ -450,12 +461,12 @@ func TestHSCodeRouter_HandleGetAllHSCodes_ServiceError(t *testing.T) {
 func TestConsignmentRouter_HandleGetConsignments_ServiceError(t *testing.T) {
 	db, sqlMock := setupRouterTestDB(t)
 	svc := service.NewConsignmentService(db, nil, nil, nil)
-	r := NewConsignmentRouter(svc, nil)
+	r := NewConsignmentRouter(svc, nil, &config.AuthConfig{TraderGroup: "Trader", CHAGroup: "CHA"})
 
 	sqlMock.ExpectQuery("(?i)SELECT count").WillReturnError(fmt.Errorf("db error"))
 
 	req, _ := http.NewRequest("GET", "/api/v1/consignments", nil)
-	req = req.WithContext(withAuthContext(req.Context(), "trader1"))
+	req = req.WithContext(withAuthContext(req.Context(), "trader1", "Trader"))
 	w := httptest.NewRecorder()
 	r.HandleGetConsignments(w, req)
 	assert.Equal(t, http.StatusInternalServerError, w.Code)
@@ -463,10 +474,10 @@ func TestConsignmentRouter_HandleGetConsignments_ServiceError(t *testing.T) {
 
 func TestConsignmentRouter_HandleCreateConsignment_InvalidPayload(t *testing.T) {
 	db, _ := setupRouterTestDB(t)
-	r := NewConsignmentRouter(service.NewConsignmentService(db, nil, nil, nil), nil)
+	r := NewConsignmentRouter(service.NewConsignmentService(db, nil, nil, nil), nil, nil)
 
 	req, _ := http.NewRequest("POST", "/api/v1/consignments", bytes.NewBufferString("invalid json"))
-	req = req.WithContext(withAuthContext(req.Context(), "trader1"))
+	req = req.WithContext(withAuthContext(req.Context(), "trader1", "Trader"))
 	w := httptest.NewRecorder()
 	r.HandleCreateConsignment(w, req)
 	assert.Equal(t, http.StatusBadRequest, w.Code)
@@ -480,7 +491,7 @@ func TestPreConsignmentRouter_HandleGetTraderPreConsignments_ServiceError(t *tes
 	sqlMock.ExpectQuery("(?i)SELECT count").WillReturnError(fmt.Errorf("db error"))
 
 	req, _ := http.NewRequest("GET", "/api/v1/pre-consignments/templates", nil)
-	req = req.WithContext(withAuthContext(req.Context(), "trader1"))
+	req = req.WithContext(withAuthContext(req.Context(), "trader1", "Trader"))
 	w := httptest.NewRecorder()
 	r.HandleGetTraderPreConsignments(w, req)
 	assert.Equal(t, http.StatusInternalServerError, w.Code)
@@ -536,4 +547,32 @@ func TestPreConsignmentRouter_HandleCreatePreConsignment_ServiceError(t *testing
 	w := httptest.NewRecorder()
 	r.HandleCreatePreConsignment(w, req)
 	assert.Equal(t, http.StatusInternalServerError, w.Code)
+}
+func TestConsignmentRouter_RBAC_RoleMismatch(t *testing.T) {
+	db, _ := setupRouterTestDB(t)
+	svc := service.NewConsignmentService(db, nil, nil, nil)
+	r := NewConsignmentRouter(svc, nil, &config.AuthConfig{TraderGroup: "Trader", CHAGroup: "CHA"})
+
+	// CHA user trying to list as trader
+	chaID := "cha-001"
+	req, _ := http.NewRequest("GET", "/api/v1/consignments?role=trader", nil)
+	req = req.WithContext(withAuthContext(req.Context(), chaID, "CHA"))
+
+	w := httptest.NewRecorder()
+	r.HandleGetConsignments(w, req)
+	assert.Equal(t, http.StatusForbidden, w.Code)
+}
+
+func TestConsignmentRouter_RBAC_HumanOnly(t *testing.T) {
+	db, _ := setupRouterTestDB(t)
+	svc := service.NewConsignmentService(db, nil, nil, nil)
+	r := NewConsignmentRouter(svc, nil, &config.AuthConfig{TraderGroup: "Trader", CHAGroup: "CHA"})
+
+	// M2M token trying to list consignments
+	req, _ := http.NewRequest("GET", "/api/v1/consignments?role=trader", nil)
+	req = req.WithContext(withM2MContext(req.Context(), "m2m-client"))
+
+	w := httptest.NewRecorder()
+	r.HandleGetConsignments(w, req)
+	assert.Equal(t, http.StatusUnauthorized, w.Code)
 }

--- a/backend/internal/workflow/router/router_test.go
+++ b/backend/internal/workflow/router/router_test.go
@@ -179,8 +179,9 @@ func TestConsignmentRouter_HandleGetConsignmentByID(t *testing.T) {
 	r := NewConsignmentRouter(svc, nil, &config.AuthConfig{TraderGroup: "Trader", CHAGroup: "CHA"})
 
 	consignmentID := uuid.NewString()
+	traderID := "trader1"
 	sqlMock.MatchExpectationsInOrder(false)
-	sqlMock.ExpectQuery("(?i)SELECT .* FROM \"consignments\"").WillReturnRows(sqlmock.NewRows([]string{"id", "state"}).AddRow(consignmentID, "IN_PROGRESS"))
+	sqlMock.ExpectQuery("(?i)SELECT .* FROM \"consignments\"").WillReturnRows(sqlmock.NewRows([]string{"id", "trader_id", "state"}).AddRow(consignmentID, traderID, "IN_PROGRESS"))
 
 	mockWM.On("GetWorkflowInstance", mock.Anything, consignmentID).Return(&model.Workflow{
 		BaseModel:     model.BaseModel{ID: consignmentID},
@@ -192,11 +193,67 @@ func TestConsignmentRouter_HandleGetConsignmentByID(t *testing.T) {
 
 	req, _ := http.NewRequest("GET", "/api/v1/consignments/"+consignmentID, nil)
 	req.SetPathValue("id", consignmentID)
-	req = req.WithContext(withAuthContext(req.Context(), "trader1", "Trader"))
+	req = req.WithContext(withAuthContext(req.Context(), traderID, "Trader"))
 
 	w := httptest.NewRecorder()
 	r.HandleGetConsignmentByID(w, req)
 	assert.Equal(t, http.StatusOK, w.Code)
+}
+
+func TestConsignmentRouter_HandleGetConsignmentByID_IDOR(t *testing.T) {
+	consignmentID := uuid.NewString()
+	traderOwner := "trader1"
+	attackerTrader := "trader2"
+	chaEmail := "cha@example.com"
+	chaID := "cha-001"
+
+	t.Run("Trader forbidden access to other's consignment", func(t *testing.T) {
+		db, sqlMock := setupRouterTestDB(t)
+		mockWM := new(MockWorkflowManager)
+		svc := service.NewConsignmentService(db, nil, mockWM, nil)
+		r := NewConsignmentRouter(svc, nil, &config.AuthConfig{TraderGroup: "Trader", CHAGroup: "CHA"})
+		sqlMock.ExpectQuery("(?i)SELECT .* FROM \"consignments\"").WillReturnRows(
+			sqlmock.NewRows([]string{"id", "trader_id", "state", "items", "cha_id", "flow"}).
+				AddRow(consignmentID, traderOwner, "IN_PROGRESS", []byte("[]"), "", "IMPORT"),
+		)
+		mockWM.On("GetWorkflowInstance", mock.Anything, consignmentID).Return(&model.Workflow{BaseModel: model.BaseModel{ID: consignmentID}}, nil)
+		// HS code query won't be triggered if items list is empty
+
+		req, _ := http.NewRequest("GET", "/api/v1/consignments/"+consignmentID, nil)
+		req.SetPathValue("id", consignmentID)
+		req = req.WithContext(withAuthContext(req.Context(), attackerTrader, "Trader"))
+
+		w := httptest.NewRecorder()
+		r.HandleGetConsignmentByID(w, req)
+		assert.Equal(t, http.StatusForbidden, w.Code)
+		assert.NoError(t, sqlMock.ExpectationsWereMet())
+	})
+
+	t.Run("CHA allowed access to assigned consignment", func(t *testing.T) {
+		db, sqlMock := setupRouterTestDB(t)
+		mockWM := new(MockWorkflowManager)
+		chaSvc := service.NewCHAService(db)
+		svc := service.NewConsignmentService(db, nil, mockWM, nil)
+		r := NewConsignmentRouter(svc, chaSvc, &config.AuthConfig{TraderGroup: "Trader", CHAGroup: "CHA"})
+
+		sqlMock.ExpectQuery("(?i)SELECT .* FROM \"consignments\"").WillReturnRows(
+			sqlmock.NewRows([]string{"id", "trader_id", "cha_id", "state", "items", "flow"}).
+				AddRow(consignmentID, traderOwner, chaID, "IN_PROGRESS", []byte("[]"), "IMPORT"),
+		)
+		mockWM.On("GetWorkflowInstance", mock.Anything, consignmentID).Return(&model.Workflow{BaseModel: model.BaseModel{ID: consignmentID}}, nil)
+		sqlMock.ExpectQuery("(?i)SELECT .* FROM \"customs_house_agents\"").WillReturnRows(
+			sqlmock.NewRows([]string{"id", "email"}).AddRow(chaID, chaEmail),
+		)
+
+		req, _ := http.NewRequest("GET", "/api/v1/consignments/"+consignmentID, nil)
+		req.SetPathValue("id", consignmentID)
+		req = req.WithContext(withAuthContext(req.Context(), chaEmail, "CHA"))
+
+		w := httptest.NewRecorder()
+		r.HandleGetConsignmentByID(w, req)
+		assert.Equal(t, http.StatusOK, w.Code)
+		assert.NoError(t, sqlMock.ExpectationsWereMet())
+	})
 }
 
 func TestConsignmentRouter_HandleGetConsignments(t *testing.T) {
@@ -216,6 +273,26 @@ func TestConsignmentRouter_HandleGetConsignments(t *testing.T) {
 	w := httptest.NewRecorder()
 	r.HandleGetConsignments(w, req)
 	assert.Equal(t, http.StatusOK, w.Code)
+}
+
+func TestConsignmentRouter_HandleGetConsignments_IDOR(t *testing.T) {
+	db, sqlMock := setupRouterTestDB(t)
+	chaSvc := service.NewCHAService(db)
+	svc := service.NewConsignmentService(db, nil, nil, nil)
+	r := NewConsignmentRouter(svc, chaSvc, &config.AuthConfig{TraderGroup: "Trader", CHAGroup: "CHA"})
+
+	chaEmail := "cha@example.com"
+	chaID := "cha-001"
+	attackerChaID := "cha-002"
+
+	sqlMock.ExpectQuery("(?i)SELECT .* FROM \"customs_house_agents\"").WillReturnRows(sqlmock.NewRows([]string{"id", "email"}).AddRow(chaID, chaEmail))
+
+	req, _ := http.NewRequest("GET", "/api/v1/consignments?role=cha&cha_id="+attackerChaID, nil)
+	req = req.WithContext(withAuthContext(req.Context(), chaEmail, "CHA"))
+
+	w := httptest.NewRecorder()
+	r.HandleGetConsignments(w, req)
+	assert.Equal(t, http.StatusForbidden, w.Code)
 }
 
 func TestConsignmentRouter_HandleCreateConsignment(t *testing.T) {
@@ -576,7 +653,7 @@ func TestConsignmentRouter_RBAC_HumanOnly(t *testing.T) {
 
 	w := httptest.NewRecorder()
 	r.HandleGetConsignments(w, req)
-	assert.Equal(t, http.StatusForbidden, w.Code)
+	assert.Equal(t, http.StatusUnauthorized, w.Code)
 }
 func TestPreConsignmentRouter_RBAC_HumanOnly(t *testing.T) {
 	r := NewPreConsignmentRouter(nil)
@@ -587,7 +664,7 @@ func TestPreConsignmentRouter_RBAC_HumanOnly(t *testing.T) {
 
 	w := httptest.NewRecorder()
 	r.HandleGetPreConsignmentsByTraderID(w, req)
-	assert.Equal(t, http.StatusForbidden, w.Code)
+	assert.Equal(t, http.StatusUnauthorized, w.Code)
 }
 
 func TestConsignmentRouter_GetByID_AuthRequired(t *testing.T) {

--- a/backend/internal/workflow/router/router_test.go
+++ b/backend/internal/workflow/router/router_test.go
@@ -396,6 +396,7 @@ func TestConsignmentRouter_HandleGetConsignmentByID_InvalidID(t *testing.T) {
 
 	req, _ := http.NewRequest("GET", "/api/v1/consignments/invalid-uuid", nil)
 	req.SetPathValue("id", "invalid-uuid")
+	req = req.WithContext(withAuthContext(req.Context(), "trader1", "Trader"))
 	w := httptest.NewRecorder()
 	r.HandleGetConsignmentByID(w, req)
 	assert.Equal(t, http.StatusInternalServerError, w.Code)
@@ -425,6 +426,7 @@ func TestConsignmentRouter_HandleGetConsignmentByID_ServiceError(t *testing.T) {
 
 	req, _ := http.NewRequest("GET", "/api/v1/consignments/"+id, nil)
 	req.SetPathValue("id", id)
+	req = req.WithContext(withAuthContext(req.Context(), "trader1", "Trader"))
 
 	w := httptest.NewRecorder()
 	r.HandleGetConsignmentByID(w, req)
@@ -474,7 +476,7 @@ func TestConsignmentRouter_HandleGetConsignments_ServiceError(t *testing.T) {
 
 func TestConsignmentRouter_HandleCreateConsignment_InvalidPayload(t *testing.T) {
 	db, _ := setupRouterTestDB(t)
-	r := NewConsignmentRouter(service.NewConsignmentService(db, nil, nil, nil), nil, nil)
+	r := NewConsignmentRouter(service.NewConsignmentService(db, nil, nil, nil), nil, &config.AuthConfig{TraderGroup: "Trader", CHAGroup: "CHA"})
 
 	req, _ := http.NewRequest("POST", "/api/v1/consignments", bytes.NewBufferString("invalid json"))
 	req = req.WithContext(withAuthContext(req.Context(), "trader1", "Trader"))
@@ -574,5 +576,26 @@ func TestConsignmentRouter_RBAC_HumanOnly(t *testing.T) {
 
 	w := httptest.NewRecorder()
 	r.HandleGetConsignments(w, req)
+	assert.Equal(t, http.StatusForbidden, w.Code)
+}
+func TestPreConsignmentRouter_RBAC_HumanOnly(t *testing.T) {
+	r := NewPreConsignmentRouter(nil)
+
+	// M2M token trying to list pre-consignments
+	req, _ := http.NewRequest("GET", "/api/v1/pre-consignments", nil)
+	req = req.WithContext(withM2MContext(req.Context(), "m2m-client"))
+
+	w := httptest.NewRecorder()
+	r.HandleGetPreConsignmentsByTraderID(w, req)
+	assert.Equal(t, http.StatusForbidden, w.Code)
+}
+
+func TestConsignmentRouter_GetByID_AuthRequired(t *testing.T) {
+	r := NewConsignmentRouter(nil, nil, nil)
+
+	// No auth context
+	req, _ := http.NewRequest("GET", "/api/v1/consignments/123", nil)
+	w := httptest.NewRecorder()
+	r.HandleGetConsignmentByID(w, req)
 	assert.Equal(t, http.StatusUnauthorized, w.Code)
 }

--- a/backend/internal/workflow/service/consignment_service.go
+++ b/backend/internal/workflow/service/consignment_service.go
@@ -10,6 +10,7 @@ import (
 	"gorm.io/gorm"
 
 	workflowManagerV2 "github.com/OpenNSW/go-temporal-workflow"
+	"github.com/OpenNSW/nsw/internal/auth"
 
 	workflowmanagerV1 "github.com/OpenNSW/nsw/internal/workflow/manager"
 	"github.com/OpenNSW/nsw/internal/workflow/model"
@@ -249,6 +250,22 @@ func (s *ConsignmentService) GetConsignmentByID(ctx context.Context, consignment
 	}
 
 	return responseDTO, nil
+}
+
+// GetConsignments returns consignments filtered by trader or by CHA role.
+func (s *ConsignmentService) GetConsignments(ctx context.Context, userID string, requestedRole string) (*model.ConsignmentListResult, error) {
+	dbQuery := s.db.WithContext(ctx).Model(&model.Consignment{})
+	switch requestedRole {
+	case auth.RoleQueryTrader:
+		dbQuery = dbQuery.Where("trader_id = ?", userID)
+	case auth.RoleQueryCHA:
+		dbQuery = dbQuery.Where("cha_id = ?", userID)
+	default:
+		return nil, fmt.Errorf("invalid role: %s", requestedRole)
+	}
+
+	filter := model.ConsignmentFilter{}
+	return s.listConsignmentsWithBaseQuery(ctx, dbQuery, filter)
 }
 
 // ListConsignments returns consignments filtered by trader (role=trader) or by CHA (role=cha). Exactly one of filter.TraderID or filter.ChaID must be set.


### PR DESCRIPTION
Part 1/N of #11 
## Summary
Implements Phase 1 of a configurable RBAC system and adds support for M2M (Machine-to-Machine) authentication for OGA integrations. The backend has transitioned from hardcoded role assumptions to a dynamic, handler-level authorization model. Key architectural changes include making user identity optional to support service-to-service communication and moving permission boundaries to the entry points (HTTP handlers) rather than the business logic layer.

## Changes
* Defined fallback defaults in `backend/internal/config/config.go` 
```
InternalClientID:      getEnvOrDefault("AUTH_INTERNAL_CLIENT_ID", "OGA_M2M_APP")
TraderGroup:           getEnvOrDefault("AUTH_TRADER_GROUP", "NSW_TRADER")
CHAGroup:              getEnvOrDefault("AUTH_CHA_GROUP", "NSW_CHA")
```

### Authentication Core
* `backend/internal/auth/context.go`: refactor `AuthContext.UserID` to `*string` to support tokens without a subject (M2M/Client Credentials). add `ClientID`, `Groups []string`, and `IsM2M bool` fields to the context struct. introduce the `HasGroup(group string) bool` helper method for permission checking.
* `backend/internal/auth/token_parser.go`: enhance JWT parsing via JWKS to extract the `groups` claim. Add logic to identify M2M tokens specifically when the token is issued by the internal client and the subject matches the client ID or follows the M2M subject pattern.
* `backend/internal/auth/middleware.go`: update middleware to act as the primary enforcement gate, building the enriched `AuthContext`. It is now designed to gracefully tolerate users without a stored DB context (passing a `nil` UserContext) and skips mandatory database lookups if the token is identified as M2M.
* `backend/internal/config/config.go`: introduce configurable IDP group names (`TraderGroup`, `CHAGroup`) and an `InternalClientID` within the `AuthConfig` struct, mapping them to the corresponding environment variables.

### Authorization & Routing (Handlers)
* `backend/internal/workflow/router/consignment_router.go`: move role and identity validation to the HTTP handlers. Enforced human-only context for consignment creation and retrieval. update `HandleGetConsignments` to support a `role` query parameter, validating it against the user's actual IDP groups via `HasGroup()`.
* `backend/internal/task/manager/http_handler.go`: implement strict RBAC checks distinguishing between view and execute actions. For human users, both Traders and CHAs can view tasks (`HandleGetTask`). However, only CHAs (and M2M systems) can access the task execution endpoint (`HandleExecuteTask`). Traders are explicitly forbidden from executing tasks.
* `backend/internal/uploads/http_handler.go`: apply M2M bypass and human-role checking logic. Ensures that the `Upload`, `Download`, and `Delete` endpoints strictly require the requestor to possess either the Trader or CHA group, or be an authenticated M2M system account.

### Service Layer (Business Logic)
* `backend/internal/workflow/service/consignment_service.go`: include robust data-level RBAC filtering. The `GetConsignments` method dynamically applies database `WHERE` clauses (`trader_id = ?` vs. `cha_id = ?`) based on the explicit `userID` and `requestedRole` parameters passed down from the handlers, ensuring users only retrieve consignments they explicitly own or manage

## Validation/Testing
- Successfully executed full backend test suite (`go test ./...`) with all tests passing.
- Verified human user context: `GET /consignments?role=trader` with a `CHA` user correctly returns `403 Forbidden`.
- Verified M2M Block Test: `GET /consignments` using an M2M token correctly returns `401/403`.
- Verified M2M Bypass Test: `PATCH /tasks/:id` or upload endpoints using an M2M token correctly bypass human checks and return `200 OK`