### PR TITLE
feat(template): implement template registry with form handler and validation

### DIFF
--- a/oga/internal/template/form.go
+++ b/oga/internal/template/form.go
@@ -1,0 +1,45 @@
+package template
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+)
+
+type FormHandler struct{}
+
+func NewFormHandler() *FormHandler {
+	return &FormHandler{}
+}
+
+func (h *FormHandler) Type() TemplateType {
+	return TemplateTypeForm
+}
+
+func (h *FormHandler) Validate(content map[string]any) error {
+	if content == nil {
+		return fmt.Errorf("content is required")
+	}
+
+	schema, ok := content["schema"]
+	if !ok || schema == nil {
+		return fmt.Errorf("schema is required")
+	}
+	if _, ok := schema.(map[string]any); !ok {
+		return fmt.Errorf("schema must be an object")
+	}
+
+	uiSchema, ok := content["uiSchema"]
+	if !ok || uiSchema == nil {
+		return fmt.Errorf("uiSchema is required")
+	}
+	if _, ok := uiSchema.(map[string]any); !ok {
+		return fmt.Errorf("uiSchema must be an object")
+	}
+
+	return nil
+}
+
+func (h *FormHandler) Process(_ context.Context, content json.RawMessage, _ map[string]any) (any, error) {
+	return content, nil
+}

--- a/oga/internal/template/integration_test.go
+++ b/oga/internal/template/integration_test.go
@@ -1,0 +1,126 @@
+package template
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+)
+
+func TestTemplateRegistry_Integration_LoadAndUseTemplateDefinition(t *testing.T) {
+	dir := t.TempDir()
+	templateID := "npqs:phytosanitary:v1"
+
+	mockTemplate := TemplateDefinition{
+		ID:         templateID,
+		Name:       "NPQS Phytosanitary Review",
+		ActionType: ActionTypeReview,
+		View: TemplateSection{
+			Type: TemplateTypeForm,
+			Content: mustMarshalJSON(map[string]any{
+				"schema": map[string]any{
+					"type":  "object",
+					"title": "View Schema",
+					"properties": map[string]any{
+						"consignmentNo": map[string]any{"type": "string"},
+					},
+				},
+				"uiSchema": map[string]any{
+					"type": "VerticalLayout",
+					"elements": []any{
+						map[string]any{"type": "Control", "scope": "#/properties/consignmentNo"},
+					},
+				},
+			}),
+		},
+		Action: TemplateSection{
+			Type: TemplateTypeForm,
+			Content: mustMarshalJSON(map[string]any{
+				"schema": map[string]any{
+					"type":     "object",
+					"title":    "Action Schema",
+					"required": []any{"decision"},
+					"properties": map[string]any{
+						"decision": map[string]any{
+							"type": "string",
+							"oneOf": []any{
+								map[string]any{"const": "APPROVED", "title": "Approved"},
+								map[string]any{"const": "REJECTED", "title": "Rejected"},
+							},
+						},
+					},
+				},
+				"uiSchema": map[string]any{
+					"type": "VerticalLayout",
+					"elements": []any{
+						map[string]any{"type": "Control", "scope": "#/properties/decision"},
+					},
+				},
+			}),
+		},
+	}
+
+	writeTemplateFile(t, dir, templateID, mockTemplate)
+
+	registry, err := NewTemplateRegistry(dir, templateID)
+	if err != nil {
+		t.Fatalf("NewTemplateRegistry() error = %v", err)
+	}
+
+	tpl, err := registry.GetDefaultTemplate()
+	if err != nil {
+		t.Fatalf("GetDefaultTemplate() error = %v", err)
+	}
+
+	if tpl.ID != templateID {
+		t.Fatalf("expected template ID %q, got %q", templateID, tpl.ID)
+	}
+	if tpl.Name != "NPQS Phytosanitary Review" {
+		t.Fatalf("unexpected template name: %q", tpl.Name)
+	}
+	if tpl.ActionType != ActionTypeReview {
+		t.Fatalf("expected ActionType %q, got %q", ActionTypeReview, tpl.ActionType)
+	}
+	if tpl.View.Type != TemplateTypeForm || tpl.Action.Type != TemplateTypeForm {
+		t.Fatalf("expected both sections to be FORM, got view=%q action=%q", tpl.View.Type, tpl.Action.Type)
+	}
+
+	viewContent := decodeSectionContent(t, tpl.View.Content)
+	actionContent := decodeSectionContent(t, tpl.Action.Content)
+	if schemaTitle(viewContent) != "View Schema" {
+		t.Fatalf("expected view schema title %q, got %q", "View Schema", schemaTitle(viewContent))
+	}
+	if schemaTitle(actionContent) != "Action Schema" {
+		t.Fatalf("expected action schema title %q, got %q", "Action Schema", schemaTitle(actionContent))
+	}
+
+	processed, err := NewFormHandler().Process(context.Background(), tpl.Action.Content, map[string]any{"decision": "APPROVED"})
+	if err != nil {
+		t.Fatalf("FormHandler.Process() error = %v", err)
+	}
+	processedRaw, ok := processed.(json.RawMessage)
+	if !ok {
+		t.Fatalf("expected processed value to be json.RawMessage, got %T", processed)
+	}
+	if string(processedRaw) != string(tpl.Action.Content) {
+		t.Fatalf("expected processed content to match action content")
+	}
+}
+
+func decodeSectionContent(t *testing.T, content json.RawMessage) map[string]any {
+	t.Helper()
+
+	var decoded map[string]any
+	if err := json.Unmarshal(content, &decoded); err != nil {
+		t.Fatalf("failed to decode section content: %v", err)
+	}
+	return decoded
+}
+
+func schemaTitle(section map[string]any) string {
+	schema, ok := section["schema"].(map[string]any)
+	if !ok {
+		return ""
+	}
+	title, _ := schema["title"].(string)
+	return title
+}

