### PR TITLE
fix(oga): ensure state persistence after outbound service call succeed

### DIFF
--- a/oga/internal/service.go
+++ b/oga/internal/service.go
@@ -312,10 +312,6 @@ func (s *ogaService) ReviewApplication(ctx context.Context, taskID string, revie
 	}
 	status := decision
 
-	if err := s.store.UpdateStatus(taskID, status, reviewerResponse); err != nil {
-		return fmt.Errorf("failed to update application status: %w", err)
-	}
-
 	// Prepare response payload for the service
 	response := TaskResponse{
 		TaskID:     app.TaskID,
@@ -333,6 +329,12 @@ func (s *ogaService) ReviewApplication(ctx context.Context, taskID string, revie
 			"serviceURL", app.ServiceURL,
 			"error", err)
 		return fmt.Errorf("failed to send response to service: %w", err)
+	}
+
+	if err := s.store.UpdateStatus(taskID, status, reviewerResponse); err != nil {
+		// TODO: If this fails, we have already sent the response to the service but failed to update our record of it. We should consider how to handle this edge case - for now we just log an error.
+		slog.ErrorContext(ctx, "failed to update application status in database after successful service call", "taskID", taskID, "status", status, "error", err)
+		return fmt.Errorf("failed to update application status in database after successful service call: %w", err)
 	}
 
 	slog.InfoContext(ctx, "application reviewed and response sent",
@@ -365,10 +367,6 @@ func (s *ogaService) FeedbackApplication(ctx context.Context, taskID string, con
 		return fmt.Errorf("failed to convert feedback entry: %w", err)
 	}
 
-	if err := s.store.AppendFeedback(taskID, entryMap); err != nil {
-		return fmt.Errorf("failed to store feedback: %w", err)
-	}
-
 	response := TaskResponse{
 		TaskID:     app.TaskID,
 		WorkflowID: app.WorkflowID,
@@ -382,6 +380,12 @@ func (s *ogaService) FeedbackApplication(ctx context.Context, taskID string, con
 		slog.ErrorContext(ctx, "failed to send feedback to NSW service",
 			"taskID", taskID, "serviceURL", app.ServiceURL, "error", err)
 		return fmt.Errorf("failed to send feedback to service: %w", err)
+	}
+
+	if err := s.store.AppendFeedback(taskID, entryMap); err != nil {
+		// TODO: If this fails, we have already sent the feedback to the service but failed to update our record of it. We should consider how to handle this edge case - for now we just log an error.
+		slog.ErrorContext(ctx, "failed to store feedback in database after successful service call", "taskID", taskID, "round", entry.Round, "error", err)
+		return fmt.Errorf("failed to store feedback in database after successful service call: %w", err)
 	}
 
 	slog.InfoContext(ctx, "feedback sent", "taskID", taskID, "round", entry.Round)


### PR DESCRIPTION
## Summary

Fixes a consistency bug in OGA review/feedback flows where database state was updated before the outbound service call completed.

This PR reorders side effects so state changes are persisted only after `sendToService` succeeds. If the outbound call fails, the application record keeps its previous state.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Other (please describe):

## Changes Made

- In `ReviewApplication`, moved `store.UpdateStatus(...)` to run after a successful `sendToService(...)`.
- In `FeedbackApplication`, moved `store.AppendFeedback(...)` to run after a successful `sendToService(...)`.
- Preserved existing validation, payload shape, and logging behavior.
- No schema changes and no API contract changes.

## Testing

- [x] I have tested this change locally
- [ ] I have added unit tests for new functionality
- [x] I have tested edge cases
- [x] All existing tests pass

Local verification run:

- `cd oga && go test ./internal/...`

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have checked that there are no merge conflicts

## Related Issues

No issues created

## Screenshots/Demo

N/A (backend-only change)

## Additional Notes

This fix improves local consistency for the operation flow (external call first, then persistence). It does not implement distributed consistency across services.

Created issue #355 addresses the distributed consistency across services

## Deployment Notes

No special deployment steps required.
