### PR TITLE
feat(wait_for_event): support dynamic display title and description by plugin state

### DIFF
--- a/backend/internal/task/plugin/wait_for_event.go
+++ b/backend/internal/task/plugin/wait_for_event.go
@@ -21,6 +21,14 @@ const (
 	receivedCallback waitForEventState = "RECEIVED_CALLBACK"
 )
 
+type DisplayState string
+
+const (
+	DisplayStateWaiting   DisplayState = "waiting"
+	DisplayStateFailed    DisplayState = "failed"
+	DisplayStateCompleted DisplayState = "completed"
+)
+
 // Internal FSM actions for WaitForEventTask.
 const (
 	waitForEventFSMStartFailed = "START_FAILED"
@@ -30,8 +38,16 @@ const (
 
 // WaitForEventDisplay holds optional UI display metadata for the portal
 type WaitForEventDisplay struct {
-	Title       string `json:"title"`
-	Description string `json:"description"`
+	Title       any `json:"title"`
+	Description any `json:"description"`
+}
+
+// If Title or Description in WaitForEventDisplay is an object, it should have the following structure to support different text based on task state.
+// Else it will be treated as static text.
+type WaitForEventExtendedDisplay struct {
+	Waiting   *string `json:"waiting,omitempty"`
+	Failed    *string `json:"failed,omitempty"`
+	Completed *string `json:"completed,omitempty"`
 }
 
 // WaitForEventConfig represents the configuration for a WAIT_FOR_EVENT task
@@ -92,10 +108,15 @@ func NewWaitForEventFSM() *PluginFSM {
 
 func (t *WaitForEventTask) renderContent(ctx context.Context) map[string]any {
 	content := map[string]any{}
+	var err error
 	if t.config.Display != nil {
-		content["display"] = t.config.Display
+		state := waitForEventState(t.api.GetPluginState())
+		content["display"], err = t.getDisplay(state)
+		if err != nil {
+			slog.Warn("failed to get display for wait_for_event task, using empty display", "taskId", t.api.GetTaskID(), "error", err)
+			content["display"] = &WaitForEventDisplay{}
+		}
 	}
-
 	// Attach OGA/Reviewer response if it exists in local store
 	if t.config.Submission != nil && t.config.Submission.Response != nil {
 		t.attachFormDisplay(ctx, content, "eventResponse", displayFormID(t.config.Submission.Response), "eventReviewForm")
@@ -235,6 +256,61 @@ func (t *WaitForEventTask) notifyExternalService(ctx context.Context, taskID str
 		return fmt.Errorf("failed to notify external service %q: %w", target, err)
 	}
 	return nil
+}
+
+// getDisplay returns the appropriate title and description based on the current state of the task and the display configuration.
+func (t *WaitForEventTask) getDisplay(state waitForEventState) (*WaitForEventDisplay, error) {
+	if t.config.Display == nil {
+		return nil, fmt.Errorf("display configuration is missing")
+	}
+
+	var resolvedState DisplayState
+	switch state {
+	case notifiedService:
+		resolvedState = DisplayStateWaiting
+	case notifyFailed:
+		resolvedState = DisplayStateFailed
+	case receivedCallback:
+		resolvedState = DisplayStateCompleted
+	default:
+		return nil, fmt.Errorf("unsupported wait_for_event plugin state %q", state)
+	}
+
+	resolvedDisplay := &WaitForEventDisplay{}
+	title, err := resolveDisplayField(t.config.Display.Title, resolvedState, "title")
+	if err != nil {
+		return nil, err
+	}
+	resolvedDisplay.Title = title
+
+	description, err := resolveDisplayField(t.config.Display.Description, resolvedState, "description")
+	if err != nil {
+		return nil, err
+	}
+	resolvedDisplay.Description = description
+
+	return resolvedDisplay, nil
+}
+
+func resolveDisplayField(field any, state DisplayState, fieldName string) (any, error) {
+	switch values := field.(type) {
+	case nil:
+		return nil, nil
+	case string:
+		return values, nil
+	case map[string]any:
+		value, exists := values[string(state)]
+		if !exists {
+			return nil, fmt.Errorf("%s for state %q not found in display configuration", fieldName, state)
+		}
+		strValue, ok := value.(string)
+		if !ok {
+			return nil, fmt.Errorf("invalid type for display %s at state %q, expected string", fieldName, state)
+		}
+		return strValue, nil
+	default:
+		return nil, fmt.Errorf("invalid type for display %s, expected string or map[string]any", fieldName)
+	}
 }
 
 // resolveInputData builds a data map by looking up values from global store based on Template

--- a/backend/internal/task/plugin/wait_for_event_test.go
+++ b/backend/internal/task/plugin/wait_for_event_test.go
@@ -313,6 +313,166 @@ func TestWaitForEventTask_GetRenderInfo_WithDisplay(t *testing.T) {
 	assert.Equal(t, "Please wait while we process your request.", display.Description)
 }
 
+func TestWaitForEventTask_GetRenderInfo_WithDynamicDisplay_UsesPluginState(t *testing.T) {
+	tests := []struct {
+		name          string
+		pluginState   string
+		expectedTitle string
+		expectedDesc  string
+	}{
+		{
+			name:          "waiting state",
+			pluginState:   string(notifiedService),
+			expectedTitle: "Waiting on Sample Drop Off Confirmation",
+			expectedDesc:  "Please drop off your sample at the designated location and confirm the drop off by clicking on this task",
+		},
+		{
+			name:          "failed state",
+			pluginState:   string(notifyFailed),
+			expectedTitle: "Sample Drop Off Confirmation Failed",
+			expectedDesc:  "We have not received confirmation of your sample drop off. Please confirm that you have dropped off your sample by clicking on this task.",
+		},
+		{
+			name:          "completed state",
+			pluginState:   string(receivedCallback),
+			expectedTitle: "Sample Drop Off Confirmation Completed",
+			expectedDesc:  "We have received confirmation of your sample drop off. We will notify you once the test results are available.",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			raw, err := json.Marshal(WaitForEventConfig{
+				Submission: &SubmissionConfig{Url: "http://irrelevant"},
+				Display: &WaitForEventDisplay{
+					Title: map[string]any{
+						"waiting":   "Waiting on Sample Drop Off Confirmation",
+						"failed":    "Sample Drop Off Confirmation Failed",
+						"completed": "Sample Drop Off Confirmation Completed",
+					},
+					Description: map[string]any{
+						"waiting":   "Please drop off your sample at the designated location and confirm the drop off by clicking on this task",
+						"failed":    "We have not received confirmation of your sample drop off. Please confirm that you have dropped off your sample by clicking on this task.",
+						"completed": "We have received confirmation of your sample drop off. We will notify you once the test results are available.",
+					},
+				},
+			})
+			require.NoError(t, err)
+
+			task, taskErr := NewWaitForEventTask(raw, "http://localhost:8080", nil, nil)
+			require.NoError(t, taskErr)
+			api := &wfeAPI{taskID: uuid.NewString(), workflowID: uuid.NewString(), pluginState: tt.pluginState}
+			task.Init(api)
+
+			resp, err := task.GetRenderInfo(context.Background())
+			require.NoError(t, err)
+
+			content, ok := resp.Data.(GetRenderInfoResponse).Content.(map[string]any)
+			require.True(t, ok)
+			display, ok := content["display"].(*WaitForEventDisplay)
+			require.True(t, ok)
+			assert.Equal(t, tt.expectedTitle, display.Title)
+			assert.Equal(t, tt.expectedDesc, display.Description)
+		})
+	}
+}
+
+func TestWaitForEventTask_GetRenderInfo_WithMixedDisplayShape(t *testing.T) {
+	raw, err := json.Marshal(WaitForEventConfig{
+		Submission: &SubmissionConfig{Url: "http://irrelevant"},
+		Display: &WaitForEventDisplay{
+			Title: "Sample Drop Off Confirmation",
+			Description: map[string]any{
+				"waiting":   "Please drop off your sample at the designated location and confirm the drop off by clicking on this task",
+				"failed":    "We have not received confirmation of your sample drop off. Please confirm that you have dropped off your sample by clicking on this task.",
+				"completed": "We have received confirmation of your sample drop off. We will notify you once the test results are available.",
+			},
+		},
+	})
+	require.NoError(t, err)
+
+	task, taskErr := NewWaitForEventTask(raw, "http://localhost:8080", nil, nil)
+	require.NoError(t, taskErr)
+	api := &wfeAPI{taskID: uuid.NewString(), workflowID: uuid.NewString(), pluginState: string(notifyFailed)}
+	task.Init(api)
+
+	resp, err := task.GetRenderInfo(context.Background())
+	require.NoError(t, err)
+
+	content, ok := resp.Data.(GetRenderInfoResponse).Content.(map[string]any)
+	require.True(t, ok)
+	display, ok := content["display"].(*WaitForEventDisplay)
+	require.True(t, ok)
+	assert.Equal(t, "Sample Drop Off Confirmation", display.Title)
+	assert.Equal(t, "We have not received confirmation of your sample drop off. Please confirm that you have dropped off your sample by clicking on this task.", display.Description)
+}
+
+func TestWaitForEventTask_GetRenderInfo_DynamicDisplayMissingStateKey_FallsBackToEmptyDisplay(t *testing.T) {
+	raw, err := json.Marshal(WaitForEventConfig{
+		Submission: &SubmissionConfig{Url: "http://irrelevant"},
+		Display: &WaitForEventDisplay{
+			Title: map[string]any{
+				"waiting": "Waiting on Sample Drop Off Confirmation",
+				"failed":  "Sample Drop Off Confirmation Failed",
+			},
+			Description: map[string]any{
+				"waiting": "Please drop off your sample at the designated location and confirm the drop off by clicking on this task",
+				"failed":  "We have not received confirmation of your sample drop off. Please confirm that you have dropped off your sample by clicking on this task.",
+			},
+		},
+	})
+	require.NoError(t, err)
+
+	task, taskErr := NewWaitForEventTask(raw, "http://localhost:8080", nil, nil)
+	require.NoError(t, taskErr)
+	api := &wfeAPI{taskID: uuid.NewString(), workflowID: uuid.NewString(), pluginState: string(receivedCallback)}
+	task.Init(api)
+
+	resp, err := task.GetRenderInfo(context.Background())
+	require.NoError(t, err)
+
+	content, ok := resp.Data.(GetRenderInfoResponse).Content.(map[string]any)
+	require.True(t, ok)
+	display, ok := content["display"].(*WaitForEventDisplay)
+	require.True(t, ok)
+	assert.Nil(t, display.Title)
+	assert.Nil(t, display.Description)
+}
+
+func TestWaitForEventTask_GetRenderInfo_UnknownPluginState_FallsBackToEmptyDisplay(t *testing.T) {
+	raw, err := json.Marshal(WaitForEventConfig{
+		Submission: &SubmissionConfig{Url: "http://irrelevant"},
+		Display: &WaitForEventDisplay{
+			Title: map[string]any{
+				"waiting":   "Waiting on Sample Drop Off Confirmation",
+				"failed":    "Sample Drop Off Confirmation Failed",
+				"completed": "Sample Drop Off Confirmation Completed",
+			},
+			Description: map[string]any{
+				"waiting":   "Please drop off your sample at the designated location and confirm the drop off by clicking on this task",
+				"failed":    "We have not received confirmation of your sample drop off. Please confirm that you have dropped off your sample by clicking on this task.",
+				"completed": "We have received confirmation of your sample drop off. We will notify you once the test results are available.",
+			},
+		},
+	})
+	require.NoError(t, err)
+
+	task, taskErr := NewWaitForEventTask(raw, "http://localhost:8080", nil, nil)
+	require.NoError(t, taskErr)
+	api := &wfeAPI{taskID: uuid.NewString(), workflowID: uuid.NewString(), pluginState: "UNKNOWN_STATE"}
+	task.Init(api)
+
+	resp, err := task.GetRenderInfo(context.Background())
+	require.NoError(t, err)
+
+	content, ok := resp.Data.(GetRenderInfoResponse).Content.(map[string]any)
+	require.True(t, ok)
+	display, ok := content["display"].(*WaitForEventDisplay)
+	require.True(t, ok)
+	assert.Nil(t, display.Title)
+	assert.Nil(t, display.Description)
+}
+
 // ── Start edge cases ──────────────────────────────────────────────────────────
 
 func TestWaitForEventTask_Start_EmptyURL(t *testing.T) {


### PR DESCRIPTION
## Summary

This PR updates the WAIT_FOR_EVENT plugin to support dynamic display title and description values by plugin state, configured directly in workflow node configuration.

Previously, title and description were static across all plugin states.
Now, the plugin resolves state-specific values for:
- waiting
- failed
- completed

This enables better frontend messaging for each stage of the WAIT_FOR_EVENT lifecycle.

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Other (please describe):

## Changes Made

- Updated WAIT_FOR_EVENT render content logic to resolve display values from plugin state.
- Added state-to-display mapping for waiting, failed, and completed display variants.
- Improved display field resolution logic to support both:
  - static string values
  - dynamic object values keyed by state
- Added validation/fallback behavior for malformed or missing state-specific display keys.
- Added unit tests for:
  - dynamic display resolution across all supported plugin states
  - mixed static and dynamic display field shapes
  - fallback behavior for unknown plugin state
  - fallback behavior for missing state key
- Verified existing plugin tests continue to pass.

## Testing

- [x] I have tested this change locally
- [x] I have added unit tests for new functionality
- [x] I have tested edge cases
- [x] All existing tests pass

### Commands run

- go test ./internal/task/plugin -run WaitForEventTask -count=1
- go test ./internal/task/plugin -count=1

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have checked that there are no merge conflicts

## Related Issues

No issues created

## Additional Notes

Here is a local test migration script to test the new feature. But I didn't push this to the repository.
```sql
BEGIN;

INSERT INTO workflow_node_templates (id, name, description, type, config, depends_on)
VALUES
    (
        'test-wait-for-event-task-template',
        'Sample Drop Off Confirmation',
        'Task to confirm with the applicant if they have dropped off their sample for testing',
        'WAIT_FOR_EVENT',
        ('{
            "display": {
                "title": { 
                    "waiting": "Waiting on Sample Drop Off Confirmation",
                    "failed": "Sample Drop Off Confirmation Failed",
                    "completed": "Sample Drop Off Confirmation Completed"
                },
                "description": {
                    "waiting": "Please drop off your sample at the designated location and confirm the drop off by clicking on this task",
                    "failed": "We have not received confirmation of your sample drop off. Please confirm that you have dropped off your sample by clicking on this task.",
                    "completed": "We have received confirmation of your sample drop off. We will notify you once the test results are available."
                 }
            },
            "submission": {
                "url": ' || to_jsonb((:'FCAU_OGA_SUBMISSION_URL')::text)::text || ',
                "request": {
                    "meta": {
                        "type": "WAIT_FOR_EVENT",
                        "templateKey": "fcau:sample_drop_ack:v1"
                    },
                    "template": {
                        "Cosignee Name": "consignee:consignee_name"
                    }
                },
                "response": {
                    "display": {
                        "formId": "fcau-sample-drop-ack-response"
                    },
                    "mapping": {
                        "acknowledgement": "sample_drop_confirmed"
                    }
                }
            }
        }')::jsonb,
        '[]'
    );

INSERT INTO workflow_template_v2 (id, name, version, workflow_definition)
VALUES
(
    'test-workflow-template-waiting-for-event',
    'Test Workflow for Waiting for Event',
    '1',
    '{
        "id": "test-workflow-template-waiting-for-event",
        "name": "Test Workflow for Waiting for Event",
        "version": 1,
        "nodes": [
            { "id": "node_0_start", "type": "START" },
            { "id": "node_1_gen_info", "type": "TASK", "task_template_id": "c0000003-0003-0003-0003-000000000001", "output_mapping": { "consignee:consignee_name": "gi:consignee:consignee_name", "consignee:countryOfOrigin": "gi:consignee:countryOfOrigin", "consignment:destination": "gi:consignment:destination", "consignee:address": "gi:consignee:address" } },
            { "id": "node_2_wait_for_event", "type": "TASK", "task_template_id": "test-wait-for-event-task-template", "input_mapping": { "gi:consignee:consignee_name": "consignee:consignee_name" }, "output_mapping": { "event_response": "wait_for_event:event_response" } },
            { "id": "node_12_end", "type": "END" }
        ],
        "edges": [
            { "id": "e_start", "source_id": "node_0_start", "target_id": "node_1_gen_info" },
            { "id": "e_gen_info_to_wait_for_event", "source_id": "node_1_gen_info", "target_id": "node_2_wait_for_event" },
            { "id": "e_wait_for_event_to_end", "source_id": "node_2_wait_for_event", "target_id": "node_12_end" }
        ]
    }'::jsonb
) ON CONFLICT (id) DO NOTHING;

INSERT INTO hs_codes (id, hs_code, description, category)
VALUES
    (
        'test-hs-code-id',
        'test-hs-code',
        'Test HS Code for Workflow Testing',
        'Test Category'
    );

INSERT INTO workflow_template_maps_v2 (id, hs_code_id, consignment_flow, workflow_template_id)
VALUES
    (
        'test-workflow-waiting-for-event',
        'test-hs-code-id',
        'EXPORT',
        'test-workflow-template-waiting-for-event'
    ) ON CONFLICT (id) DO NOTHING;

COMMIT;
```

## Manual Testing Guidelines (DB + Trader App)

1. Add the above script at `backend/internal/database/migrations/test.sql`
2. Add `test.sql` to the `MIGRATIONS` array of `backend/internal/database/migrations/run.sh`
3. Run the `./start-dev.sh` in the root
5. In the trader app, select the HS code `test-hs-code-id` and initiate a consignment
6. Proceed through the test workflow and verify state-specific title and description updates are shown for waiting, failed, and completed states.