--- a/oga/internal/template/interface.go
+++ b/oga/internal/template/interface.go
@@ -1,0 +1,12 @@
+package template
+
+import (
+	"context"
+	"encoding/json"
+)
+
+type TemplateHandler interface {
+	Type() TemplateType
+	Validate(content map[string]any) error
+	Process(ctx context.Context, content json.RawMessage, data map[string]any) (any, error)
+}

--- a/oga/internal/template/model.go
+++ b/oga/internal/template/model.go
@@ -1,0 +1,30 @@
+package template
+
+import "encoding/json"
+
+type TemplateType string
+
+const (
+	TemplateTypeForm     TemplateType = "FORM"
+	TemplateTypeMarkdown TemplateType = "MARKDOWN"
+)
+
+type ActionType string
+
+const (
+	ActionTypeReview ActionType = "REVIEW"
+	ActionTypeSubmit ActionType = "SUBMIT"
+)
+
+type TemplateSection struct {
+	Type    TemplateType    `json:"type"`
+	Content json.RawMessage `json:"content"`
+}
+
+type TemplateDefinition struct {
+	ID         string          `json:"id"`
+	Name       string          `json:"name"`
+	View       TemplateSection `json:"view"`
+	Action     TemplateSection `json:"action"`
+	ActionType ActionType      `json:"actionType"` // Used by the frontend to determine how to display the action section (e.g. as a review application or submit form)
+}

