### PR TITLE
feat(Helm): add Charts for Trader App

### DIFF
--- a/deployments/helm/trader-app/templates/_helpers.tpl
+++ b/deployments/helm/trader-app/templates/_helpers.tpl
@@ -3,9 +3,32 @@
 {{- end }}
 
 {{- define "trader-app.fullname" -}}
-{{- if .Values.fullnameOverride }}
-{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
-{{- else }}
-{{- printf "%s-%s" .Release.Name (include "trader-app.name" .) | trunc 63 | trimSuffix "-" }}
+{{- if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- if contains $name .Release.Name -}}
+{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "trader-app.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
 {{- end }}
+
+{{- define "trader-app.labels" -}}
+helm.sh/chart: {{ include "trader-app.chart" . }}
+{{ include "trader-app.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{- define "trader-app.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "trader-app.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
 {{- end }}

--- a/deployments/helm/trader-app/templates/deployment.yaml
+++ b/deployments/helm/trader-app/templates/deployment.yaml
@@ -6,7 +6,9 @@ metadata:
     app.kubernetes.io/name: {{ include "trader-app.name" . }}
     app.kubernetes.io/instance: {{ .Release.Name }}
 spec:
+{{- if not .Values.autoscaling.enabled }}
   replicas: {{ .Values.replicaCount }}
+{{- end }}
   selector:
     matchLabels:
       app.kubernetes.io/name: {{ include "trader-app.name" . }}
@@ -17,9 +19,15 @@ spec:
         app.kubernetes.io/name: {{ include "trader-app.name" . }}
         app.kubernetes.io/instance: {{ .Release.Name }}
     spec:
+      securityContext:
+        {{- toYaml .Values.podSecurityContext | nindent 8 }}
       {{- if .Values.imagePullSecrets }}
       imagePullSecrets:
         {{- toYaml .Values.imagePullSecrets | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
       {{- end }}
       containers:
         - name: {{ .Chart.Name }}
@@ -27,36 +35,50 @@ spec:
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           ports:
             - name: http
-              containerPort: 80
+              containerPort: {{ .Values.service.targetPort }}
               protocol: TCP
           env:
             - name: VITE_API_BASE_URL
-              value: {{ .Values.config.apiBaseUrl | quote }}
+              value: {{ tpl .Values.config.apiBaseUrl . | quote }}
             - name: VITE_IDP_BASE_URL
-              value: {{ .Values.config.idpBaseUrl | quote }}
+              value: {{ tpl .Values.config.idpBaseUrl . | quote }}
             - name: VITE_IDP_CLIENT_ID
-              value: {{ .Values.config.idpClientId | quote }}
+              value: {{ tpl .Values.config.idpClientId . | quote }}
             - name: VITE_APP_URL
-              value: {{ .Values.config.appUrl | quote }}
+              value: {{ tpl .Values.config.appUrl . | quote }}
             - name: VITE_IDP_SCOPES
               value: {{ .Values.config.idpScopes | quote }}
+            - name: VITE_IDP_TRADER_GROUP_NAME
+              value: {{ .Values.config.idpTraderGroupName | quote }}
+            - name: VITE_IDP_CHA_GROUP_NAME
+              value: {{ .Values.config.idpCHAGroupName | quote }}
             - name: VITE_IDP_PLATFORM
               value: {{ .Values.config.idpPlatform | quote }}
             - name: VITE_SHOW_AUTOFILL_BUTTON
               value: {{ .Values.config.showAutofillButton | quote }}
           livenessProbe:
             httpGet:
-              path: /
+              path: /health
               port: http
             initialDelaySeconds: 5
             periodSeconds: 15
             failureThreshold: 3
           readinessProbe:
             httpGet:
-              path: /
+              path: /health
               port: http
             initialDelaySeconds: 3
             periodSeconds: 10
             failureThreshold: 3
+          volumeMounts:
+            - name: nginx-config
+              mountPath: /etc/nginx/conf.d/default.conf
+              subPath: default.conf.template
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
+          securityContext:
+            {{- toYaml .Values.securityContext | nindent 12 }}
+      volumes:
+        - name: nginx-config
+          configMap:
+            name: {{ include "trader-app.fullname" . }}-nginx-config

--- a/deployments/helm/trader-app/templates/hpa.yaml
+++ b/deployments/helm/trader-app/templates/hpa.yaml
@@ -1,0 +1,32 @@
+{{- if .Values.autoscaling.enabled }}
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: {{ include "trader-app.fullname" . }}
+  labels:
+    {{- include "trader-app.labels" . | nindent 4 }}
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: {{ include "trader-app.fullname" . }}
+  minReplicas: {{ .Values.autoscaling.minReplicas }}
+  maxReplicas: {{ .Values.autoscaling.maxReplicas }}
+  metrics:
+    {{- if .Values.autoscaling.targetCPUUtilizationPercentage }}
+    - type: Resource
+      resource:
+        name: cpu
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.autoscaling.targetCPUUtilizationPercentage }}
+    {{- end }}
+    {{- if .Values.autoscaling.targetMemoryUtilizationPercentage }}
+    - type: Resource
+      resource:
+        name: memory
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.autoscaling.targetMemoryUtilizationPercentage }}
+    {{- end }}
+{{- end }}

--- a/deployments/helm/trader-app/templates/nginx-cm.yaml
+++ b/deployments/helm/trader-app/templates/nginx-cm.yaml
@@ -1,0 +1,48 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "trader-app.fullname" . }}-nginx-config
+  labels:
+    app.kubernetes.io/name: {{ include "trader-app.name" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+data:
+  default.conf.template: |
+    server {
+        listen 8080;
+        server_tokens off;
+        server_name localhost;
+
+        # Gzip compression
+        gzip on;
+        gzip_vary on;
+        gzip_proxied any;
+        gzip_min_length 256;
+        gzip_types text/plain text/css application/json application/javascript text/xml application/xml text/javascript image/svg+xml;
+
+        # Security headers
+        add_header X-Frame-Options "SAMEORIGIN" always;
+        add_header X-Content-Type-Options "nosniff" always;
+        add_header Referrer-Policy "strict-origin-when-cross-origin" always;
+
+        location / {
+            root /usr/share/nginx/html;
+            try_files $uri $uri/ /index.html;
+        }
+
+        # Never cache index.html to ensure users always get the latest configuration
+        location = /index.html {
+            root /usr/share/nginx/html;
+            add_header Cache-Control "no-store, no-cache, must-revalidate";
+        }
+
+        location = /runtime-env.js {
+            root /usr/share/nginx/html;
+            add_header Cache-Control "no-store, no-cache, must-revalidate";
+        }
+
+        # Health check for the portal itself
+        location /health {
+            access_log off;
+            return 200 'OK';
+        }
+    }

--- a/deployments/helm/trader-app/templates/pdb.yaml
+++ b/deployments/helm/trader-app/templates/pdb.yaml
@@ -1,0 +1,13 @@
+{{- if .Values.podDisruptionBudget.enabled }}
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: {{ include "trader-app.fullname" . }}
+  labels:
+    {{- include "trader-app.labels" . | nindent 4 }}
+spec:
+  minAvailable: {{ .Values.podDisruptionBudget.minAvailable }}
+  selector:
+    matchLabels:
+      {{- include "trader-app.selectorLabels" . | nindent 6 }}
+{{- end }}

--- a/deployments/helm/trader-app/templates/route.yaml
+++ b/deployments/helm/trader-app/templates/route.yaml
@@ -2,13 +2,13 @@
 apiVersion: route.openshift.io/v1
 kind: Route
 metadata:
-  name: {{ include "trader-app.fullname" . }}
+  name: {{ .Values.route.name | default (include "trader-app.fullname" .) }}
   labels:
     app.kubernetes.io/name: {{ include "trader-app.name" . }}
     app.kubernetes.io/instance: {{ .Release.Name }}
 spec:
   {{- if .Values.route.host }}
-  host: {{ .Values.route.host | quote }}
+  host: {{ .Values.route.host }}
   {{- end }}
   to:
     kind: Service

--- a/deployments/helm/trader-app/values.yaml
+++ b/deployments/helm/trader-app/values.yaml
@@ -17,7 +17,7 @@ securityContext:
       - ALL
 
 image:
-  repository: ghcr.io/opennsw/nsw-trader-portal
+  repository: ghcr.io/opennsw/trader-app
   pullPolicy: IfNotPresent
   tag: latest
 

--- a/deployments/helm/trader-app/values.yaml
+++ b/deployments/helm/trader-app/values.yaml
@@ -1,41 +1,78 @@
-# Default values for trader-app.
+# deployments/helm/trader-app/values.yaml (Base Schema)
 
+global:
+  clusterDomain: "apps.sovecloud1.akaza.lk"
+  namespace: "national-single-window-platform"
+
+fullnameOverride: ""
 replicaCount: 1
+
+podSecurityContext:
+  runAsNonRoot: true
+
+securityContext:
+  allowPrivilegeEscalation: false
+  capabilities:
+    drop:
+      - ALL
 
 image:
   repository: ghcr.io/opennsw/trader-app
   pullPolicy: IfNotPresent
   tag: latest
 
-imagePullSecrets:
-  - name: ghcr-pull-secret
+imagePullSecrets: []
+#  - name: ghcr-secret
 
 service:
   type: ClusterIP
   port: 80
-  targetPort: 80
+  targetPort: 8080
 
+# Generic defaults. Overridden by environment files.
 config:
   apiBaseUrl: "https://nsw-api-national-single-window-platform.lgc.gov.lk/api/v1"
   idpBaseUrl: "https://idp-route.national-single-window-platform.lgc.gov.lk"
   idpClientId: "TRADER_PORTAL_APP"
   appUrl: "https://trader-portal-national-single-window-platform.lgc.gov.lk"
-  idpScopes: "openid,profile,email"
+  idpScopes: "openid,profile,email,group,role"
   idpPlatform: "AsgardeoV2"
+  idpTraderGroupName: "Traders"
+  idpCHAGroupName: "CHA"
   showAutofillButton: "false"
 
 resources:
   limits:
     cpu: 200m
-    memory: 128Mi
+    memory: 256Mi
   requests:
     cpu: 50m
-    memory: 64Mi
+    memory: 128Mi
 
 route:
   enabled: true
-  host: trader-portal-national-single-window-platform.lgc.gov.lk
+  host: "" # Leave empty to let OpenShift auto-generate the hyphenated route
   tls:
     enabled: true
     termination: edge
     insecureEdgeTerminationPolicy: Redirect
+autoscaling:
+  enabled: true
+  minReplicas: 2
+  maxReplicas: 5
+  targetCPUUtilizationPercentage: 80
+  # targetMemoryUtilizationPercentage: 80
+
+podDisruptionBudget:
+  enabled: true
+  minAvailable: 1
+
+affinity:
+  podAntiAffinity:
+    preferredDuringSchedulingIgnoredDuringExecution:
+      - weight: 100
+        podAffinityTerm:
+          labelSelector:
+            matchLabels:
+              app.kubernetes.io/name: trader-app
+          topologyKey: kubernetes.io/hostname

--- a/deployments/helm/trader-app/values.yaml
+++ b/deployments/helm/trader-app/values.yaml
@@ -1,8 +1,8 @@
 # deployments/helm/trader-app/values.yaml (Base Schema)
 
 global:
-  clusterDomain: "apps.sovecloud1.akaza.lk"
-  namespace: "national-single-window-platform"
+  clusterDomain: ""
+  namespace: ""
 
 fullnameOverride: ""
 replicaCount: 1
@@ -17,12 +17,12 @@ securityContext:
       - ALL
 
 image:
-  repository: ghcr.io/opennsw/trader-app
+  repository: ghcr.io/opennsw/nsw-trader-portal
   pullPolicy: IfNotPresent
   tag: latest
 
-imagePullSecrets: []
-#  - name: ghcr-secret
+imagePullSecrets: 
+  - name: ghcr-secret
 
 service:
   type: ClusterIP
@@ -31,10 +31,10 @@ service:
 
 # Generic defaults. Overridden by environment files.
 config:
-  apiBaseUrl: "https://nsw-api-national-single-window-platform.lgc.gov.lk/api/v1"
-  idpBaseUrl: "https://idp-route.national-single-window-platform.lgc.gov.lk"
+  apiBaseUrl: ""
+  idpBaseUrl: ""
   idpClientId: "TRADER_PORTAL_APP"
-  appUrl: "https://trader-portal-national-single-window-platform.lgc.gov.lk"
+  appUrl: ""
   idpScopes: "openid,profile,email,group,role"
   idpPlatform: "AsgardeoV2"
   idpTraderGroupName: "Traders"

--- a/portals/apps/trader-app/Dockerfile
+++ b/portals/apps/trader-app/Dockerfile
@@ -16,20 +16,24 @@ COPY . .
 
 RUN pnpm --filter trader-app build
 
-FROM nginx:1.27-alpine
+FROM nginxinc/nginx-unprivileged:1.27-alpine
 
 LABEL org.opencontainers.image.source="https://github.com/OpenNSW/nsw"
 LABEL org.opencontainers.image.description="NSW Trader Portal Frontend"
 
-COPY apps/trader-app/nginx.conf /etc/nginx/conf.d/default.conf
+COPY apps/trader-app/nginx.conf /etc/nginx/templates/default.conf.template
 COPY --from=builder /workspace/apps/trader-app/dist /usr/share/nginx/html
-COPY apps/trader-app/docker-entrypoint.sh /docker-entrypoint.d/40-runtime-env.sh
 
-RUN chmod +x /docker-entrypoint.d/40-runtime-env.sh
-
-EXPOSE 80
+# OpenShift Compliance: Fix permissions for random UID (Group 0)
+USER root
+COPY --chown=101:0 apps/trader-app/docker-entrypoint.sh /docker-entrypoint.d/40-runtime-env.sh
+RUN chmod +x /docker-entrypoint.d/40-runtime-env.sh && \
+    chmod -R g+w /var/cache/nginx /var/run /var/log/nginx /etc/nginx/conf.d /usr/share/nginx/html
+USER 101
+EXPOSE 8080
 
 HEALTHCHECK --interval=30s --timeout=3s --start-period=5s --retries=3 \
-  CMD wget -qO- http://localhost:80/ || exit 1
+  CMD wget -qO- http://localhost:8080/ || exit 1
 
 CMD ["nginx", "-g", "daemon off;"]
+

--- a/portals/apps/trader-app/nginx.conf
+++ b/portals/apps/trader-app/nginx.conf
@@ -1,6 +1,13 @@
 server {
-  listen 80;
+  listen 8080;
   server_name _;
+  server_tokens off;
+  
+  # Health check for the portal itself
+  location /health {
+    access_log off;
+    return 200 'OK';
+  }
 
   root /usr/share/nginx/html;
   index index.html;


### PR DESCRIPTION
## Summary
Already have all services running. 
Breaking up #285 into smaller pull requests, this one includes Helm Chart for Trader app,  plus Dockerfile and nginx.conf updates 

<img width="1639" height="685" alt="image" src="https://github.com/user-attachments/assets/6a3cde3e-7eb6-4501-8c91-f707d4a7b079" />


## Verified Deployment Routes (nsw-dev)

### Portal Routes
- [trader-app-nsw-dev](https://trader-app-nsw-dev.apps.sovecloud1.akaza.lk/login) — **200 OK**
- [oga-fcau-app-nsw-dev](https://oga-fcau-app-nsw-dev.apps.sovecloud1.akaza.lk/login)
- [oga-npqs-app-nsw-dev](https://oga-npqs-app-nsw-dev.apps.sovecloud1.akaza.lk/login)
- [oga-ird-app-nsw-dev](https://oga-ird-app-nsw-dev.apps.sovecloud1.akaza.lk/login)

### Backend / Infrastructure
- `nsw-api-service-nsw-dev` — **200 OK**
- `temporal-ui-nsw-dev` — **200 OK**
- [idp-thunder-console](https://idp-thunder-national-single-window-platform.apps.sovecloud1.akaza.lk/console/) — **200 OK**
- `oga-fcau-backend-nsw-dev`
- `oga-npqs-backend-nsw-dev`
- `oga-ird-backend-nsw-dev`

## Staging Verification (nsw-staging)
- **nsw-api-service**: [nsw-api-service-nsw-staging](https://nsw-api-service-nsw-staging.apps.sovecloud1.akaza.lk/health) — **200 OK**
- **trader-app**: [trader-app-nsw-staging](https://trader-app-nsw-staging.apps.sovecloud1.akaza.lk/login) — **200 OK**
