### PR TITLE
feat: refactor file uploads to secure presigned URLs and bridge OGA API gateways

### DIFF
--- a/api/openapi-uploads.yaml
+++ b/api/openapi-uploads.yaml
@@ -81,11 +81,10 @@ paths:
 
   /uploads/{key}:
     get:
-      summary: Download File
+      summary: Get File Download URL
       description: >
-        Download a previously uploaded file by its unique key.
-        Returns the file content with the appropriate content type.
-      operationId: downloadFile
+        Fetches a presigned or limited-time URL to securely download the file content.
+      operationId: getDownloadUrl
       tags:
         - Uploads
       parameters:
@@ -98,20 +97,20 @@ paths:
           example: "550e8400-e29b-41d4-a716-446655440000.pdf"
       responses:
         "200":
-          description: File retrieved successfully
+          description: Download URL generated successfully
           content:
-            application/octet-stream:
+            application/json:
               schema:
-                type: string
-                format: binary
-            application/pdf:
-              schema:
-                type: string
-                format: binary
-            image/*:
-              schema:
-                type: string
-                format: binary
+                type: object
+                properties:
+                  download_url:
+                    type: string
+                    description: The presigned URL to download the actual file contents
+                    example: "/api/v1/uploads/550e8400-e29b-41d4-a716-446655440000.pdf/content?token=12345&expiresAt=123"
+                  expires_at:
+                    type: integer
+                    description: Unix timestamp indicating when the link expires
+                    example: 1713256000
         "400":
           description: Bad request - key is required or invalid
           content:

--- a/api/openapi-uploads.yaml
+++ b/api/openapi-uploads.yaml
@@ -29,19 +29,24 @@ paths:
       requestBody:
         required: true
         content:
-          multipart/form-data:
+          application/json:
             schema:
               type: object
               required:
-                - file
+                - filename
+                - mime_type
+                - size
               properties:
-                file:
+                filename:
                   type: string
-                  format: binary
-                  description: The file to upload
-            encoding:
-              file:
-                contentType: application/octet-stream
+                  description: The original filename
+                mime_type:
+                  type: string
+                  description: The MIME type of the file
+                size:
+                  type: integer
+                  format: int64
+                  description: The file size in bytes
       responses:
         "200":
           description: File uploaded successfully
@@ -53,9 +58,10 @@ paths:
                 id: "550e8400-e29b-41d4-a716-446655440000"
                 name: "document.pdf"
                 key: "550e8400-e29b-41d4-a716-446655440000.pdf"
-                url: "/bucket/550e8400-e29b-41d4-a716-446655440000.pdf"
+                url: "/api/v1/uploads/550e8400-e29b-41d4-a716-446655440000.pdf/content"
+                upload_url: "/api/v1/uploads/local-put/550e8400-e29b-41d4-a716-446655440000.pdf?token=..."
                 size: 1024000
-                mimeType: "application/pdf"
+                mime_type: "application/pdf"
         "400":
           description: Bad request - file is required or invalid
           content:
@@ -168,11 +174,9 @@ components:
       type: object
       required:
         - id
-        - name
         - key
-        - url
         - size
-        - mimeType
+        - mime_type
       properties:
         id:
           type: string
@@ -190,13 +194,17 @@ components:
         url:
           type: string
           description: Public URL to access the file
-          example: "/bucket/550e8400-e29b-41d4-a716-446655440000.pdf"
+          example: "/api/v1/uploads/550e8400-e29b-41d4-a716-446655440000.pdf/content"
+        upload_url:
+          type: string
+          description: Presigned or local URL for uploading the file content
+          example: "/api/v1/uploads/local-put/550e8400-e29b-41d4-a716-446655440000.pdf?token=..."
         size:
           type: integer
           format: int64
           description: File size in bytes
           example: 1024000
-        mimeType:
+        mime_type:
           type: string
           description: MIME type of the uploaded file
           example: "application/pdf"

--- a/backend/internal/app/bootstrap/app.go
+++ b/backend/internal/app/bootstrap/app.go
@@ -272,9 +272,9 @@ func Build(ctx context.Context, cfg *config.Config) (*App, error) {
 	mux.Handle("POST /api/v1/payments/webhook", http.HandlerFunc(paymentHandler.HandleWebhook))
 	mux.Handle("POST /api/v1/payments/validate", http.HandlerFunc(paymentHandler.HandleValidateReference))
 
-	// When using local storage, this endpoint serves the actual file bytes.
-	// It's made public since it's the equivalent of a presigned URL when using S3.
+	// When using local storage, these endpoints serve as mocks for S3.
 	if _, ok := storageDriver.(*drivers.LocalFSDriver); ok {
+		mux.HandleFunc("PUT /api/v1/uploads/local-put/{key}", uploadHandler.UploadContentLocal)
 		mux.HandleFunc("GET /api/v1/uploads/{key}/content", uploadHandler.DownloadContent)
 	}
 

--- a/backend/internal/config/config.go
+++ b/backend/internal/config/config.go
@@ -61,6 +61,7 @@ type StorageConfig struct {
 	S3SecretKey    string
 	S3UseSSL       bool
 	S3PublicURL    string
+	LocalPutSecret string
 }
 
 type AuthConfig struct {
@@ -123,6 +124,7 @@ func Load() (*Config, error) {
 			S3SecretKey:    os.Getenv("STORAGE_S3_SECRET_KEY"),
 			S3UseSSL:       getBoolOrDefault("STORAGE_S3_USE_SSL", true),
 			S3PublicURL:    os.Getenv("STORAGE_S3_PUBLIC_URL"),
+			LocalPutSecret: getEnvOrDefault("STORAGE_LOCAL_PUT_SECRET", "local-dev-secret"),
 		},
 		Auth: AuthConfig{
 			JWKSURL:               getEnvOrDefault("AUTH_JWKS_URL", "https://localhost:8090/oauth2/jwks"),

--- a/backend/internal/uploads/drivers/local_fs.go
+++ b/backend/internal/uploads/drivers/local_fs.go
@@ -26,7 +26,7 @@ var (
 type LocalFSDriver struct {
 	BaseDir   string
 	PublicURL string
-	SecretKey string
+	secretKey string
 }
 
 // NewLocalFSDriver creates a new LocalFSDriver.
@@ -37,7 +37,7 @@ func NewLocalFSDriver(baseDir, publicURL, secretKey string) (*LocalFSDriver, err
 	if err := os.MkdirAll(baseDir, 0755); err != nil {
 		return nil, fmt.Errorf("failed to create base directory: %w", err)
 	}
-	return &LocalFSDriver{BaseDir: baseDir, PublicURL: publicURL, SecretKey: secretKey}, nil
+	return &LocalFSDriver{BaseDir: baseDir, PublicURL: publicURL, secretKey: secretKey}, nil
 }
 
 // getHashedPath generates a two-level deep path for a key to avoid flat directory issues.
@@ -144,8 +144,11 @@ func (d *LocalFSDriver) GetDownloadURL(ctx context.Context, key string, ttl time
 		return key, nil
 	}
 
+	if ttl == 0 {
+		ttl = 15 * time.Minute
+	}
 	expiresAt := time.Now().Add(ttl).Unix()
-	token := GenerateDownloadToken(key, d.SecretKey, expiresAt)
+	token := GenerateDownloadToken(key, d.secretKey, expiresAt)
 
 	// Returns a URL with security token and expiration
 	v := url.Values{}
@@ -157,7 +160,7 @@ func (d *LocalFSDriver) GetDownloadURL(ctx context.Context, key string, ttl time
 
 // VerifyDownloadToken checks if a provided download token is valid and not expired.
 func (d *LocalFSDriver) VerifyDownloadToken(key, token string, expiresAt int64) bool {
-	return VerifyDownloadToken(key, token, d.SecretKey, expiresAt)
+	return VerifyDownloadToken(key, token, d.secretKey, expiresAt)
 }
 
 func (d *LocalFSDriver) GetUploadURL(ctx context.Context, key string, ttl time.Duration, contentType string, maxSizeBytes int64) (string, error) {
@@ -165,8 +168,11 @@ func (d *LocalFSDriver) GetUploadURL(ctx context.Context, key string, ttl time.D
 		return "", fmt.Errorf("public URL not configured for local storage")
 	}
 
+	if ttl == 0 {
+		ttl = 15 * time.Minute
+	}
 	expiresAt := time.Now().Add(ttl).Unix()
-	token := GenerateToken(key, d.SecretKey, expiresAt, contentType, maxSizeBytes)
+	token := GenerateToken(key, d.secretKey, expiresAt, contentType, maxSizeBytes)
 
 	// Returns a URL pointing back to our local PUT handler with security constraints encoded
 	v := url.Values{}
@@ -181,5 +187,5 @@ func (d *LocalFSDriver) GetUploadURL(ctx context.Context, key string, ttl time.D
 
 // VerifyToken checks if a token is valid for a given key and constraints using the driver's secret.
 func (d *LocalFSDriver) VerifyToken(key, token string, expiresAt int64, contentType string, maxSizeBytes int64) bool {
-	return VerifyToken(key, token, d.SecretKey, expiresAt, contentType, maxSizeBytes)
+	return VerifyToken(key, token, d.secretKey, expiresAt, contentType, maxSizeBytes)
 }

--- a/backend/internal/uploads/drivers/local_fs.go
+++ b/backend/internal/uploads/drivers/local_fs.go
@@ -2,14 +2,13 @@ package drivers
 
 import (
 	"context"
-	"crypto/hmac"
-	"crypto/sha256"
-	"encoding/hex"
 	"errors"
 	"fmt"
 	"io"
+	"net/url"
 	"os"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"time"
 )
@@ -27,16 +26,18 @@ var (
 type LocalFSDriver struct {
 	BaseDir   string
 	PublicURL string
+	SecretKey string
 }
 
 // NewLocalFSDriver creates a new LocalFSDriver.
 // baseDir is where files will be stored.
 // publicURL is the base URL used to generate public links (e.g., /api/uploads).
-func NewLocalFSDriver(baseDir, publicURL string) (*LocalFSDriver, error) {
+// secretKey is the secret used for HMAC signing of local-put upload URLs.
+func NewLocalFSDriver(baseDir, publicURL, secretKey string) (*LocalFSDriver, error) {
 	if err := os.MkdirAll(baseDir, 0755); err != nil {
 		return nil, fmt.Errorf("failed to create base directory: %w", err)
 	}
-	return &LocalFSDriver{BaseDir: baseDir, PublicURL: publicURL}, nil
+	return &LocalFSDriver{BaseDir: baseDir, PublicURL: publicURL, SecretKey: secretKey}, nil
 }
 
 // getHashedPath generates a two-level deep path for a key to avoid flat directory issues.
@@ -150,12 +151,21 @@ func (d *LocalFSDriver) GetUploadURL(ctx context.Context, key string, ttl time.D
 		return "", fmt.Errorf("public URL not configured for local storage")
 	}
 
-	// Generate a basic HMAC token for local dev security
-	secret := "local-dev-secret"
-	h := hmac.New(sha256.New, []byte(secret))
-	h.Write([]byte(key))
-	token := hex.EncodeToString(h.Sum(nil))
+	expiresAt := time.Now().Add(ttl).Unix()
+	token := GenerateToken(key, d.SecretKey, expiresAt, contentType, maxSizeBytes)
 
-	// Returns a URL pointing back to our local PUT handler with a security token
-	return fmt.Sprintf("%s/api/v1/uploads/local-put/%s?token=%s", d.PublicURL, key, token), nil
+	// Returns a URL pointing back to our local PUT handler with security constraints encoded
+	v := url.Values{}
+	v.Set("token", token)
+	v.Set("expiresAt", strconv.FormatInt(expiresAt, 10))
+	v.Set("contentType", contentType)
+	v.Set("maxSizeBytes", strconv.FormatInt(maxSizeBytes, 10))
+
+	return fmt.Sprintf("%s/api/v1/uploads/local-put/%s?%s",
+		d.PublicURL, key, v.Encode()), nil
+}
+
+// VerifyToken checks if a token is valid for a given key and constraints using the driver's secret.
+func (d *LocalFSDriver) VerifyToken(key, token string, expiresAt int64, contentType string, maxSizeBytes int64) bool {
+	return VerifyToken(key, token, d.SecretKey, expiresAt, contentType, maxSizeBytes)
 }

--- a/backend/internal/uploads/drivers/local_fs.go
+++ b/backend/internal/uploads/drivers/local_fs.go
@@ -143,7 +143,21 @@ func (d *LocalFSDriver) GetDownloadURL(ctx context.Context, key string, ttl time
 	if d.PublicURL == "" {
 		return key, nil
 	}
-	return fmt.Sprintf("%s/api/v1/uploads/%s/content", d.PublicURL, key), nil
+
+	expiresAt := time.Now().Add(ttl).Unix()
+	token := GenerateDownloadToken(key, d.SecretKey, expiresAt)
+
+	// Returns a URL with security token and expiration
+	v := url.Values{}
+	v.Set("token", token)
+	v.Set("expiresAt", strconv.FormatInt(expiresAt, 10))
+
+	return fmt.Sprintf("%s/api/v1/uploads/%s/content?%s", d.PublicURL, key, v.Encode()), nil
+}
+
+// VerifyDownloadToken checks if a provided download token is valid and not expired.
+func (d *LocalFSDriver) VerifyDownloadToken(key, token string, expiresAt int64) bool {
+	return VerifyDownloadToken(key, token, d.SecretKey, expiresAt)
 }
 
 func (d *LocalFSDriver) GetUploadURL(ctx context.Context, key string, ttl time.Duration, contentType string, maxSizeBytes int64) (string, error) {

--- a/backend/internal/uploads/drivers/local_fs.go
+++ b/backend/internal/uploads/drivers/local_fs.go
@@ -2,6 +2,9 @@ package drivers
 
 import (
 	"context"
+	"crypto/hmac"
+	"crypto/sha256"
+	"encoding/hex"
 	"errors"
 	"fmt"
 	"io"
@@ -140,4 +143,19 @@ func (d *LocalFSDriver) GetDownloadURL(ctx context.Context, key string, ttl time
 		return key, nil
 	}
 	return fmt.Sprintf("%s/api/v1/uploads/%s/content", d.PublicURL, key), nil
+}
+
+func (d *LocalFSDriver) GetUploadURL(ctx context.Context, key string, ttl time.Duration, contentType string, maxSizeBytes int64) (string, error) {
+	if d.PublicURL == "" {
+		return "", fmt.Errorf("public URL not configured for local storage")
+	}
+
+	// Generate a basic HMAC token for local dev security
+	secret := "local-dev-secret"
+	h := hmac.New(sha256.New, []byte(secret))
+	h.Write([]byte(key))
+	token := hex.EncodeToString(h.Sum(nil))
+
+	// Returns a URL pointing back to our local PUT handler with a security token
+	return fmt.Sprintf("%s/api/v1/uploads/local-put/%s?token=%s", d.PublicURL, key, token), nil
 }

--- a/backend/internal/uploads/drivers/local_fs_test.go
+++ b/backend/internal/uploads/drivers/local_fs_test.go
@@ -19,7 +19,7 @@ func TestLocalFSDriver_DirectoryHashing(t *testing.T) {
 	}
 	defer os.RemoveAll(tempDir)
 
-	driver, err := NewLocalFSDriver(tempDir, "/uploads")
+	driver, err := NewLocalFSDriver(tempDir, "/uploads", "local-dev-secret")
 	if err != nil {
 		t.Fatalf("failed to create driver: %v", err)
 	}
@@ -81,7 +81,7 @@ func TestLocalFSDriver_RejectsPathTraversal(t *testing.T) {
 	}
 	defer os.RemoveAll(tempDir)
 
-	driver, err := NewLocalFSDriver(tempDir, "/uploads")
+	driver, err := NewLocalFSDriver(tempDir, "/uploads", "local-dev-secret")
 	if err != nil {
 		t.Fatalf("failed to create driver: %v", err)
 	}
@@ -113,7 +113,7 @@ func TestLocalFSDriver_ConcurrentWritesSameDir(t *testing.T) {
 	}
 	defer os.RemoveAll(tempDir)
 
-	driver, err := NewLocalFSDriver(tempDir, "/uploads")
+	driver, err := NewLocalFSDriver(tempDir, "/uploads", "local-dev-secret")
 	if err != nil {
 		t.Fatalf("failed to create driver: %v", err)
 	}
@@ -168,7 +168,7 @@ func TestLocalFSDriver_RejectsKeyWithNullOrSpecialChars(t *testing.T) {
 	}
 	defer os.RemoveAll(tempDir)
 
-	driver, err := NewLocalFSDriver(tempDir, "/uploads")
+	driver, err := NewLocalFSDriver(tempDir, "/uploads", "local-dev-secret")
 	if err != nil {
 		t.Fatalf("failed to create driver: %v", err)
 	}
@@ -196,7 +196,7 @@ func TestLocalFSDriver_PathTraversal(t *testing.T) {
 	}
 	defer os.RemoveAll(tempDir)
 
-	driver, err := NewLocalFSDriver(tempDir, "/uploads")
+	driver, err := NewLocalFSDriver(tempDir, "/uploads", "local-dev-secret")
 	if err != nil {
 		t.Fatalf("failed to create driver: %v", err)
 	}
@@ -219,7 +219,7 @@ func BenchmarkLocalFSDriver_Get(b *testing.B) {
 	}
 	defer os.RemoveAll(tempDir)
 
-	driver, err := NewLocalFSDriver(tempDir, "/uploads")
+	driver, err := NewLocalFSDriver(tempDir, "/uploads", "local-dev-secret")
 	if err != nil {
 		b.Fatal(err)
 	}

--- a/backend/internal/uploads/drivers/local_fs_test.go
+++ b/backend/internal/uploads/drivers/local_fs_test.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 	"sync"
 	"testing"
+	"time"
 )
 
 func TestLocalFSDriver_DirectoryHashing(t *testing.T) {
@@ -53,14 +54,13 @@ func TestLocalFSDriver_DirectoryHashing(t *testing.T) {
 		t.Errorf("expected content type application/pdf, got %s", contentType)
 	}
 
-	// Verify GetDownloadURL
+	// Verify GetDownloadURL: should be tokenized and include /uploads
 	url, err := driver.GetDownloadURL(ctx, key, 0)
 	if err != nil {
 		t.Errorf("GetDownloadURL failed: %v", err)
 	}
-	expectedSuffix := key + "/content"
-	if !strings.HasSuffix(url, expectedSuffix) || !strings.Contains(url, "/uploads") {
-		t.Errorf("unexpected URL: %s", url)
+	if !strings.Contains(url, "/uploads") || !strings.Contains(url, "token=") || !strings.Contains(url, "expiresAt=") {
+		t.Errorf("unexpected URL format: %s", url)
 	}
 
 	// Test Delete
@@ -241,5 +241,36 @@ func BenchmarkLocalFSDriver_Get(b *testing.B) {
 		}
 		_, _ = io.Copy(io.Discard, r)
 		r.Close()
+	}
+}
+
+func TestLocalFSDriver_LinkVerification(t *testing.T) {
+	tempDir, _ := os.MkdirTemp("", "localfs-link")
+	defer os.RemoveAll(tempDir)
+
+	secret := "test-secret"
+	driver, _ := NewLocalFSDriver(tempDir, "/uploads", secret)
+	key := "test-file.pdf"
+
+	// 1. Valid Link
+	expiresAt := time.Now().Add(time.Hour).Unix()
+	token := GenerateDownloadToken(key, secret, expiresAt)
+	if !driver.VerifyDownloadToken(key, token, expiresAt) {
+		t.Error("valid token failed verification")
+	}
+
+	// 2. Invalid Key
+	if driver.VerifyDownloadToken("wrong-key.pdf", token, expiresAt) {
+		t.Error("token verified for wrong key")
+	}
+
+	// 3. Modified Expiration
+	if driver.VerifyDownloadToken(key, token, expiresAt+1) {
+		t.Error("token verified despite modified expiration")
+	}
+
+	// 4. Invalid Signature
+	if driver.VerifyDownloadToken(key, "invalid-token", expiresAt) {
+		t.Error("invalid token signature was accepted")
 	}
 }

--- a/backend/internal/uploads/drivers/s3_driver.go
+++ b/backend/internal/uploads/drivers/s3_driver.go
@@ -90,3 +90,21 @@ func (d *S3Driver) GetDownloadURL(ctx context.Context, key string, ttl time.Dura
 	}
 	return d.presignGet(ctx, key, ttl)
 }
+
+func (d *S3Driver) GetUploadURL(ctx context.Context, key string, ttl time.Duration, contentType string, maxSizeBytes int64) (string, error) {
+	if ttl == 0 {
+		ttl = 15 * time.Minute
+	}
+
+	presignedReq, err := d.PresignClient.PresignPutObject(ctx, &s3.PutObjectInput{
+		Bucket:        aws.String(d.Bucket),
+		Key:           aws.String(key),
+		ContentType:   aws.String(contentType),
+		ContentLength: aws.Int64(maxSizeBytes),
+	}, s3.WithPresignExpires(ttl))
+	if err != nil {
+		return "", fmt.Errorf("failed to presign upload URL: %w", err)
+	}
+
+	return presignedReq.URL, nil
+}

--- a/backend/internal/uploads/drivers/token.go
+++ b/backend/internal/uploads/drivers/token.go
@@ -1,0 +1,25 @@
+package drivers
+
+import (
+	"crypto/hmac"
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+)
+
+// GenerateToken creates an HMAC-SHA256 token signing multiple constraints.
+func GenerateToken(key, secret string, expiresAt int64, contentType string, maxSizeBytes int64) string {
+	payload := fmt.Sprintf("%s:%d:%s:%d", key, expiresAt, contentType, maxSizeBytes)
+	mac := hmac.New(sha256.New, []byte(secret))
+	mac.Write([]byte(payload))
+	return hex.EncodeToString(mac.Sum(nil))
+}
+
+// VerifyToken checks if a provided token matches the expected signature for given constraints.
+func VerifyToken(key, token, secret string, expiresAt int64, contentType string, maxSizeBytes int64) bool {
+	if token == "" || secret == "" {
+		return false
+	}
+	expected := GenerateToken(key, secret, expiresAt, contentType, maxSizeBytes)
+	return hmac.Equal([]byte(token), []byte(expected))
+}

--- a/backend/internal/uploads/drivers/token.go
+++ b/backend/internal/uploads/drivers/token.go
@@ -23,3 +23,20 @@ func VerifyToken(key, token, secret string, expiresAt int64, contentType string,
 	expected := GenerateToken(key, secret, expiresAt, contentType, maxSizeBytes)
 	return hmac.Equal([]byte(token), []byte(expected))
 }
+
+// GenerateDownloadToken creates an HMAC-SHA256 token specifically for download links (only signs key and expiration).
+func GenerateDownloadToken(key, secret string, expiresAt int64) string {
+	payload := fmt.Sprintf("%s:%d", key, expiresAt)
+	mac := hmac.New(sha256.New, []byte(secret))
+	mac.Write([]byte(payload))
+	return hex.EncodeToString(mac.Sum(nil))
+}
+
+// VerifyDownloadToken checks if a provided download token matches the expected signature.
+func VerifyDownloadToken(key, token, secret string, expiresAt int64) bool {
+	if token == "" || secret == "" {
+		return false
+	}
+	expected := GenerateDownloadToken(key, secret, expiresAt)
+	return hmac.Equal([]byte(token), []byte(expected))
+}

--- a/backend/internal/uploads/factory.go
+++ b/backend/internal/uploads/factory.go
@@ -20,7 +20,7 @@ func NewStorageFromConfig(ctx context.Context, cfg config.StorageConfig) (Storag
 	switch strings.TrimSpace(cfg.Type) {
 	case "local":
 		slog.Info("Initializing local storage", "dir", cfg.LocalBaseDir)
-		return drivers.NewLocalFSDriver(cfg.LocalBaseDir, cfg.LocalPublicURL)
+		return drivers.NewLocalFSDriver(cfg.LocalBaseDir, cfg.LocalPublicURL, cfg.LocalPutSecret)
 	case "s3":
 		slog.Info("Initializing S3 storage", "endpoint", cfg.S3Endpoint, "bucket", cfg.S3Bucket)
 

--- a/backend/internal/uploads/http_handler.go
+++ b/backend/internal/uploads/http_handler.go
@@ -1,9 +1,6 @@
 package uploads
 
 import (
-	"crypto/hmac"
-	"crypto/sha256"
-	"encoding/hex"
 	"encoding/json"
 	"io"
 	"log/slog"
@@ -11,6 +8,7 @@ import (
 	"os"
 	"regexp"
 	"strconv"
+	"strings"
 	"time"
 
 	"github.com/OpenNSW/nsw/internal/auth"
@@ -124,44 +122,65 @@ func (h *HTTPHandler) UploadContentLocal(w http.ResponseWriter, r *http.Request)
 		return
 	}
 
-	// Verify security token (HMAC)
+	// Extract security constraints from query parameters
 	token := r.URL.Query().Get("token")
-	if token == "" {
-		writeJSONError(w, http.StatusUnauthorized, "missing security token")
+	expiresAtStr := r.URL.Query().Get("expiresAt")
+	encodedContentType := r.URL.Query().Get("contentType")
+	maxSizeBytesStr := r.URL.Query().Get("maxSizeBytes")
+
+	if token == "" || expiresAtStr == "" || encodedContentType == "" || maxSizeBytesStr == "" {
+		writeJSONError(w, http.StatusUnauthorized, "missing security token or constraints")
 		return
 	}
 
-	secret := "local-dev-secret"
-	mac := hmac.New(sha256.New, []byte(secret))
-	mac.Write([]byte(key))
-	expectedToken := hex.EncodeToString(mac.Sum(nil))
+	expiresAt, err := strconv.ParseInt(expiresAtStr, 10, 64)
+	if err != nil {
+		writeJSONError(w, http.StatusBadRequest, "invalid expiration format")
+		return
+	}
 
-	if !hmac.Equal([]byte(token), []byte(expectedToken)) {
+	maxSizeBytes, err := strconv.ParseInt(maxSizeBytesStr, 10, 64)
+	if err != nil {
+		writeJSONError(w, http.StatusBadRequest, "invalid max size format")
+		return
+	}
+
+	// Verify HMAC token (signs all constraints)
+	if !driver.VerifyToken(key, token, expiresAt, encodedContentType, maxSizeBytes) {
 		writeJSONError(w, http.StatusUnauthorized, "invalid security token")
 		return
 	}
 
-	// Get the length and content type if provided
-	contentType := r.Header.Get("Content-Type")
-	if contentType == "" {
-		contentType = "application/octet-stream"
-	}
-
-	// Enforce Local MIME Type Allowlist
-	if !isAllowedContentType(contentType) {
-		writeJSONError(w, http.StatusUnsupportedMediaType, "unsupported media type")
+	// 1. Enforce TTL (Time-To-Live)
+	if time.Now().Unix() > expiresAt {
+		writeJSONError(w, http.StatusForbidden, "upload link expired")
 		return
 	}
 
-	// Prevent Local Disk Exhaustion (DoS) - enforce 32MB limit
-	r.Body = http.MaxBytesReader(w, r.Body, 32<<20)
+	// 2. Enforce Content-Type (Strict Check)
+	var contentType string
+	contentType = r.Header.Get("Content-Type")
+	if contentType == "" {
+		contentType = "application/octet-stream"
+	}
+	if contentType != encodedContentType {
+		writeJSONError(w, http.StatusUnsupportedMediaType, "content-type mismatch")
+		return
+	}
+
+	// 3. Prevent Local Disk Exhaustion (DoS) - enforce dynamic limit from URL
+	r.Body = http.MaxBytesReader(w, r.Body, maxSizeBytes)
 
 	// Save using the local driver
-	err := driver.Save(r.Context(), key, r.Body, contentType)
+	err = driver.Save(r.Context(), key, r.Body, contentType)
 	if err != nil {
 		slog.ErrorContext(r.Context(), "Local upload failed", "key", key, "error", err)
-		// MaxBytesReader returns a specific error when exceeded, but driver.Save might wrap it.
-		writeJSONError(w, http.StatusInternalServerError, "failed to save file")
+		// MaxBytesReader returns a specific error when exceeded
+		if strings.Contains(err.Error(), "http: request body too large") {
+			writeJSONError(w, http.StatusRequestEntityTooLarge, "file size exceeds specified limit")
+		} else {
+			writeJSONError(w, http.StatusInternalServerError, "failed to save file")
+		}
 		return
 	}
 

--- a/backend/internal/uploads/http_handler.go
+++ b/backend/internal/uploads/http_handler.go
@@ -228,7 +228,8 @@ func (h *HTTPHandler) DownloadContent(w http.ResponseWriter, r *http.Request) {
 	// This endpoint is only available when using LocalFSDriver (local development).
 	// It serves the same role as an S3 presigned URL — no auth required since the
 	// caller was already authenticated when obtaining the URL via GET /uploads/{key}.
-	if _, ok := h.Service.Driver.(*drivers.LocalFSDriver); !ok {
+	driver, ok := h.Service.Driver.(*drivers.LocalFSDriver)
+	if !ok {
 		writeJSONError(w, http.StatusNotFound, "not found")
 		return
 	}
@@ -240,6 +241,32 @@ func (h *HTTPHandler) DownloadContent(w http.ResponseWriter, r *http.Request) {
 	}
 	if !validStorageKey(key) {
 		writeJSONError(w, http.StatusBadRequest, "invalid key format")
+		return
+	}
+
+	// Extract and verify security constraints
+	token := r.URL.Query().Get("token")
+	expiresAtStr := r.URL.Query().Get("expiresAt")
+	if token == "" || expiresAtStr == "" {
+		writeJSONError(w, http.StatusUnauthorized, "missing security token or expiration")
+		return
+	}
+
+	expiresAt, err := strconv.ParseInt(expiresAtStr, 10, 64)
+	if err != nil {
+		writeJSONError(w, http.StatusBadRequest, "invalid expiration format")
+		return
+	}
+
+	// Verify HMAC signature
+	if !driver.VerifyDownloadToken(key, token, expiresAt) {
+		writeJSONError(w, http.StatusUnauthorized, "invalid security token")
+		return
+	}
+
+	// Enforce TTL
+	if time.Now().Unix() > expiresAt {
+		writeJSONError(w, http.StatusForbidden, "download link expired")
 		return
 	}
 

--- a/backend/internal/uploads/http_handler.go
+++ b/backend/internal/uploads/http_handler.go
@@ -1,6 +1,9 @@
 package uploads
 
 import (
+	"crypto/hmac"
+	"crypto/sha256"
+	"encoding/hex"
 	"encoding/json"
 	"io"
 	"log/slog"
@@ -55,47 +58,38 @@ func (h *HTTPHandler) Upload(w http.ResponseWriter, r *http.Request) {
 		writeJSONError(w, http.StatusUnauthorized, "Unauthorized")
 		return
 	}
-	r.Body = http.MaxBytesReader(w, r.Body, 32<<20)
 
-	if err := r.ParseMultipartForm(32 << 20); err != nil {
-		writeJSONError(w, http.StatusBadRequest, "failed to parse form or request too large")
+	var req struct {
+		Filename string `json:"filename"`
+		MimeType string `json:"mime_type"`
+		Size     int64  `json:"size"`
+	}
+
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		writeJSONError(w, http.StatusBadRequest, "invalid request body")
 		return
 	}
 
-	file, header, err := r.FormFile("file")
-	if err != nil {
-		writeJSONError(w, http.StatusBadRequest, "file is required")
+	if req.Filename == "" || req.MimeType == "" || req.Size <= 0 {
+		writeJSONError(w, http.StatusBadRequest, "filename, mime_type, and size are required")
 		return
 	}
-	defer func() { _ = file.Close() }()
 
-	// Derive a trustworthy content type from the actual bytes when possible.
-	// We avoid trusting client-supplied multipart headers for security and accuracy.
-	mimeType := header.Header.Get("Content-Type")
-	if seeker, ok := file.(io.ReadSeeker); ok {
-		// Sniff content type from the first 512 bytes.
-		sniffBuf := make([]byte, 512)
-		n, _ := seeker.Read(sniffBuf)
-		if n > 0 {
-			mimeType = http.DetectContentType(sniffBuf[:n])
-		}
-
-		// Rewind so the upload service can read from the beginning. The service
-		// is responsible for reporting the actual number of bytes written.
-		_, _ = seeker.Seek(0, io.SeekStart)
+	// Enforce 32MB limit as per requirements
+	if req.Size > 32<<20 {
+		writeJSONError(w, http.StatusBadRequest, "file size exceeds 32MB limit")
+		return
 	}
 
-	if !isAllowedContentType(mimeType) {
+	if !isAllowedContentType(req.MimeType) {
 		writeJSONError(w, http.StatusUnsupportedMediaType, "invalid or prohibited file type")
 		return
 	}
 
-	// NOTE: The service layer is responsible for determining the actual number
-	// of bytes written; the size passed here is treated only as a hint.
-	metadata, err := h.Service.Upload(r.Context(), header.Filename, file, header.Size, mimeType)
+	metadata, err := h.Service.Upload(r.Context(), req.Filename, req.Size, req.MimeType)
 	if err != nil {
-		slog.ErrorContext(r.Context(), "Upload failed", "error", err)
-		writeJSONError(w, http.StatusInternalServerError, "upload failed")
+		slog.ErrorContext(r.Context(), "Upload preparation failed", "error", err)
+		writeJSONError(w, http.StatusInternalServerError, "failed to prepare upload")
 		return
 	}
 
@@ -103,6 +97,75 @@ func (h *HTTPHandler) Upload(w http.ResponseWriter, r *http.Request) {
 	if err := json.NewEncoder(w).Encode(metadata); err != nil {
 		slog.ErrorContext(r.Context(), "Failed to encode response", "error", err)
 	}
+}
+
+// UploadContentLocal acts as a mock S3 bucket for local development.
+// It accepts a PUT request with the raw file body.
+func (h *HTTPHandler) UploadContentLocal(w http.ResponseWriter, r *http.Request) {
+	// This endpoint is only available when using LocalFSDriver (local development).
+	driver, ok := h.Service.Driver.(*drivers.LocalFSDriver)
+	if !ok {
+		writeJSONError(w, http.StatusNotFound, "not found")
+		return
+	}
+
+	if r.Method != http.MethodPut {
+		writeJSONError(w, http.StatusMethodNotAllowed, "method not allowed")
+		return
+	}
+
+	key := r.PathValue("key")
+	if key == "" {
+		writeJSONError(w, http.StatusBadRequest, "key is required")
+		return
+	}
+	if !validStorageKey(key) {
+		writeJSONError(w, http.StatusBadRequest, "invalid key format")
+		return
+	}
+
+	// Verify security token (HMAC)
+	token := r.URL.Query().Get("token")
+	if token == "" {
+		writeJSONError(w, http.StatusUnauthorized, "missing security token")
+		return
+	}
+
+	secret := "local-dev-secret"
+	mac := hmac.New(sha256.New, []byte(secret))
+	mac.Write([]byte(key))
+	expectedToken := hex.EncodeToString(mac.Sum(nil))
+
+	if !hmac.Equal([]byte(token), []byte(expectedToken)) {
+		writeJSONError(w, http.StatusUnauthorized, "invalid security token")
+		return
+	}
+
+	// Get the length and content type if provided
+	contentType := r.Header.Get("Content-Type")
+	if contentType == "" {
+		contentType = "application/octet-stream"
+	}
+
+	// Enforce Local MIME Type Allowlist
+	if !isAllowedContentType(contentType) {
+		writeJSONError(w, http.StatusUnsupportedMediaType, "unsupported media type")
+		return
+	}
+
+	// Prevent Local Disk Exhaustion (DoS) - enforce 32MB limit
+	r.Body = http.MaxBytesReader(w, r.Body, 32<<20)
+
+	// Save using the local driver
+	err := driver.Save(r.Context(), key, r.Body, contentType)
+	if err != nil {
+		slog.ErrorContext(r.Context(), "Local upload failed", "key", key, "error", err)
+		// MaxBytesReader returns a specific error when exceeded, but driver.Save might wrap it.
+		writeJSONError(w, http.StatusInternalServerError, "failed to save file")
+		return
+	}
+
+	w.WriteHeader(http.StatusNoContent)
 }
 
 func (h *HTTPHandler) Download(w http.ResponseWriter, r *http.Request) {

--- a/backend/internal/uploads/http_handler_test.go
+++ b/backend/internal/uploads/http_handler_test.go
@@ -3,9 +3,12 @@ package uploads
 import (
 	"bytes"
 	"context"
+	"crypto/hmac"
+	"crypto/sha256"
+	"encoding/hex"
 	"encoding/json"
 	"errors"
-	"mime/multipart"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -163,18 +166,15 @@ func TestDownload_InvalidKeyFormat(t *testing.T) {
 func TestUpload_Unauthorized(t *testing.T) {
 	handler := NewHTTPHandler(NewUploadService(&MockDriver{}))
 
-	var buf bytes.Buffer
-	w := multipart.NewWriter(&buf)
-	part, _ := w.CreateFormFile("file", "test.pdf")
-	if _, err := part.Write([]byte("content")); err != nil {
-		t.Fatalf("failed to write multipart content: %v", err)
+	body := map[string]any{
+		"filename": "test.pdf",
+		"mime_type": "application/pdf",
+		"size":      1024,
 	}
-	if err := w.Close(); err != nil {
-		t.Fatalf("failed to close multipart writer: %v", err)
-	}
+	jsonBody, _ := json.Marshal(body)
 
-	req := httptest.NewRequest(http.MethodPost, "/uploads", &buf)
-	req.Header.Set("Content-Type", w.FormDataContentType())
+	req := httptest.NewRequest(http.MethodPost, "/uploads", bytes.NewReader(jsonBody))
+	req.Header.Set("Content-Type", "application/json")
 	rec := httptest.NewRecorder()
 
 	handler.Upload(rec, req)
@@ -182,15 +182,84 @@ func TestUpload_Unauthorized(t *testing.T) {
 	if rec.Code != http.StatusUnauthorized {
 		t.Fatalf("expected status 401, got %d", rec.Code)
 	}
-	if ct := rec.Header().Get("Content-Type"); ct != "application/json" {
-		t.Errorf("expected Content-Type application/json, got %q", ct)
+}
+
+func TestUpload_Success(t *testing.T) {
+	mock := &MockDriver{}
+	handler := NewHTTPHandler(NewUploadService(mock))
+
+	body := map[string]any{
+		"filename":  "test.pdf",
+		"mime_type": "application/pdf",
+		"size":      1024,
 	}
-	var errBody map[string]string
-	if err := json.NewDecoder(rec.Body).Decode(&errBody); err != nil {
-		t.Errorf("expected JSON body: %v", err)
+	jsonBody, _ := json.Marshal(body)
+
+	req := httptest.NewRequest(http.MethodPost, "/uploads", bytes.NewReader(jsonBody))
+	req.Header.Set("Content-Type", "application/json")
+	ctx := withAuthContext(req.Context(), &auth.AuthContext{
+		UserID: "trader-1", UserContext: &auth.UserContext{UserID: "trader-1"},
+	})
+	req = req.WithContext(ctx)
+	rec := httptest.NewRecorder()
+
+	handler.Upload(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected status 200, got %d. Body: %s", rec.Code, rec.Body.String())
 	}
-	if errBody["error"] == "" {
-		t.Error("expected error message in body")
+
+	var metadata FileMetadata
+	if err := json.NewDecoder(rec.Body).Decode(&metadata); err != nil {
+		t.Fatalf("failed to decode response: %v", err)
+	}
+
+	if metadata.Name != "test.pdf" {
+		t.Errorf("expected name test.pdf, got %s", metadata.Name)
+	}
+	if metadata.UploadURL == "" {
+		t.Error("expected upload_url to be populated")
+	}
+}
+
+func TestUploadContentLocal_Success(t *testing.T) {
+	tempDir := t.TempDir()
+	driver, _ := drivers.NewLocalFSDriver(tempDir, "/api/v1/uploads")
+	service := NewUploadService(driver)
+	handler := NewHTTPHandler(service)
+
+	key := "550e8400-e29b-41d4-a716-446655440000.pdf"
+	content := []byte("pdf content")
+
+	// Generate valid HMAC token
+	secret := "local-dev-secret"
+	mac := hmac.New(sha256.New, []byte(secret))
+	mac.Write([]byte(key))
+	token := hex.EncodeToString(mac.Sum(nil))
+
+	req := httptest.NewRequest(http.MethodPut, "/uploads/local-put/"+key+"?token="+token, bytes.NewReader(content))
+	req.SetPathValue("key", key)
+	req.Header.Set("Content-Type", "application/pdf")
+	rec := httptest.NewRecorder()
+
+	handler.UploadContentLocal(rec, req)
+
+	if rec.Code != http.StatusNoContent {
+		t.Fatalf("expected status 204, got %d. Body: %s", rec.Code, rec.Body.String())
+	}
+
+	// Verify file was saved
+	reader, ct, err := driver.Get(context.Background(), key)
+	if err != nil {
+		t.Fatalf("failed to get saved file: %v", err)
+	}
+	defer reader.Close()
+	if ct != "application/pdf" {
+		t.Errorf("expected content type application/pdf, got %s", ct)
+	}
+	savedContent, _ := io.ReadAll(reader)
+	if !bytes.Equal(savedContent, content) {
+		t.Error("saved content does not match")
 	}
 }
 

--- a/backend/internal/uploads/http_handler_test.go
+++ b/backend/internal/uploads/http_handler_test.go
@@ -31,15 +31,27 @@ func TestDownloadContent_LocalDriver_Success(t *testing.T) {
 		t.Fatalf("failed to save test file: %v", err)
 	}
 
-	req := httptest.NewRequest(http.MethodGet, "/uploads/"+key+"/content", nil)
+	// Generate valid signed URL using the driver
+	ttl := 15 * time.Minute
+	downloadURL, err := driver.GetDownloadURL(ctx, key, ttl)
+	if err != nil {
+		t.Fatalf("Failed to get download URL: %v", err)
+	}
+
+	parsedURL, err := url.Parse(downloadURL)
+	if err != nil {
+		t.Fatalf("Failed to parse download URL: %v", err)
+	}
+
+	req := httptest.NewRequest(http.MethodGet, parsedURL.String(), nil)
 	req.SetPathValue("key", key)
 	rec := httptest.NewRecorder()
 
-	// No auth context set — should still succeed because this endpoint is intended to be public.
+	// No auth context set — should still succeed because this endpoint is signature-secured instead of auth-secured.
 	handler.DownloadContent(rec, req)
 
 	if rec.Code != http.StatusOK {
-		t.Fatalf("expected status 200, got %d", rec.Code)
+		t.Fatalf("expected status 200, got %d. Body: %s", rec.Code, rec.Body.String())
 	}
 
 	if rec.Header().Get("Content-Type") != "application/pdf" {

--- a/backend/internal/uploads/http_handler_test.go
+++ b/backend/internal/uploads/http_handler_test.go
@@ -3,15 +3,14 @@ package uploads
 import (
 	"bytes"
 	"context"
-	"crypto/hmac"
-	"crypto/sha256"
-	"encoding/hex"
 	"encoding/json"
 	"errors"
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"net/url"
 	"testing"
+	"time"
 
 	"github.com/OpenNSW/nsw/internal/auth"
 	"github.com/OpenNSW/nsw/internal/uploads/drivers"
@@ -21,7 +20,7 @@ import (
 
 func TestDownloadContent_LocalDriver_Success(t *testing.T) {
 	tempDir := t.TempDir()
-	driver, _ := drivers.NewLocalFSDriver(tempDir, "/api/v1/uploads")
+	driver, _ := drivers.NewLocalFSDriver(tempDir, "/api/v1/uploads", "local-dev-secret")
 	service := NewUploadService(driver)
 	handler := NewHTTPHandler(service)
 
@@ -167,7 +166,7 @@ func TestUpload_Unauthorized(t *testing.T) {
 	handler := NewHTTPHandler(NewUploadService(&MockDriver{}))
 
 	body := map[string]any{
-		"filename": "test.pdf",
+		"filename":  "test.pdf",
 		"mime_type": "application/pdf",
 		"size":      1024,
 	}
@@ -224,20 +223,28 @@ func TestUpload_Success(t *testing.T) {
 
 func TestUploadContentLocal_Success(t *testing.T) {
 	tempDir := t.TempDir()
-	driver, _ := drivers.NewLocalFSDriver(tempDir, "/api/v1/uploads")
+	driver, _ := drivers.NewLocalFSDriver(tempDir, "/api/v1/uploads", "local-dev-secret")
 	service := NewUploadService(driver)
 	handler := NewHTTPHandler(service)
 
 	key := "550e8400-e29b-41d4-a716-446655440000.pdf"
 	content := []byte("pdf content")
 
-	// Generate valid HMAC token
-	secret := "local-dev-secret"
-	mac := hmac.New(sha256.New, []byte(secret))
-	mac.Write([]byte(key))
-	token := hex.EncodeToString(mac.Sum(nil))
+	// Generate valid upload URL using the driver
+	contentType := "application/pdf"
+	maxSizeBytes := int64(32 << 20)
 
-	req := httptest.NewRequest(http.MethodPut, "/uploads/local-put/"+key+"?token="+token, bytes.NewReader(content))
+	uploadURL, err := driver.GetUploadURL(context.Background(), key, 15*time.Minute, contentType, maxSizeBytes)
+	if err != nil {
+		t.Fatalf("Failed to get upload URL: %v", err)
+	}
+
+	parsedURL, err := url.Parse(uploadURL)
+	if err != nil {
+		t.Fatalf("Failed to parse upload URL: %v", err)
+	}
+
+	req := httptest.NewRequest(http.MethodPut, parsedURL.RequestURI(), bytes.NewReader(content))
 	req.SetPathValue("key", key)
 	req.Header.Set("Content-Type", "application/pdf")
 	rec := httptest.NewRecorder()

--- a/backend/internal/uploads/models.go
+++ b/backend/internal/uploads/models.go
@@ -2,10 +2,11 @@ package uploads
 
 // FileMetadata represents the metadata of an uploaded file
 type FileMetadata struct {
-	ID       string `json:"id"`
-	Name     string `json:"name"`
-	Key      string `json:"key"`
-	URL      string `json:"url"`
-	Size     int64  `json:"size"`
-	MimeType string `json:"mime_type"`
+	ID        string `json:"id"`
+	Name      string `json:"name"`
+	Key       string `json:"key"`
+	URL       string `json:"url,omitempty"`
+	UploadURL string `json:"upload_url,omitempty"`
+	Size      int64  `json:"size"`
+	MimeType  string `json:"mime_type"`
 }

--- a/backend/internal/uploads/service.go
+++ b/backend/internal/uploads/service.go
@@ -16,39 +16,13 @@ type UploadService struct {
 	Driver StorageDriver
 }
 
-type countingReader struct {
-	r io.Reader
-	n int64
-}
-
-func (c *countingReader) Read(p []byte) (int, error) {
-	n, err := c.r.Read(p)
-	c.n += int64(n)
-	return n, err
-}
-
-// countingReadSeeker extends countingReader with seeking support.
-// Constructed only when the underlying reader is an io.Seeker, so callers
-// (e.g. the S3 SDK) that type-assert to io.ReadSeeker get a truthful answer.
-type countingReadSeeker struct {
-	*countingReader
-	s io.Seeker
-}
-
-func (c *countingReadSeeker) Seek(offset int64, whence int) (int64, error) {
-	pos, err := c.s.Seek(offset, whence)
-	if err == nil && pos == 0 {
-		c.n = 0
-	}
-	return pos, err
-}
-
 func NewUploadService(driver StorageDriver) *UploadService {
 	return &UploadService{Driver: driver}
 }
 
-// Upload handles the incoming file, saves it via driver, and returns metadata
-func (s *UploadService) Upload(ctx context.Context, filename string, reader io.Reader, size int64, mime string) (*FileMetadata, error) {
+// Upload handles the preparation of a file upload by generating a unique key
+// and a presigned/upload URL via the storage driver.
+func (s *UploadService) Upload(ctx context.Context, filename string, size int64, mime string) (*FileMetadata, error) {
 	if mime == "" {
 		mime = "application/octet-stream"
 	}
@@ -56,33 +30,23 @@ func (s *UploadService) Upload(ctx context.Context, filename string, reader io.R
 	ext := filepath.Ext(filename)
 	key := fmt.Sprintf("%s%s", id, ext)
 
-	// Wrap the reader so we can determine the actual number of bytes written,
-	// rather than trusting any client-supplied size hints.
-	// If the reader supports seeking (e.g. multipart.File), expose it so the
-	// S3 SDK can type-assert to io.ReadSeeker for retries and content-length.
-	cr := &countingReader{r: reader}
-	var body io.Reader = cr
-	if s, ok := reader.(io.Seeker); ok {
-		body = &countingReadSeeker{countingReader: cr, s: s}
-	}
-
-	err := s.Driver.Save(ctx, key, body, mime)
+	// Generate a presigned URL for the upload.
+	// We use a 15-minute TTL by default.
+	uploadURL, err := s.Driver.GetUploadURL(ctx, key, 15*time.Minute, mime, size)
 	if err != nil {
-		return nil, fmt.Errorf("storage driver failed: %w", err)
+		return nil, fmt.Errorf("failed to generate upload URL: %w", err)
 	}
 
 	metadata := &FileMetadata{
-		ID:   id,
-		Name: filename,
-		Key:  key,
-		// URL is not populated by default; clients should call GetDownloadURL
-		// when they need a time-limited or presigned URL for download.
-		URL:      "",
-		Size:     cr.n,
-		MimeType: mime,
+		ID:        id,
+		Name:      filename,
+		Key:       key,
+		UploadURL: uploadURL,
+		Size:      size,
+		MimeType:  mime,
 	}
 
-	slog.InfoContext(ctx, "File uploaded successfully", "id", id, "key", key)
+	slog.InfoContext(ctx, "File upload prepared", "id", id, "key", key)
 	return metadata, nil
 }
 

--- a/backend/internal/uploads/service_test.go
+++ b/backend/internal/uploads/service_test.go
@@ -47,15 +47,23 @@ func (m *MockDriver) GetDownloadURL(ctx context.Context, key string, ttl time.Du
 	return "/test/download/" + key, nil
 }
 
+func (m *MockDriver) GetUploadURL(ctx context.Context, key string, ttl time.Duration, contentType string, maxSizeBytes int64) (string, error) {
+	m.LastTTL = ttl
+	if m.GenerateURLErr != nil {
+		return "", m.GenerateURLErr
+	}
+	return "/test/upload/" + key, nil
+}
+
 func TestUploadService(t *testing.T) {
 	mock := &MockDriver{}
 	service := NewUploadService(mock)
 
 	ctx := context.Background()
 	filename := "test.jpg"
-	content := []byte("image data")
+	size := int64(1024)
 
-	metadata, err := service.Upload(ctx, filename, bytes.NewReader(content), int64(len(content)), "image/jpeg")
+	metadata, err := service.Upload(ctx, filename, size, "image/jpeg")
 	if err != nil {
 		t.Fatalf("Upload failed: %v", err)
 	}
@@ -64,12 +72,12 @@ func TestUploadService(t *testing.T) {
 		t.Errorf("expected name %s, got %s", filename, metadata.Name)
 	}
 
-	if !bytes.Equal(mock.SavedBody, content) {
-		t.Error("saved body does not match input")
+	if metadata.Size != size {
+		t.Errorf("expected size %d, got %d", size, metadata.Size)
 	}
 
-	if metadata.URL != "" {
-		t.Errorf("expected URL to be empty, got %s", metadata.URL)
+	if metadata.UploadURL != "/test/upload/"+metadata.Key {
+		t.Errorf("unexpected upload URL: %s", metadata.UploadURL)
 	}
 }
 

--- a/backend/internal/uploads/storage.go
+++ b/backend/internal/uploads/storage.go
@@ -19,4 +19,7 @@ type StorageDriver interface {
 
 	// GetDownloadURL returns a presigned or time-limited URL for downloading
 	GetDownloadURL(ctx context.Context, key string, ttl time.Duration) (string, error)
+
+	// GetUploadURL returns a presigned URL for uploading a file directly to storage
+	GetUploadURL(ctx context.Context, key string, ttl time.Duration, contentType string, maxSizeBytes int64) (string, error)
 }

--- a/oga/cmd/server/main.go
+++ b/oga/cmd/server/main.go
@@ -73,6 +73,8 @@ func main() {
 	mux.HandleFunc("GET /api/oga/applications/{taskId}", handler.HandleGetApplication)
 	mux.HandleFunc("POST /api/oga/applications/{taskId}/review", handler.HandleReviewApplication)
 	mux.HandleFunc("POST /api/oga/applications/{taskId}/feedback", feedbackHandler.HandleFeedback)
+
+	mux.HandleFunc("POST /api/oga/uploads", handler.HandleCreateUpload)
 	mux.HandleFunc("GET /api/oga/uploads/{key}", handler.HandleGetUploadURL)
 
 	// Set up graceful shutdown

--- a/oga/internal/handler.go
+++ b/oga/internal/handler.go
@@ -247,3 +247,26 @@ func (h *OGAHandler) HandleGetUploadURL(w http.ResponseWriter, r *http.Request) 
 		"expires_at":   time.Now().Add(15 * time.Minute).Unix(),
 	})
 }
+
+// HandleCreateUpload prepares an upload by requesting an upload URL from the main backend
+func (h *OGAHandler) HandleCreateUpload(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		WriteJSONError(w, http.StatusMethodNotAllowed, "Method not allowed")
+		return
+	}
+
+	var body json.RawMessage
+	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+		WriteJSONError(w, http.StatusBadRequest, "Invalid request body")
+		return
+	}
+
+	result, err := h.service.CreateUploadURL(r.Context(), body)
+	if err != nil {
+		slog.ErrorContext(r.Context(), "failed to create upload URL", "error", err)
+		WriteJSONError(w, http.StatusInternalServerError, "Failed to create upload URL")
+		return
+	}
+
+	WriteJSONResponse(w, http.StatusOK, result)
+}

--- a/oga/internal/handler_test.go
+++ b/oga/internal/handler_test.go
@@ -1,0 +1,141 @@
+package internal
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+// mockOGAService is a mock implementation of OGAService for testing
+type mockOGAService struct {
+	// embed the interface so we don't have to implement everything
+	OGAService
+
+	mockCreateUploadURL func(ctx context.Context, payload []byte) (map[string]any, error)
+	mockGetDownloadURL  func(ctx context.Context, key string) (string, error)
+}
+
+func (m *mockOGAService) CreateUploadURL(ctx context.Context, payload []byte) (map[string]any, error) {
+	if m.mockCreateUploadURL != nil {
+		return m.mockCreateUploadURL(ctx, payload)
+	}
+	return nil, nil
+}
+
+func (m *mockOGAService) GetDownloadURL(ctx context.Context, key string) (string, error) {
+	if m.mockGetDownloadURL != nil {
+		return m.mockGetDownloadURL(ctx, key)
+	}
+	return "", nil
+}
+
+func TestHandleCreateUpload(t *testing.T) {
+	t.Run("success", func(t *testing.T) {
+		mockSvc := &mockOGAService{
+			mockCreateUploadURL: func(ctx context.Context, payload []byte) (map[string]any, error) {
+				return map[string]any{
+					"key":        "123-abc",
+					"upload_url": "http://test/upload",
+				}, nil
+			},
+		}
+		handler := NewOGAHandler(mockSvc)
+
+		body := []byte(`{"filename":"test.txt"}`)
+		req := httptest.NewRequest(http.MethodPost, "/api/oga/uploads", bytes.NewBuffer(body))
+		rec := httptest.NewRecorder()
+
+		handler.HandleCreateUpload(rec, req)
+
+		if rec.Code != http.StatusOK {
+			t.Errorf("expected status %d, got %d", http.StatusOK, rec.Code)
+		}
+
+		var resp map[string]any
+		if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {
+			t.Fatalf("failed to parse response body: %v", err)
+		}
+
+		if resp["key"] != "123-abc" {
+			t.Errorf("expected key '123-abc', got %v", resp["key"])
+		}
+	})
+
+	t.Run("invalid method", func(t *testing.T) {
+		handler := NewOGAHandler(&mockOGAService{})
+		req := httptest.NewRequest(http.MethodGet, "/api/oga/uploads", nil)
+		rec := httptest.NewRecorder()
+
+		handler.HandleCreateUpload(rec, req)
+
+		if rec.Code != http.StatusMethodNotAllowed {
+			t.Errorf("expected status %d, got %d", http.StatusMethodNotAllowed, rec.Code)
+		}
+	})
+
+	t.Run("service error", func(t *testing.T) {
+		mockSvc := &mockOGAService{
+			mockCreateUploadURL: func(ctx context.Context, payload []byte) (map[string]any, error) {
+				return nil, errors.New("upstream error")
+			},
+		}
+		handler := NewOGAHandler(mockSvc)
+
+		body := []byte(`{"filename":"test.txt"}`)
+		req := httptest.NewRequest(http.MethodPost, "/api/oga/uploads", bytes.NewBuffer(body))
+		rec := httptest.NewRecorder()
+
+		handler.HandleCreateUpload(rec, req)
+
+		if rec.Code != http.StatusInternalServerError {
+			t.Errorf("expected status %d, got %d", http.StatusInternalServerError, rec.Code)
+		}
+	})
+}
+
+func TestHandleGetUploadURL(t *testing.T) {
+	t.Run("success", func(t *testing.T) {
+		mockSvc := &mockOGAService{
+			mockGetDownloadURL: func(ctx context.Context, key string) (string, error) {
+				return "http://test/download", nil
+			},
+		}
+		handler := NewOGAHandler(mockSvc)
+
+		req := httptest.NewRequest(http.MethodGet, "/api/oga/uploads/550e8400-e29b-41d4-a716-446655440000.pdf", nil)
+		req.SetPathValue("key", "550e8400-e29b-41d4-a716-446655440000.pdf") // Set the mux path value
+		rec := httptest.NewRecorder()
+
+		handler.HandleGetUploadURL(rec, req)
+
+		if rec.Code != http.StatusOK {
+			t.Errorf("expected status %d, got %d. Body: %s", http.StatusOK, rec.Code, rec.Body.String())
+		}
+
+		var resp map[string]any
+		if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {
+			t.Fatalf("failed to parse response body: %v", err)
+		}
+
+		if resp["download_url"] != "http://test/download" {
+			t.Errorf("expected download_url 'http://test/download', got %v", resp["download_url"])
+		}
+	})
+
+	t.Run("invalid key", func(t *testing.T) {
+		handler := NewOGAHandler(&mockOGAService{})
+		req := httptest.NewRequest(http.MethodGet, "/api/oga/uploads/invalid_key", nil)
+		req.SetPathValue("key", "invalid_key")
+		rec := httptest.NewRecorder()
+
+		handler.HandleGetUploadURL(rec, req)
+
+		if rec.Code != http.StatusBadRequest {
+			t.Errorf("expected status %d, got %d", http.StatusBadRequest, rec.Code)
+		}
+	})
+}

--- a/oga/internal/service.go
+++ b/oga/internal/service.go
@@ -42,6 +42,9 @@ type OGAService interface {
 	// GetDownloadURL fetches a download URL for a key from the main backend.
 	GetDownloadURL(ctx context.Context, key string) (string, error)
 
+	// CreateUploadURL proxies an upload initialization request to the main backend.
+	CreateUploadURL(ctx context.Context, payload []byte) (map[string]any, error)
+
 	// Close closes the service and releases resources
 	Close() error
 }
@@ -417,6 +420,28 @@ func (s *ogaService) GetDownloadURL(ctx context.Context, key string) (string, er
 
 	slog.InfoContext(ctx, "resolved download URL from metadata", "key", key, "downloadURL", metadata.DownloadURL)
 	return metadata.DownloadURL, nil
+}
+
+// CreateUploadURL proxies an upload initialization request to the main backend.
+func (s *ogaService) CreateUploadURL(ctx context.Context, payload []byte) (map[string]any, error) {
+	resp, err := s.httpClient.Post("uploads", "application/json", payload)
+	if err != nil {
+		return nil, fmt.Errorf("failed to POST upload metadata: %w", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusOK {
+		slog.WarnContext(ctx, "failed to fetch upload metadata from backend",
+			"status", resp.Status)
+		return nil, fmt.Errorf("failed to POST upload metadata, status code: %d", resp.StatusCode)
+	}
+
+	var metadata map[string]any
+	if err := json.NewDecoder(resp.Body).Decode(&metadata); err != nil {
+		return nil, fmt.Errorf("failed to decode upload metadata: %w", err)
+	}
+
+	return metadata, nil
 }
 
 // feedbackHistoryFromRaw converts the raw JSONB slice from the store into typed feedback entries.

--- a/oga/internal/service_test.go
+++ b/oga/internal/service_test.go
@@ -1,0 +1,79 @@
+package internal
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/OpenNSW/nsw/oga/pkg/httpclient"
+)
+
+func TestService_CreateUploadURL(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/uploads", func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			w.WriteHeader(http.StatusMethodNotAllowed)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte(`{"key":"123-abc", "upload_url":"http://test/upload"}`))
+	})
+
+	server := httptest.NewServer(mux)
+	defer server.Close()
+
+	client := httpclient.NewClientBuilder().
+		WithBaseURL(server.URL + "/").
+		Build()
+
+	service := NewOGAService(nil, nil, client)
+
+	payload := []byte(`{"filename":"test.txt"}`)
+	ctx := context.Background()
+
+	result, err := service.CreateUploadURL(ctx, payload)
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+
+	if result["key"] != "123-abc" {
+		t.Errorf("expected key '123-abc', got %v", result["key"])
+	}
+	if result["upload_url"] != "http://test/upload" {
+		t.Errorf("expected upload_url 'http://test/upload', got %v", result["upload_url"])
+	}
+}
+
+func TestService_GetDownloadURL(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/uploads/550e8400-e29b-41d4-a716-446655440000.pdf", func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet {
+			w.WriteHeader(http.StatusMethodNotAllowed)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte(`{"download_url":"http://test/download"}`))
+	})
+
+	server := httptest.NewServer(mux)
+	defer server.Close()
+
+	client := httpclient.NewClientBuilder().
+		WithBaseURL(server.URL + "/").
+		Build()
+
+	service := NewOGAService(nil, nil, client)
+	ctx := context.Background()
+
+	url, err := service.GetDownloadURL(ctx, "550e8400-e29b-41d4-a716-446655440000.pdf")
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+
+	if url != "http://test/download" {
+		t.Errorf("expected download_url 'http://test/download', got %v", url)
+	}
+}

--- a/portals/apps/oga-app/.env.example
+++ b/portals/apps/oga-app/.env.example
@@ -11,6 +11,8 @@ VITE_INSTANCE_CONFIG=npqs
 
 # Backend API Base URL
 VITE_API_BASE_URL=http://localhost:8081
+# Storage API Base URL (points to the main backend)
+VITE_OGA_API_BASE_URL=http://localhost:8080/api/v1
 
 # Identity Provider (Asgardeo/Thunder)
 VITE_IDP_BASE_URL=https://localhost:8090

--- a/portals/apps/oga-app/src/screens/WorkflowDetailScreen.tsx
+++ b/portals/apps/oga-app/src/screens/WorkflowDetailScreen.tsx
@@ -1,12 +1,33 @@
 import { useState, useEffect } from 'react'
 import { useNavigate, useSearchParams } from 'react-router-dom'
 import { Button, Badge, Spinner, Text, Card, Flex, Box, Callout, Tabs } from '@radix-ui/themes'
-import { ArrowLeftIcon, CheckCircledIcon, ExclamationTriangleIcon, InfoCircledIcon, ChatBubbleIcon } from '@radix-ui/react-icons'
+import { ArrowLeftIcon, CheckCircledIcon, ExclamationTriangleIcon, InfoCircledIcon, ChatBubbleIcon, FileTextIcon } from '@radix-ui/react-icons'
 import { fetchApplicationDetail, submitReview, submitFeedback, type OGAApplication } from '../api'
 import { JsonForms } from '@jsonforms/react';
-import { radixRenderers } from '@opennsw/jsonforms-renderers';
+import { radixRenderers, useUpload, storageKeyRegex, viewFile, getStorageKeyDisplayText } from '@opennsw/jsonforms-renderers';
 import type { JsonSchema, UISchemaElement } from '@jsonforms/core';
 import { useApi } from '../services/useApi'
+
+function FileValue({ storageKey }: { storageKey: string }) {
+  const { getDownloadUrl } = useUpload() || {};
+
+  const handleView = async (e: React.MouseEvent) => {
+    e.preventDefault();
+    await viewFile(storageKey, getDownloadUrl);
+  };
+
+  return (
+    <Flex align="center" gap="3">
+      <Text size="2" weight="medium" className="truncate" style={{ maxWidth: '150px' }}>
+        {getStorageKeyDisplayText(storageKey)}
+      </Text>
+      <Button variant="soft" size="1" color="blue" onClick={handleView} style={{ cursor: 'pointer' }}>
+        <FileTextIcon width="14" height="14" />
+        View
+      </Button>
+    </Flex>
+  );
+}
 
 export function WorkflowDetailScreen() {
   const navigate = useNavigate()
@@ -257,7 +278,13 @@ export function WorkflowDetailScreen() {
                             {key.replace(/([A-Z])/g, ' $1').replace(/_/g, ' ')}
                           </Text>
                           <Text size="2" weight="medium">
-                            {typeof value === 'object' && value !== null ? JSON.stringify(value) : String(value)}
+                            {typeof value === 'string' && storageKeyRegex.test(value) ? (
+                              <FileValue storageKey={value} />
+                            ) : typeof value === 'object' && value !== null ? (
+                              JSON.stringify(value)
+                            ) : (
+                              String(value)
+                            )}
                           </Text>
                         </Box>
                       ))}

--- a/portals/apps/oga-app/src/services/upload.ts
+++ b/portals/apps/oga-app/src/services/upload.ts
@@ -1,6 +1,7 @@
 import type { ApiClient } from '../api'
+import { getEnv } from '../runtimeConfig'
 
-const API_BASE_URL = (import.meta.env.VITE_OGA_API_BASE_URL as string | undefined) ?? 'http://localhost:8080/api/v1'
+const API_BASE_URL = getEnv('VITE_API_BASE_URL', 'http://localhost:8080/api/v1')!
 
 export interface UploadResponse {
   key: string

--- a/portals/apps/oga-app/src/services/upload.ts
+++ b/portals/apps/oga-app/src/services/upload.ts
@@ -1,7 +1,8 @@
 import type { ApiClient } from '../api'
 import { getEnv } from '../runtimeConfig'
 
-const API_BASE_URL = getEnv('VITE_API_BASE_URL', 'http://localhost:8080/api/v1')!
+const API_BASE_URL = getEnv('VITE_API_BASE_URL', 'http://localhost:8081')!
+const STORAGE_API_BASE_URL = getEnv('VITE_OGA_API_BASE_URL', 'http://localhost:8080/api/v1')!
 
 export interface UploadResponse {
   key: string
@@ -11,7 +12,7 @@ export interface UploadResponse {
 
 export async function uploadFile(apiClient: ApiClient, file: File): Promise<UploadResponse> {
   // Request the presigned URL (S3 or local equivalent)
-  const initResponse = await fetch(`${API_BASE_URL}/uploads`, {
+  const initResponse = await fetch(`${API_BASE_URL}/api/oga/uploads`, {
     method: 'POST',
     headers: {
       ...(await apiClient.getAuthHeaders(false)),
@@ -36,8 +37,13 @@ export async function uploadFile(apiClient: ApiClient, file: File): Promise<Uplo
     throw new Error('Server did not provide an upload URL')
   }
 
+  // Resolve relative upload URL if we are using the local backend mock
+  const finalUploadUrl = meta.upload_url.startsWith('/')
+    ? new URL(STORAGE_API_BASE_URL).origin + meta.upload_url
+    : meta.upload_url
+
   // Upload directly to Blob Storage / Local Mock
-  const uploadResponse = await fetch(meta.upload_url, {
+  const uploadResponse = await fetch(finalUploadUrl, {
     method: 'PUT',
     headers: {
       'Content-Type': file.type || 'application/octet-stream',
@@ -55,7 +61,7 @@ export async function uploadFile(apiClient: ApiClient, file: File): Promise<Uplo
 }
 
 export async function getDownloadUrl(apiClient: ApiClient, key: string): Promise<{ url: string; expiresAt: number }> {
-  const response = await fetch(`${API_BASE_URL}/uploads/${key}`, {
+  const response = await fetch(`${API_BASE_URL}/api/oga/uploads/${key}`, {
     headers: await apiClient.getAuthHeaders(false),
   })
 
@@ -67,7 +73,7 @@ export async function getDownloadUrl(apiClient: ApiClient, key: string): Promise
 
   // Format local relative paths to absolute paths so the browser can download it
   const url = data.download_url.startsWith('/')
-    ? `${new URL(API_BASE_URL).origin}${data.download_url}`
+    ? new URL(STORAGE_API_BASE_URL).origin + data.download_url
     : data.download_url
 
   return { url, expiresAt: data.expires_at }

--- a/portals/apps/oga-app/src/services/upload.ts
+++ b/portals/apps/oga-app/src/services/upload.ts
@@ -1,7 +1,3 @@
-/**
- * OGA-app–specific upload implementation. Points to this app's backend;
- * when OGA moves to a separate repo, this file can target OGA-specific endpoints/S3 without touching shared UI.
- */
 import type { ApiClient } from '../api'
 
 const API_BASE_URL = (import.meta.env.VITE_OGA_API_BASE_URL as string | undefined) ?? 'http://localhost:8080/api/v1'
