### PR TITLE
feat(oga): show OGA action response in UI

### DIFF
--- a/oga/internal/service.go
+++ b/oga/internal/service.go
@@ -66,10 +66,11 @@ type Application struct {
 	TaskID          string           `json:"taskId"`
 	WorkflowID      string           `json:"workflowId"`
 	ServiceURL      string           `json:"serviceUrl"`
-	Data            map[string]any   `json:"data"`
+	Data            map[string]any   `json:"data"`                    // Data from NSW service to be rendered in the UI
+	OgaActionData   map[string]any   `json:"ogaActionData,omitempty"` // Copy of the payload sent back to the NSW after review, for display in the UI
 	Meta            *Meta            `json:"meta,omitempty"`
-	Form            json.RawMessage  `json:"form,omitempty"`
-	OgaForm         json.RawMessage  `json:"ogaForm,omitempty"`
+	DataForm        json.RawMessage  `json:"dataForm,omitempty"` // Schema for rendering the data in Read Only mode in the UI
+	OgaForm         json.RawMessage  `json:"ogaForm,omitempty"`  // Schema for rendering the OGA Action form in the UI
 	Status          string           `json:"status"`
 	FeedbackHistory []feedback.Entry `json:"feedbackHistory,omitempty"`
 	ReviewedAt      *time.Time       `json:"reviewedAt,omitempty"`
@@ -265,6 +266,7 @@ func (s *ogaService) GetApplication(ctx context.Context, taskID string) (*Applic
 		WorkflowID:      record.WorkflowID,
 		ServiceURL:      record.ServiceURL,
 		Data:            record.Data,
+		OgaActionData:   record.ReviewerResponse,
 		Meta:            meta,
 		Status:          record.Status,
 		FeedbackHistory: feedbackHistoryFromRaw(record.OGAFeedbackHistory),
@@ -273,25 +275,25 @@ func (s *ogaService) GetApplication(ctx context.Context, taskID string) (*Applic
 		UpdatedAt:       record.UpdatedAt,
 	}
 
-	// Attach form: look up by meta, fall back to default
+	// Attach oga form: look up by meta, fall back to default
 	formID := FormIDFromMeta(meta)
 	if formID != "" {
-		if form, err := s.formStore.GetForm(formID); err == nil {
-			app.Form = form
+		if ogaForm, err := s.formStore.GetForm(formID); err == nil {
+			app.OgaForm = ogaForm
 		} else {
 			slog.WarnContext(ctx, "form not found for application, using default", "taskID", taskID, "formID", formID)
-			if form, err := s.formStore.GetDefaultForm(); err == nil {
-				app.Form = form
+			if ogaForm, err := s.formStore.GetDefaultForm(); err == nil {
+				app.OgaForm = ogaForm
 			}
 		}
-		// Try to load an oga form (view template)
-		ogaFormID := formID + ".view"
-		if ogaForm, err := s.formStore.GetForm(ogaFormID); err == nil {
-			app.OgaForm = ogaForm
+		// Try to load a separate "view" form for rendering the data in read-only mode in the UI, using a naming convention "{formID}.view"
+		dataViewFormID := formID + ".view"
+		if dataForm, err := s.formStore.GetForm(dataViewFormID); err == nil {
+			app.DataForm = dataForm
 		}
 	} else {
-		if form, err := s.formStore.GetDefaultForm(); err == nil {
-			app.Form = form
+		if ogaForm, err := s.formStore.GetDefaultForm(); err == nil {
+			app.OgaForm = ogaForm
 		}
 	}
 

--- a/portals/apps/oga-app/src/api.ts
+++ b/portals/apps/oga-app/src/api.ts
@@ -113,11 +113,16 @@ export interface OGAApplication {
   workflowId: string;
   serviceUrl: string;
   data: Record<string, unknown>;
+  ogaActionData?: Record<string, unknown>;
   meta?: {
     type: string;
     verificationId: string;
   };
-  form: {
+  dataForm?: {
+    schema: JsonSchema;
+    uiSchema: UISchemaElement;
+  };
+  ogaForm?: {
     schema: JsonSchema;
     uiSchema: UISchemaElement;
   };
@@ -127,10 +132,6 @@ export interface OGAApplication {
   reviewedAt?: string;
   createdAt: string;
   updatedAt: string;
-  ogaForm?: {
-    schema: JsonSchema;
-    uiSchema: UISchemaElement;
-  };
 }
 
 

--- a/portals/apps/oga-app/src/screens/WorkflowDetailScreen.tsx
+++ b/portals/apps/oga-app/src/screens/WorkflowDetailScreen.tsx
@@ -21,8 +21,8 @@ export function WorkflowDetailScreen() {
   const [error, setError] = useState<string | null>(null)
   const [success, setSuccess] = useState(false)
 
-  const [formConfig, setFormConfig] = useState<{ schema: JsonSchema; uiSchema: UISchemaElement } | null>(null)
-  const [formData, setFormData] = useState<Record<string, unknown>>({})
+  const [ogaFormConfig, setOgaFormConfig] = useState<{ schema: JsonSchema; uiSchema: UISchemaElement } | null>(null)
+  const [ogaFormData, setOgaFormData] = useState<Record<string, unknown>>({})
   const [formErrors, setFormErrors] = useState<unknown[]>([])
 
   const [activeTab, setActiveTab] = useState('review')
@@ -58,7 +58,7 @@ export function WorkflowDetailScreen() {
     setIsSubmitting(true)
     setError(null)
     try {
-      await submitReview(apiClient, taskId, formData)
+      await submitReview(apiClient, taskId, ogaFormData)
       setSuccess(true)
       setTimeout(() => navigate('/workflows'), 2000)
     } catch (err) {
@@ -78,7 +78,12 @@ export function WorkflowDetailScreen() {
       try {
         const data = await fetchApplicationDetail(apiClient, taskId)
         setApplication(data)
-        setFormConfig({ schema: data.form.schema, uiSchema: data.form.uiSchema })
+        if (data.ogaForm) {
+          setOgaFormConfig({ schema: data.ogaForm.schema, uiSchema: data.ogaForm.uiSchema })
+        } else {
+          setOgaFormConfig(null)
+        }
+        setOgaFormData(data.ogaActionData || {})
       } catch (err) {
         setError('Failed to load application details')
         console.error(err)
@@ -234,12 +239,12 @@ export function WorkflowDetailScreen() {
                 Submitted Information
               </Text>
               {(() => {
-                if (application.ogaForm) {
+                if (application.dataForm) {
                   return (
                     <Box className="bg-white p-4 rounded border border-gray-100">
                       <JsonForms
-                        schema={application.ogaForm.schema}
-                        uischema={application.ogaForm.uiSchema}
+                        schema={application.dataForm.schema}
+                        uischema={application.dataForm.uiSchema}
                         data={application.data}
                         renderers={radixRenderers}
                         readonly={true}
@@ -297,17 +302,17 @@ export function WorkflowDetailScreen() {
               <Box pt="4">
                 {/* Review Tab */}
                 <Tabs.Content value="review">
-                  {formConfig && isActionable ? (
+                  {ogaFormConfig && isActionable ? (
                       <form onSubmit={(event) => {
                   void handleSubmit(event)
                 }} noValidate>
                         <JsonForms
-                          schema={formConfig.schema}
-                          uischema={formConfig.uiSchema}
-                          data={formData}
+                          schema={ogaFormConfig.schema}
+                          uischema={ogaFormConfig.uiSchema}
+                          data={ogaFormData}
                           renderers={radixRenderers}
                           onChange={({ data, errors }: { data: Record<string, unknown>; errors?: unknown[] }) => {
-                            setFormData(data);
+                            setOgaFormData(data);
                             setFormErrors(errors || []);
                           }}
                         />
@@ -341,15 +346,15 @@ export function WorkflowDetailScreen() {
                           </Button>
                         </Flex>
                       </form>
-                    ) : formConfig ? (
+                    ) : ogaFormConfig ? (
                       <JsonForms
-                        schema={formConfig.schema}
-                        uischema={formConfig.uiSchema}
-                        data={formData}
+                        schema={ogaFormConfig.schema}
+                        uischema={ogaFormConfig.uiSchema}
+                        data={ogaFormData}
                         renderers={radixRenderers}
                         readonly
                         onChange={({ data, errors }: { data: Record<string, unknown>; errors?: unknown[] }) => {
-                          setFormData(data);
+                          setOgaFormData(data);
                           setFormErrors(errors || []);
                         }}
                       />


### PR DESCRIPTION
## Summary

Add support for displaying the OGA officer’s action response in the UI after a task is completed, so previously submitted reviewer actions can be viewed later instead of disappearing after submission.

## Type of Change

- [x] New feature (non-breaking change which adds functionality)

## Changes Made

- Updated the backend application payload to expose both the original submitted data and the OGA action response separately.
- Changed the application detail flow to load a read-only data form for submitted information and a separate OGA action form for reviewer actions.
- Updated the frontend workflow detail screen to render the OGA response data and submit the correct action payload.

## Testing

- [x] I have tested this change locally
- [x] I have added unit tests for new functionality
- [x] I have tested edge cases
- [x] All existing tests pass

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have checked that there are no merge conflicts

## Related Issues

- No issues created

## Additional Notes

This change keeps the applicant’s submitted data visible while also preserving the OGA officer’s completed action response for later review.