### PR TITLE
fix(spa_application): correct JSON formatting in create_spa_application function

### DIFF
--- a/idp/02-sample-resources.sh
+++ b/idp/02-sample-resources.sh
@@ -191,7 +191,7 @@ create_spa_application() {
         read -r -d '' APP_PAYLOAD <<JSON || true
 {
     "name": "${APP_NAME}",
-    "description": "${APP_DESCRIPTION}",${ADDITIONAL_FIELDS}
+    "description": "${APP_DESCRIPTION}",
     "is_registration_flow_enabled": false,
     "template": "react",
     "logo_url": "https://ssl.gstatic.com/docs/common/profile/kiwi_lg.png",


### PR DESCRIPTION
## Summary

This PR fixes a bug in the JSON payload Format for creating Single Page Applications in the Thunder.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Other (please describe):

## Testing

- [x] I have tested this change locally
- [x] I have added unit tests for new functionality
- [x] I have tested edge cases
- [x] All existing tests pass

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have checked that there are no merge conflicts

## Related Issues

No issues created