### PR TITLE
refactor(workflow): remove GetWorkflowNodeByID and standardize on transaction-based access

### DIFF
--- a/backend/internal/workflow/service/workflow_node_service.go
+++ b/backend/internal/workflow/service/workflow_node_service.go
@@ -18,16 +18,6 @@ func NewWorkflowNodeService(db *gorm.DB) *WorkflowNodeService {
 	return &WorkflowNodeService{db: db}
 }
 
-// GetWorkflowNodeByID retrieves a workflow node by its ID.
-func (s *WorkflowNodeService) GetWorkflowNodeByID(ctx context.Context, nodeID string) (*model.WorkflowNode, error) {
-	var node model.WorkflowNode
-	result := s.db.WithContext(ctx).Where("id = ?", nodeID).First(&node)
-	if result.Error != nil {
-		return nil, fmt.Errorf("failed to retrieve workflow node: %w", result.Error)
-	}
-	return &node, nil
-}
-
 // GetWorkflowNodeByIDInTx retrieves a workflow node by its ID within a transaction.
 func (s *WorkflowNodeService) GetWorkflowNodeByIDInTx(ctx context.Context, tx *gorm.DB, nodeID string) (*model.WorkflowNode, error) {
 	var node model.WorkflowNode

--- a/backend/internal/workflow/service/workflow_node_service_test.go
+++ b/backend/internal/workflow/service/workflow_node_service_test.go
@@ -204,11 +204,16 @@ func TestWorkflowNodeService_GetWorkflowNodeByIDInTx_Success(t *testing.T) {
 	ctx := context.Background()
 	sqlMock.ExpectBegin()
 	tx := db.Begin()
+	assert.NoError(t, tx.Error)
+	defer func() {
+		assert.NoError(t, tx.Rollback().Error)
+	}()
 	id := uuid.NewString()
 
 	sqlMock.ExpectQuery(`SELECT \* FROM "workflow_nodes" WHERE id = \$1 ORDER BY "workflow_nodes"."id" LIMIT \$2`).
 		WithArgs(id, 1).
 		WillReturnRows(sqlmock.NewRows([]string{"id"}).AddRow(id))
+	sqlMock.ExpectRollback()
 
 	node, err := service.GetWorkflowNodeByIDInTx(ctx, tx, id)
 	assert.NoError(t, err)
@@ -240,14 +245,20 @@ func TestWorkflowNodeService_GetWorkflowNodeByIDInTx_Failure(t *testing.T) {
 	db, sqlMock := setupTestDB(t)
 	service := NewWorkflowNodeService(db)
 	ctx := context.Background()
-	sqlMock.ExpectBegin()
-	tx := db.Begin()
 	id := uuid.NewString()
 
 	t.Run("Not Found", func(t *testing.T) {
+		sqlMock.ExpectBegin()
+		tx := db.Begin()
+		assert.NoError(t, tx.Error)
+		defer func() {
+			assert.NoError(t, tx.Rollback().Error)
+		}()
+
 		sqlMock.ExpectQuery(`SELECT \* FROM "workflow_nodes" WHERE id = \$1 ORDER BY "workflow_nodes"."id" LIMIT \$2`).
 			WithArgs(id, 1).
 			WillReturnError(gorm.ErrRecordNotFound)
+		sqlMock.ExpectRollback()
 
 		node, err := service.GetWorkflowNodeByIDInTx(ctx, tx, id)
 		assert.Error(t, err)

--- a/backend/internal/workflow/service/workflow_node_service_test.go
+++ b/backend/internal/workflow/service/workflow_node_service_test.go
@@ -198,17 +198,19 @@ func TestWorkflowNodeService_GetWorkflowNodesByWorkflowIDsInTx(t *testing.T) {
 	assert.Len(t, nodes, 2)
 }
 
-func TestWorkflowNodeService_GetWorkflowNodeByID(t *testing.T) {
+func TestWorkflowNodeService_GetWorkflowNodeByIDInTx_Success(t *testing.T) {
 	db, sqlMock := setupTestDB(t)
 	service := NewWorkflowNodeService(db)
 	ctx := context.Background()
+	sqlMock.ExpectBegin()
+	tx := db.Begin()
 	id := uuid.NewString()
 
 	sqlMock.ExpectQuery(`SELECT \* FROM "workflow_nodes" WHERE id = \$1 ORDER BY "workflow_nodes"."id" LIMIT \$2`).
 		WithArgs(id, 1).
 		WillReturnRows(sqlmock.NewRows([]string{"id"}).AddRow(id))
 
-	node, err := service.GetWorkflowNodeByID(ctx, id)
+	node, err := service.GetWorkflowNodeByIDInTx(ctx, tx, id)
 	assert.NoError(t, err)
 	assert.Equal(t, id, node.ID)
 }
@@ -234,10 +236,12 @@ func TestWorkflowNodeService_UpdateWorkflowNodesInTx_Failure(t *testing.T) {
 	})
 }
 
-func TestWorkflowNodeService_GetWorkflowNodeByID_Failure(t *testing.T) {
+func TestWorkflowNodeService_GetWorkflowNodeByIDInTx_Failure(t *testing.T) {
 	db, sqlMock := setupTestDB(t)
 	service := NewWorkflowNodeService(db)
 	ctx := context.Background()
+	sqlMock.ExpectBegin()
+	tx := db.Begin()
 	id := uuid.NewString()
 
 	t.Run("Not Found", func(t *testing.T) {
@@ -245,7 +249,7 @@ func TestWorkflowNodeService_GetWorkflowNodeByID_Failure(t *testing.T) {
 			WithArgs(id, 1).
 			WillReturnError(gorm.ErrRecordNotFound)
 
-		node, err := service.GetWorkflowNodeByID(ctx, id)
+		node, err := service.GetWorkflowNodeByIDInTx(ctx, tx, id)
 		assert.Error(t, err)
 		assert.Nil(t, node)
 	})


### PR DESCRIPTION
## Summary

This PR removes the redundant `GetWorkflowNodeByID` method from `WorkflowNodeService` and standardizes all workflow node retrievals to use the transaction-aware `GetWorkflowNodeByIDInTx`.

This change simplifies the service API and enforces consistent, transaction-safe data access aligned with the workflow engine’s design, where most operations are executed within transactional boundaries.

---

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [x] Refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Other (please describe):

---

## Changes Made

- Removed `GetWorkflowNodeByID` from `workflow_node_service.go`
- Standardized node retrieval to use `GetWorkflowNodeByIDInTx`
- Updated tests in `workflow_node_service_test.go`:
  - Replaced usages of `GetWorkflowNodeByID` with `GetWorkflowNodeByIDInTx`
  - Added transaction initialization (`tx := db.Begin()`)
  - Added `sqlMock.ExpectBegin()` where required
- Updated error assertions in tests where applicable

---

## Testing

- [x] I have tested this change locally
- [ ] I have added unit tests for new functionality
- [x] I have tested edge cases
- [x] All existing tests pass

---

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have checked that there are no merge conflicts

---

## Related Issues

Closes #323 

---

## Screenshots/Demo

Passing the test cases:
<img width="2154" height="118" alt="image" src="https://github.com/user-attachments/assets/1be019c0-2463-44a3-9ace-b814a350d23a" />

---

## Additional Notes

This change reduces the risk of accidental non-transactional reads in workflow execution paths and enforces a consistent access pattern across the codebase.

---

## Deployment Notes

No special deployment steps required.