### PR TITLE
refactor: fix workspace package updates in oga-app

### DIFF
--- a/portals/apps/oga-app/vite.config.ts
+++ b/portals/apps/oga-app/vite.config.ts
@@ -1,6 +1,7 @@
 import { defineConfig } from 'vite'
 import react from '@vitejs/plugin-react-swc'
 import tailwindcss from "@tailwindcss/vite";
+import path from "node:path";
 
 // https://vite.dev/config/
 export default defineConfig({
@@ -8,4 +9,10 @@ export default defineConfig({
   server: {
     port: process.env.VITE_PORT ? parseInt(process.env.VITE_PORT, 10) : 5174,
   },
+  resolve: {
+    alias: {
+      '@opennsw/ui': path.resolve(import.meta.dirname, '../../packages/ui/src'),
+      '@opennsw/jsonforms-renderers': path.resolve(import.meta.dirname, '../../packages/jsonforms-renderers/src')
+    }
+  }
 })

--- a/portals/apps/trader-app/vite.config.ts
+++ b/portals/apps/trader-app/vite.config.ts
@@ -1,18 +1,15 @@
 import { defineConfig } from 'vite'
 import react from '@vitejs/plugin-react-swc'
 import * as path from "node:path";
-import { fileURLToPath } from 'node:url';
 import tailwindcss from "@tailwindcss/vite";
-
-const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
 // https://vite.dev/config/
 export default defineConfig({
   plugins: [react(), tailwindcss()],
   resolve: {
     alias: {
-      '@opennsw/ui': path.resolve(__dirname, '../../packages/ui/src'),
-      '@opennsw/jsonforms-renderers': path.resolve(__dirname, '../../packages/jsonforms-renderers/src')
+      '@opennsw/ui': path.resolve(import.meta.dirname, '../../packages/ui/src'),
+      '@opennsw/jsonforms-renderers': path.resolve(import.meta.dirname, '../../packages/jsonforms-renderers/src')
     }
   }
 })


### PR DESCRIPTION
## Summary

This PR updates the Vite configuration for `oga-app` to ensure that changes made to workspace packages (`@opennsw/ui` and `@opennsw/jsonforms-renderers`) are immediately reflected during development. 

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [x] Refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Other (please describe):

## Changes Made

- Modified `portals/apps/oga-app/vite.config.ts` to include `path` from `node:path`.
- Added `resolve.alias` configuration to point workspace packages to their source directories.

## Testing

- [x] I have tested this change locally
- [ ] I have added unit tests for new functionality
- [ ] I have tested edge cases
- [x] All existing tests pass

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have checked that there are no merge conflicts

## Related Issues

Closes #302

## Screenshots/Demo

N/A

## Additional Notes

This aligns `oga-app` with the configuration already present in `trader-app`.

## Deployment Notes

N/A