--- a/oga/internal/template/registry.go
+++ b/oga/internal/template/registry.go
@@ -1,0 +1,152 @@
+package template
+
+import (
+	"encoding/json"
+	"fmt"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+type TemplateRegistry struct {
+	templates         map[string]TemplateDefinition
+	handlers          map[TemplateType]TemplateHandler
+	defaultTemplateID string
+}
+
+func NewTemplateRegistry(dir string, defaultTemplateID string) (*TemplateRegistry, error) {
+	registry := &TemplateRegistry{
+		templates:         make(map[string]TemplateDefinition),
+		handlers:          make(map[TemplateType]TemplateHandler),
+		defaultTemplateID: defaultTemplateID,
+	}
+
+	if err := registry.RegisterHandler(NewFormHandler()); err != nil {
+		return nil, err
+	}
+
+	if err := registry.loadTemplates(dir); err != nil {
+		return nil, err
+	}
+
+	if defaultTemplateID != "" {
+		if _, ok := registry.templates[defaultTemplateID]; !ok {
+			return nil, fmt.Errorf("default template %q not found in %q", defaultTemplateID, dir)
+		}
+	}
+
+	slog.Info("template registry initialized", "count", len(registry.templates), "defaultTemplateID", defaultTemplateID)
+	return registry, nil
+}
+
+func (r *TemplateRegistry) RegisterHandler(h TemplateHandler) error {
+	if h == nil {
+		return fmt.Errorf("template handler is required")
+	}
+
+	handlerType := h.Type()
+	if handlerType == "" {
+		return fmt.Errorf("template handler type is required")
+	}
+
+	r.handlers[handlerType] = h
+	return nil
+}
+
+func (r *TemplateRegistry) GetTemplate(id string) (TemplateDefinition, error) {
+	templateDef, ok := r.templates[id]
+	if !ok {
+		return TemplateDefinition{}, fmt.Errorf("template %q not found", id)
+	}
+
+	return templateDef, nil
+}
+
+func (r *TemplateRegistry) GetDefaultTemplate() (TemplateDefinition, error) {
+	if r.defaultTemplateID == "" {
+		return TemplateDefinition{}, fmt.Errorf("no default template configured")
+	}
+
+	return r.GetTemplate(r.defaultTemplateID)
+}
+
+func (r *TemplateRegistry) loadTemplates(dir string) error {
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		return fmt.Errorf("failed to read templates directory %q: %w", dir, err)
+	}
+
+	for _, entry := range entries {
+		if entry.IsDir() || !strings.HasSuffix(entry.Name(), ".json") {
+			continue
+		}
+
+		data, err := os.ReadFile(filepath.Join(dir, entry.Name()))
+		if err != nil {
+			return fmt.Errorf("failed to read template file %q: %w", entry.Name(), err)
+		}
+
+		if !json.Valid(data) {
+			return fmt.Errorf("template file %q contains invalid JSON", entry.Name())
+		}
+
+		var templateDef TemplateDefinition
+		if err := json.Unmarshal(data, &templateDef); err != nil {
+			return fmt.Errorf("failed to parse template file %q: %w", entry.Name(), err)
+		}
+
+		templateID := strings.TrimSuffix(entry.Name(), ".json")
+		if templateDef.ID != "" && templateDef.ID != templateID {
+			return fmt.Errorf("template ID %q in file %q does not match filename", templateDef.ID, entry.Name())
+		}
+		templateDef.ID = templateID
+
+		if err := r.validateTemplate(templateID, templateDef); err != nil {
+			return err
+		}
+
+		r.templates[templateID] = templateDef
+		slog.Debug("loaded template", "id", templateID)
+	}
+
+	return nil
+}
+
+func (r *TemplateRegistry) validateTemplate(templateID string, templateDef TemplateDefinition) error {
+	if err := r.validateSection(templateID, "view", templateDef.View); err != nil {
+		return err
+	}
+
+	if err := r.validateSection(templateID, "action", templateDef.Action); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (r *TemplateRegistry) validateSection(templateID string, sectionName string, section TemplateSection) error {
+	if section.Type == "" {
+		return fmt.Errorf("template %q section %q is missing type", templateID, sectionName)
+	}
+
+	h, ok := r.handlers[section.Type]
+	if !ok {
+		return fmt.Errorf("template %q section %q has unsupported type %q", templateID, sectionName, section.Type)
+	}
+
+	if len(section.Content) == 0 {
+		return fmt.Errorf("template %q section %q is missing content", templateID, sectionName)
+	}
+
+	var content map[string]any
+	if err := json.Unmarshal(section.Content, &content); err != nil {
+		return fmt.Errorf("template %q section %q content must be an object: %w", templateID, sectionName, err)
+	}
+
+	if err := h.Validate(content); err != nil {
+		return fmt.Errorf("template %q section %q failed validation: %w", templateID, sectionName, err)
+	}
+
+	return nil
+}

--- a/oga/internal/template/registry_test.go
+++ b/oga/internal/template/registry_test.go
@@ -1,0 +1,130 @@
+package template
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestNewTemplateRegistry_LoadsTemplatesAndDefault(t *testing.T) {
+	dir := t.TempDir()
+	writeTemplateFile(t, dir, "default", buildTemplateDefinition("default", TemplateTypeForm, minimalFormContent(), TemplateTypeForm, minimalFormContent()))
+	writeTemplateFile(t, dir, "custom", buildTemplateDefinition("custom", TemplateTypeForm, minimalFormContent(), TemplateTypeForm, minimalFormContent()))
+
+	registry, err := NewTemplateRegistry(dir, "default")
+	if err != nil {
+		t.Fatalf("NewTemplateRegistry() error = %v", err)
+	}
+
+	if _, err := registry.GetTemplate("custom"); err != nil {
+		t.Fatalf("GetTemplate(custom) error = %v", err)
+	}
+
+	if _, err := registry.GetDefaultTemplate(); err != nil {
+		t.Fatalf("GetDefaultTemplate() error = %v", err)
+	}
+}
+
+func TestNewTemplateRegistry_FailsForInvalidFormContent(t *testing.T) {
+	dir := t.TempDir()
+	invalidContent := map[string]any{
+		"schema": map[string]any{"type": "object"},
+	}
+	writeTemplateFile(t, dir, "default", buildTemplateDefinition("default", TemplateTypeForm, invalidContent, TemplateTypeForm, minimalFormContent()))
+
+	_, err := NewTemplateRegistry(dir, "default")
+	if err == nil {
+		t.Fatalf("expected error for invalid form content")
+	}
+	if !strings.Contains(err.Error(), "uiSchema is required") {
+		t.Fatalf("expected uiSchema validation error, got %v", err)
+	}
+}
+
+func TestNewTemplateRegistry_FailsForUnsupportedSectionType(t *testing.T) {
+	dir := t.TempDir()
+	writeTemplateFile(t, dir, "default", buildTemplateDefinition("default", TemplateTypeMarkdown, map[string]any{"text": "hello"}, TemplateTypeForm, minimalFormContent()))
+
+	_, err := NewTemplateRegistry(dir, "default")
+	if err == nil {
+		t.Fatalf("expected error for unsupported template section type")
+	}
+	if !strings.Contains(err.Error(), "unsupported type") {
+		t.Fatalf("expected unsupported type error, got %v", err)
+	}
+}
+
+func TestNewTemplateRegistry_FailsWhenDefaultTemplateMissing(t *testing.T) {
+	dir := t.TempDir()
+	writeTemplateFile(t, dir, "custom", buildTemplateDefinition("custom", TemplateTypeForm, minimalFormContent(), TemplateTypeForm, minimalFormContent()))
+
+	_, err := NewTemplateRegistry(dir, "default")
+	if err == nil {
+		t.Fatalf("expected error when default template is missing")
+	}
+	if !strings.Contains(err.Error(), "default template") {
+		t.Fatalf("expected default template error, got %v", err)
+	}
+}
+
+func TestNewTemplateRegistry_FailsWhenTemplateIDMismatchesFilename(t *testing.T) {
+	dir := t.TempDir()
+	writeTemplateFile(t, dir, "default", buildTemplateDefinition("mismatch-id", TemplateTypeForm, minimalFormContent(), TemplateTypeForm, minimalFormContent()))
+
+	_, err := NewTemplateRegistry(dir, "default")
+	if err == nil {
+		t.Fatalf("expected error when template ID mismatches filename")
+	}
+	if !strings.Contains(err.Error(), "does not match filename") {
+		t.Fatalf("expected filename mismatch error, got %v", err)
+	}
+}
+
+func buildTemplateDefinition(id string, roType TemplateType, roContent map[string]any, officerType TemplateType, officerContent map[string]any) TemplateDefinition {
+	return TemplateDefinition{
+		ID:         id,
+		Name:       id,
+		ActionType: ActionTypeReview,
+		View: TemplateSection{
+			Type:    roType,
+			Content: mustMarshalJSON(roContent),
+		},
+		Action: TemplateSection{
+			Type:    officerType,
+			Content: mustMarshalJSON(officerContent),
+		},
+	}
+}
+
+func minimalFormContent() map[string]any {
+	return map[string]any{
+		"schema": map[string]any{
+			"type": "object",
+		},
+		"uiSchema": map[string]any{
+			"type":     "VerticalLayout",
+			"elements": []any{},
+		},
+	}
+}
+
+func writeTemplateFile(t *testing.T, dir string, id string, definition TemplateDefinition) {
+	t.Helper()
+
+	data, err := json.Marshal(definition)
+	if err != nil {
+		t.Fatalf("failed to marshal template definition: %v", err)
+	}
+
+	path := filepath.Join(dir, id+".json")
+	if err := os.WriteFile(path, data, 0o644); err != nil {
+		t.Fatalf("failed to write template file %q: %v", path, err)
+	}
+}
+
+func mustMarshalJSON(v any) json.RawMessage {
+	data, _ := json.Marshal(v)
+	return data
+}


### PR DESCRIPTION
## Summary
This PR introduces only the initial OGA template module foundation. It adds the base abstractions and validation needed for a plugin-based template system, without changing current service wiring yet.

## Type of Change
- [x] New feature (foundation layer)

## Changes Made
- Added template package models: `model.go`
- Added common template handler interface: `interface.go`
- Added FORM handler with validation logic: `form.go`
- Implemented TemplateRegistry for loading, validation, lookup, and default template resolution: `registry.go`
- Added focused unit tests for template registry behavior: `registry_test.go`
- Added integration test with realistic mock template data showing end-to-end usage of the template package: `integration_test.go`

## Testing
- [x] I have tested this change locally
- [x] I have added unit tests for new functionality
- [x] All existing tests pass

## Additional Notes
This PR is intentionally scoped to the newly created template module only.

Follow-up PRs will cover:
- Replace formStore with templateRegistry
- Migration of template files
- Implement MarkdownHandler
- Refactor OGA Portal
- Update docs