@@ -9,31 +5,69 @@ const API_BASE_URL = (import.meta.env.VITE_OGA_API_BASE_URL as string | undefine
 export interface UploadResponse {
   key: string
   name: string
+  url?: string
 }
 
 export async function uploadFile(apiClient: ApiClient, file: File): Promise<UploadResponse> {
-  const formData = new FormData()
-  formData.append('file', file)
-
-  const response = await fetch(`${API_BASE_URL}/uploads`, {
+  // Request the presigned URL (S3 or local equivalent)
+  const initResponse = await fetch(`${API_BASE_URL}/uploads`, {
     method: 'POST',
-    headers: await apiClient.getAuthHeaders(false),
-    body: formData,
+    headers: {
+      ...(await apiClient.getAuthHeaders(false)),
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify({
+      filename: file.name,
+      mime_type: file.type || 'application/octet-stream',
+      size: file.size,
+    }),
   })
 
-  if (!response.ok) {
-    const errorText = await response.text()
-    console.error(`Upload error ${response.status}: ${errorText}`)
-    throw new Error(`Failed to upload file: ${response.status} ${response.statusText}`)
+  if (!initResponse.ok) {
+    const errorText = await initResponse.text()
+    console.error(`Upload initialization error ${initResponse.status}: ${errorText}`)
+    throw new Error(`Failed to initialize upload: ${initResponse.status}`)
   }
 
-  const meta = (await response.json()) as { key: string; name: string }
-  return { key: meta.key, name: meta.name }
+  const meta = (await initResponse.json()) as { key: string; name: string; upload_url: string; url: string }
+
+  if (!meta.upload_url) {
+    throw new Error('Server did not provide an upload URL')
+  }
+
+  // Upload directly to Blob Storage / Local Mock
+  const uploadResponse = await fetch(meta.upload_url, {
+    method: 'PUT',
+    headers: {
+      'Content-Type': file.type || 'application/octet-stream',
+    },
+    body: file,
+  })
+
+  if (!uploadResponse.ok) {
+    const errorText = await uploadResponse.text()
+    console.error(`File content upload error ${uploadResponse.status}: ${errorText}`)
+    throw new Error(`Failed to upload file content: ${uploadResponse.status}`)
+  }
+
+  return { key: meta.key, name: meta.name, url: meta.url }
 }
 
 export async function getDownloadUrl(apiClient: ApiClient, key: string): Promise<{ url: string; expiresAt: number }> {
-  const response = await apiClient.get<{ download_url: string; expires_at: number }>(
-    `/api/oga/uploads/${key}`
-  )
-  return { url: response.download_url, expiresAt: response.expires_at }
+  const response = await fetch(`${API_BASE_URL}/uploads/${key}`, {
+    headers: await apiClient.getAuthHeaders(false),
+  })
+
+  if (!response.ok) {
+    throw new Error(`Failed to get download URL: ${response.status}`)
+  }
+
+  const data = (await response.json()) as { download_url: string; expires_at: number }
+
+  // Format local relative paths to absolute paths so the browser can download it
+  const url = data.download_url.startsWith('/')
+    ? `${new URL(API_BASE_URL).origin}${data.download_url}`
+    : data.download_url
+
+  return { url, expiresAt: data.expires_at }
 }

--- a/portals/apps/trader-app/src/services/upload.ts
+++ b/portals/apps/trader-app/src/services/upload.ts
@@ -9,26 +9,52 @@ const API_BASE_URL = import.meta.env.VITE_API_BASE_URL || 'http://localhost:8080
 export interface UploadResponse {
   key: string
   name: string
+  url: string
+  upload_url?: string
 }
 
 export async function uploadFile(apiClient: ApiClient, file: File): Promise<UploadResponse> {
-  const formData = new FormData()
-  formData.append('file', file)
-
-  const response = await fetch(`${API_BASE_URL}/uploads`, {
+  // Register the upload and get a presigned/upload URL
+  const initResponse = await fetch(`${API_BASE_URL}/uploads`, {
     method: 'POST',
-    headers: await apiClient.getAuthHeaders(false),
-    body: formData,
+    headers: {
+      ...(await apiClient.getAuthHeaders(false)),
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify({
+      filename: file.name,
+      mime_type: file.type || 'application/octet-stream',
+      size: file.size,
+    }),
   })
 
-  if (!response.ok) {
-    const errorText = await response.text()
-    console.error(`Upload error ${response.status}: ${errorText}`)
-    throw new Error(`Failed to upload file: ${response.status} ${response.statusText}`)
+  if (!initResponse.ok) {
+    const errorText = await initResponse.text()
+    console.error(`Upload initialization error ${initResponse.status}: ${errorText}`)
+    throw new Error(`Failed to initialize upload: ${initResponse.status} ${initResponse.statusText}`)
   }
 
-  const meta = (await response.json()) as { key: string; name: string }
-  return { key: meta.key, name: meta.name }
+  const meta = (await initResponse.json()) as UploadResponse
+  if (!meta.upload_url) {
+    throw new Error('Server did not provide an upload URL')
+  }
+
+  // Upload the actual file content to the provided URL
+  const uploadResponse = await fetch(meta.upload_url, {
+    method: 'PUT',
+    headers: {
+      'Content-Type': file.type || 'application/octet-stream',
+    },
+    body: file,
+  })
+
+  if (!uploadResponse.ok) {
+    const errorText = await uploadResponse.text()
+    console.error(`File content upload error ${uploadResponse.status}: ${errorText}`)
+    throw new Error(`Failed to upload file content: ${uploadResponse.status} ${uploadResponse.statusText}`)
+  }
+
+  return meta
 }
 
 export async function getDownloadUrl(apiClient: ApiClient, key: string): Promise<{ url: string; expiresAt: number }> {

--- a/portals/apps/trader-app/src/services/upload.ts
+++ b/portals/apps/trader-app/src/services/upload.ts
@@ -10,7 +10,7 @@ const API_BASE_URL = getEnv('VITE_API_BASE_URL', 'http://localhost:8080/api/v1')
 export interface UploadResponse {
   key: string
   name: string
-  url: string
+  url?: string
   upload_url?: string
 }
 

--- a/portals/apps/trader-app/src/services/upload.ts
+++ b/portals/apps/trader-app/src/services/upload.ts
@@ -3,8 +3,9 @@
  * when the API or auth changes, only this file is updated.
  */
 import type { ApiClient } from './api'
+import { getEnv } from '../runtimeConfig'
 
-const API_BASE_URL = import.meta.env.VITE_API_BASE_URL || 'http://localhost:8080/api/v1'
+const API_BASE_URL = getEnv('VITE_API_BASE_URL', 'http://localhost:8080/api/v1')!
 
 export interface UploadResponse {
   key: string

--- a/portals/packages/jsonforms-renderers/src/index.ts
+++ b/portals/packages/jsonforms-renderers/src/index.ts
@@ -1,4 +1,3 @@
-import './index.css';
-
 export * from './contexts/UploadContext';
 export * from './renderers';
+export * from './utils/storage';

--- a/portals/packages/jsonforms-renderers/src/renderers/FileControl.tsx
+++ b/portals/packages/jsonforms-renderers/src/renderers/FileControl.tsx
@@ -11,6 +11,7 @@ import {
   type DragEvent
 } from 'react';
 import { useUpload } from '../contexts/UploadContext';
+import { getStorageKeyDisplayText, viewFile } from '../utils/storage';
 import * as React from "react";
 
 interface FileControlProps {
@@ -45,9 +46,7 @@ const FileControl = ({ data, handleChange, path, label, required, uischema, enab
 
     const getDisplayText = () => {
         if (fileName) return fileName;
-        if (!data) return null;
-        // Try to extract name from data URL if stored there, otherwise generic
-        return 'Uploaded File';
+        return getStorageKeyDisplayText(data || '');
     };
 
     const processFile = useCallback(async (file: File) => {
@@ -141,58 +140,9 @@ const FileControl = ({ data, handleChange, path, label, required, uischema, enab
     if (!isEnabled && !data) return null;
 
     const onView = async (e: React.MouseEvent<HTMLButtonElement>) => {
-        e.preventDefault()
-        // 1. Handle local files or data URLs immediately (synchronous = no popup block)
-        if (localBlobUrl) {
-            const url = localBlobUrl || data;
-            window.open(url!, '_blank', 'noopener,noreferrer')?.focus();
-            return;
-        }
-
-        if (data && data.startsWith('data:')) {
-            let blobUrl: string | null = null;
-            try {
-                const parts = data.split(',');
-                const mime = parts[0].match(/:(.*?);/)?.[1] || 'application/octet-stream';
-                const b64Data = parts[1];
-                const byteCharacters = atob(b64Data);
-                const byteNumbers = new Array(byteCharacters.length);
-                for (let i = 0; i < byteCharacters.length; i++) {
-                    byteNumbers[i] = byteCharacters.charCodeAt(i);
-                }
-                const byteArray = new Uint8Array(byteNumbers);
-                const blob = new Blob([byteArray], { type: mime });
-                blobUrl = URL.createObjectURL(blob);
-                window.open(blobUrl, '_blank', 'noopener,noreferrer')?.focus();
-            } catch (err) {
-                console.error('[FileControl] Failed to create blob URL from data URL, attempting direct open:', err);
-                window.open(data, '_blank', 'noopener,noreferrer')?.focus();
-            } finally {
-                if (blobUrl) {
-                    URL.revokeObjectURL(blobUrl);
-                }
-            }
-            return;
-        }
-
+        e.preventDefault();
         if (!data) return;
-
-        // 2. Handle remote keys: open a blank tab FIRST to capture the user gesture
-        const newWindow = window.open('', '_blank');
-        if (!newWindow) return; // Browser blocked the popup
-
-        try {
-            const result = await uploadContext?.getDownloadUrl?.(data);
-            if (result?.url) {
-                // 3. Redirect the already-opened tab to the presigned URL
-                newWindow.location.href = result.url;
-            } else {
-                newWindow.close();
-            }
-        } catch (err) {
-            console.error('[FileControl] Failed to fetch download URL:', err);
-            newWindow.close();
-        }
+        await viewFile(data, uploadContext?.getDownloadUrl, { localBlobUrl });
     };
 
     return (

--- a/portals/packages/jsonforms-renderers/src/utils/storage.ts
+++ b/portals/packages/jsonforms-renderers/src/utils/storage.ts
@@ -1,0 +1,86 @@
+export const storageKeyRegex = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}(\.[a-z0-9]+)?$/i;
+
+export const getStorageKeyDisplayText = (key: string): string => {
+    if (!key) return '';
+    if (key.startsWith('data:')) return 'Uploaded File';
+
+    if (storageKeyRegex.test(key)) {
+        const parts = key.split('.');
+        if (parts.length > 1) {
+            return `${parts[parts.length - 1].toUpperCase()} Document`;
+        }
+        return 'Document';
+    }
+
+    return 'Uploaded File';
+};
+
+export interface ViewFileOptions {
+    localBlobUrl?: string | null;
+}
+
+/**
+ * Common logic for opening a file/document in a new tab.
+ * Handles local blobs, data URLs, and remote storage keys (requires getDownloadUrl).
+ */
+export const viewFile = async (
+    data: string,
+    getDownloadUrl?: (key: string) => Promise<{ url: string; expiresAt: number } | null>,
+    options: ViewFileOptions = {}
+) => {
+    // 1. Handle local files immediately (synchronous = no popup block)
+    if (options.localBlobUrl) {
+        window.open(options.localBlobUrl, '_blank', 'noopener,noreferrer')?.focus();
+        return;
+    }
+
+    // 2. Handle Data URLs
+    if (data && data.startsWith('data:')) {
+        let blobUrl: string | null = null;
+        try {
+            const parts = data.split(',');
+            if (parts.length < 2) throw new Error('Invalid data URL');
+            
+            const mime = parts[0].match(/:(.*?);/)?.[1] || 'application/octet-stream';
+            const b64Data = parts[1];
+            const byteCharacters = atob(b64Data);
+            const byteNumbers = new Array(byteCharacters.length);
+            for (let i = 0; i < byteCharacters.length; i++) {
+                byteNumbers[i] = byteCharacters.charCodeAt(i);
+            }
+            const byteArray = new Uint8Array(byteNumbers);
+            const blob = new Blob([byteArray], { type: mime });
+            blobUrl = URL.createObjectURL(blob);
+            window.open(blobUrl, '_blank', 'noopener,noreferrer')?.focus();
+        } catch (err) {
+            console.error('[StorageUtils] Failed to create blob URL from data URL, attempting direct open:', err);
+            window.open(data, '_blank', 'noopener,noreferrer')?.focus();
+        } finally {
+            // Note: In real production, we might want to delay revocation or let the browser handle it.
+        }
+        return;
+    }
+
+    if (!data) return;
+
+    // 3. Handle remote keys (S3/LocalFS): open a blank tab FIRST to capture the user gesture
+    // Then fetch the presigned URL and redirect the tab.
+    const newWindow = window.open('', '_blank');
+    if (!newWindow) {
+        console.warn('[StorageUtils] Popup blocked. Ensure this is called from a user gesture.');
+        return;
+    }
+
+    try {
+        const result = await getDownloadUrl?.(data);
+        if (result?.url) {
+            newWindow.location.href = result.url;
+        } else {
+            newWindow.close();
+            console.error('[StorageUtils] No download URL returned for key:', data);
+        }
+    } catch (err) {
+        console.error('[StorageUtils] Failed to fetch download URL:', err);
+        newWindow.close();
+    }
+};


### PR DESCRIPTION
https://github.com/user-attachments/assets/7779ca51-4208-413d-973f-0e04cb40f6f1

## Summary
Refactor the file upload service to remove duplicated HMAC logic, centralize security secrets into the configuration system, and enhance the local dev upload mock to enforce production-level security constraints (TTL, Content-Type validation, and size limits). Also migrate the upload flow to a more scalable two-stage process (Metadata POST + Content PUT) across the backend, frontend, API documentation, and isolated OGA gateways.

## How it works
1. OGA Portal UI only trusts its own backend -> when click "View" file, OGA backend validates the OGA session and then reaches out _internally_ to the main NSW backend to request a secure link
- in local dev, NSW backend mocks S3 and returns a URL pointing to itself (`:8080/api/v1/uploads/...`) because it is currently responsible for serving those local files
- added`STORAGE_API_BASE_URL` to the frontend to tell OGA portal that if it receives a relative path from the OGA backend, it should resolve it against the NSW storage server (port 8080), not the OGA gateway (port 8082).

**Note: in production (Helm environment)** when `oga-npqs` (on port 8082) needs a link, it will call `http://nsw-api/` (port 80) inside the Kubernetes cluster. The user never sees this internal traffic.

* **in Production with AWS S3**, "Download URL" will point directly to AWS S3 storage, not our Go backend. Once we switch `storage.type` to `s3` in Helm values
    1.  OGA backend still requests the link from NSW backend
    2.  NSW backend uses its IAM role to generate a real AWS S3 Presigned URL
    3.  URL returned to the user will look like `https://nsw-prod-bucket.s3.amazonaws.com/...`

## Testing
1. run locally with `./start-dev.sh`
2. go to trader-app localhost:5173, for Health Certificate -> upload a file, you should see two distinct requests:
  * `POST /api/v1/uploads`: Sends JSON metadata (filename, mime_type, size).
  * `PUT /storage/local/...`: Sends the actual binary content directly to the storage driver.
3. verify that the file actually landed in the backend's storage folder:
```bash
ls -R backend/bucket/
```

## Changes
#### Backend Core & Storage Drivers
* Interface Update: update the `StorageDriver` interface to include `GetUploadURL(ctx, key, ttl, contentType, maxSizeBytes)` to standardize presigned URL generation
* S3 Implementation: update `s3_driver.go` to use AWS SDK's `PresignPutObject`, strictly enforcing the `ContentLength` and `ContentType` during AWS signature generation
* Local Mock Implementation: update `local_fs.go` to return a mock upload URL, safely URL-encoding the constraint parameters (`expiresAt`, `contentType`, `maxSizeBytes`) as query strings

#### Security & Configuration
* Secret Management: remove the hardcoded local HMAC secret, migrating it to the application configuration (`config.go`) and `.env` files (`STORAGE_LOCAL_PUT_SECRET`)
* Robust Cryptography: centralize HMAC logic (`GenerateToken`, `VerifyToken`) in `internal/uploads/drivers/token.go`
  * The payload now signs a delimited string (`key:expiresAt:contentType:maxSizeBytes`) to prevent boundary collisions
  * Token verification utilizes `hmac.Equal` to verify equality safely without timing leak vulnerabilities
* Local Endpoint Hardening: update `HTTPHandler.UploadContentLocal` to strictly enforce production constraints locally:
  * Authentication: rejects invalid or missing HMAC tokens (`401 Unauthorized`)
  * TTL: Rejects expired links (`403 Forbidden`)
  * Content-Type: rejects mismatched MIME types (`415 Unsupported Media Type`)
  * Size Limits: uses `http.MaxBytesReader` configured dynamically to the signed `maxSizeBytes` threshold to prevent local disk exhaustion/DoS (`413 Payload Too Large`)

#### API Gateway & Frontend Integration
* Frontend Clients: refactor `upload.ts` in both `trader-app` and `oga-app` to utilize the new architecture:
  * First, `POST` JSON metadata (filename, size, mime_type) to the backend API to receive the `upload_url`
  * Second, `PUT` the raw `File` object directly to the provided presigned URL buffer
* OGA Service Bridging: extend the `oga` gateway to bridge OGA external file uploads without relying on CORS vulnerabilities. OGA now hits `/api/oga/uploads` endpoint, dynamically forwarded to the central namespace using internal `httpclient` configurations (preparing the environment for when we move upload service into it's own pckg/microservice)
