### PR TITLE
feat(oga,httpclient): implement fluent API with ClientBuilder and enhance OAuth2 support

### DIFF
--- a/oga/cmd/server/main.go
+++ b/oga/cmd/server/main.go
@@ -43,7 +43,10 @@ func main() {
 	// TODO: Once M2M Auth Implemented, Uncomment this and pass it to nswHttpClient for automatic token management
 	//nswOAuth2Client := httpclient.NewOAuth2Authenticator(cfg.NSW.ClientID, cfg.NSW.ClientSecret, cfg.NSW.TokenURL, cfg.NSW.Scopes)
 	// Initialize HTTP client for NSW API integration
-	nswHttpClient := httpclient.NewClient(cfg.NSW.BaseURL, 10*time.Second, nil)
+	nswHttpClient := httpclient.NewClientBuilder().
+		WithBaseURL(cfg.NSW.BaseURL).
+		WithTimeout(10 * time.Second).
+		Build()
 
 	// Initialize OGA service
 	service := internal.NewOGAService(store, formStore, nswHttpClient)

--- a/oga/pkg/httpclient/USAGE.md
+++ b/oga/pkg/httpclient/USAGE.md
@@ -1,0 +1,103 @@
+# HTTP Client Package Usage Guide
+
+The `httpclient` package provides a generic, composable HTTP client builder for creating HTTP clients with optional authentication and TLS configuration.
+
+## Core Types
+
+### `Config`
+Generic configuration for HTTP clients:
+```go
+type Config struct {
+    Timeout time.Duration
+    TLS     *TLSConfig
+}
+```
+
+### `TLSConfig`
+Isolated TLS configuration:
+```go
+type TLSConfig struct {
+    InsecureSkipVerify bool // Development only
+}
+```
+
+### `ClientBuilder`
+Fluent API for building clients:
+```go
+client := NewClientBuilder().
+    WithBaseURL("https://api.example.com").
+    WithTimeout(10 * time.Second).
+    WithTLS(&TLSConfig{InsecureSkipVerify: true}).
+    WithAuthenticator(oauth2Auth).
+    Build()
+```
+
+Timeout behavior:
+- `ClientBuilder` defaults to `Timeout: 0` (no request timeout).
+- Use `WithTimeout(...)` explicitly for production workloads.
+
+## Usage Examples
+
+### Basic Client with OAuth2
+```go
+oauth2Client := httpclient.NewOAuth2Authenticator(
+    "client-id",
+    "client-secret",
+    "https://auth.example.com/token",
+    []string{"scope1", "scope2"},
+)
+
+client := httpclient.NewClientBuilder().
+    WithBaseURL("https://api.example.com").
+    WithTimeout(10 * time.Second).
+    WithAuthenticator(oauth2Client).
+    Build()
+
+resp, err := client.Get("/users")
+```
+
+### Client with API Key Authentication
+```go
+apiKeyAuth := httpclient.NewAPIKeyAuthenticator("my-api-key", "X-API-Key")
+
+client := httpclient.NewClientBuilder().
+    WithBaseURL("https://api.example.com").
+    WithAuthenticator(apiKeyAuth).
+    Build()
+```
+
+### Development Client with Insecure TLS
+```go
+client := httpclient.NewClientBuilder().
+    WithBaseURL("https://localhost:8080").
+    WithTLS(&httpclient.TLSConfig{InsecureSkipVerify: true}).
+    WithAuthenticator(oauth2Client).
+    Build()
+```
+
+## Creating Custom Authenticators
+
+Implement the `Authenticator` interface:
+```go
+type Authenticator interface {
+    Authenticate(req *http.Request) error
+}
+
+type CustomAuth struct {
+    token string
+}
+
+func (ca *CustomAuth) Authenticate(req *http.Request) error {
+    req.Header.Set("Authorization", "Bearer " + ca.token)
+    return nil
+}
+```
+
+## Key Features
+
+✅ **Generic** - Works with any authenticator  
+✅ **Composable** - Builder pattern for flexible configuration  
+✅ **Separated Concerns** - TLS, auth, and HTTP config are independent  
+✅ **Clear Responsibility Boundaries** - HTTP client/transport manages connection pooling; OAuth2 authenticator injects access tokens per request  
+✅ **Stable API Surface** - Keep common flows simple and use `Do(req)` for custom methods/headers  
+✅ **Type-Safe** - No string-based configuration  

--- a/oga/pkg/httpclient/apikey_test.go
+++ b/oga/pkg/httpclient/apikey_test.go
@@ -23,7 +23,10 @@ func TestAPIKeyAuthenticator(t *testing.T) {
 	defer server.Close()
 
 	auth := NewAPIKeyAuthenticator(apiKey, header)
-	client := NewClient("", 5*time.Second, auth)
+	client := NewClientBuilder().
+		WithTimeout(5 * time.Second).
+		WithAuthenticator(auth).
+		Build()
 
 	resp, err := client.Get(server.URL)
 	if err != nil {
@@ -57,7 +60,10 @@ func TestAPIKeyAuthenticatorDefaultHeader(t *testing.T) {
 		t.Errorf("expected default header %q, got %q", defaultHeader, auth.Header)
 	}
 
-	client := NewClient("", 5*time.Second, auth)
+	client := NewClientBuilder().
+		WithTimeout(5 * time.Second).
+		WithAuthenticator(auth).
+		Build()
 
 	resp, err := client.Get(server.URL)
 	if err != nil {

--- a/oga/pkg/httpclient/client.go
+++ b/oga/pkg/httpclient/client.go
@@ -2,11 +2,28 @@ package httpclient
 
 import (
 	"bytes"
+	"context"
+	"crypto/tls"
+	"errors"
+	"log/slog"
 	"net/http"
 	"net/url"
 	"strings"
 	"time"
+
+	"golang.org/x/oauth2"
 )
+
+// TLSConfig holds TLS-specific configuration.
+type TLSConfig struct {
+	InsecureSkipVerify bool // If true, TLS certificate verification is disabled (development only)
+}
+
+// Config holds generic HTTP client configuration.
+type Config struct {
+	Timeout time.Duration
+	TLS     *TLSConfig
+}
 
 // Client is a wrapper around *http.Client with built-in authentication and a base URL.
 type Client struct {
@@ -15,23 +32,120 @@ type Client struct {
 	BaseURL    string
 }
 
-// NewClient creates a new HTTP client with the given authenticator and base URL.
-func NewClient(baseURL string, timeout time.Duration, auth Authenticator) *Client {
+// NewHTTPClient creates an HTTP client from a Config.
+func NewHTTPClient(config Config) *http.Client {
+	transport := http.DefaultTransport.(*http.Transport).Clone()
+
+	if config.TLS != nil {
+		transport.TLSClientConfig = &tls.Config{
+			InsecureSkipVerify: config.TLS.InsecureSkipVerify,
+		}
+		if config.TLS.InsecureSkipVerify {
+			slog.Warn("TLS certificate verification disabled - use only in development")
+		}
+	}
+
+	return &http.Client{
+		Timeout:   config.Timeout,
+		Transport: transport,
+	}
+}
+
+// ClientBuilder provides a fluent API for building HTTP clients.
+type ClientBuilder struct {
+	baseURL    string
+	config     Config
+	auth       Authenticator
+	transport  *http.Transport
+	httpClient *http.Client
+}
+
+// NewClientBuilder creates a new ClientBuilder with sensible defaults.
+func NewClientBuilder() *ClientBuilder {
+	return &ClientBuilder{
+		config: Config{
+			Timeout: 0,
+		},
+	}
+}
+
+// WithBaseURL sets the base URL.
+func (cb *ClientBuilder) WithBaseURL(baseURL string) *ClientBuilder {
+	cb.baseURL = baseURL
+	return cb
+}
+
+// WithTimeout sets the HTTP timeout.
+func (cb *ClientBuilder) WithTimeout(timeout time.Duration) *ClientBuilder {
+	cb.config.Timeout = timeout
+	return cb
+}
+
+// WithTLS sets the TLS configuration.
+func (cb *ClientBuilder) WithTLS(tlsConfig *TLSConfig) *ClientBuilder {
+	cb.config.TLS = tlsConfig
+	return cb
+}
+
+// WithAuthenticator sets the authenticator.
+func (cb *ClientBuilder) WithAuthenticator(auth Authenticator) *ClientBuilder {
+	cb.auth = auth
+	return cb
+}
+
+// WithTransport sets a shared transport for the HTTP client.
+// This allows multiple clients to reuse the same connection pool.
+func (cb *ClientBuilder) WithTransport(transport *http.Transport) *ClientBuilder {
+	cb.transport = transport
+	cb.httpClient = nil
+	return cb
+}
+
+// WithHTTPClient sets a pre-configured HTTP client.
+// When set, builder timeout and TLS settings are ignored in favor of the provided client.
+func (cb *ClientBuilder) WithHTTPClient(httpClient *http.Client) *ClientBuilder {
+	cb.httpClient = httpClient
+	cb.transport = nil
+	return cb
+}
+
+// Build creates the Client.
+func (cb *ClientBuilder) Build() *Client {
+	baseURL := cb.baseURL
 	if baseURL != "" && !strings.HasSuffix(baseURL, "/") {
 		baseURL += "/"
 	}
+
+	httpClient := cb.httpClient
+	if httpClient == nil {
+		if cb.transport != nil {
+			httpClient = &http.Client{
+				Timeout:   cb.config.Timeout,
+				Transport: cb.transport,
+			}
+		} else {
+			httpClient = NewHTTPClient(cb.config)
+		}
+	}
+
 	return &Client{
-		httpClient: &http.Client{
-			Timeout: timeout,
-		},
-		auth:    auth,
-		BaseURL: baseURL,
+		httpClient: httpClient,
+		auth:       cb.auth,
+		BaseURL:    baseURL,
 	}
 }
 
 // Do performs an HTTP request and applies authentication.
 func (c *Client) Do(req *http.Request) (*http.Response, error) {
+	if req == nil {
+		return nil, errors.New("http request is nil")
+	}
 	if c.auth != nil && c.shouldAuthenticate(req) {
+		// Inject HTTP client into the context so OAuth2 token fetches
+		// use the same transport (e.g. InsecureSkipVerify TLS config).
+		ctx := context.WithValue(req.Context(), oauth2.HTTPClient, c.httpClient)
+		req = req.WithContext(ctx)
+
 		if err := c.auth.Authenticate(req); err != nil {
 			return nil, err
 		}

--- a/oga/pkg/httpclient/client_test.go
+++ b/oga/pkg/httpclient/client_test.go
@@ -1,12 +1,15 @@
 package httpclient
 
 import (
+	"context"
 	"fmt"
 	"io"
 	"net/http"
 	"net/http/httptest"
 	"testing"
 	"time"
+
+	"golang.org/x/oauth2"
 )
 
 func TestNoAuthenticator(t *testing.T) {
@@ -15,7 +18,9 @@ func TestNoAuthenticator(t *testing.T) {
 	}))
 	defer server.Close()
 
-	client := NewClient("", 5*time.Second, nil)
+	client := NewClientBuilder().
+		WithTimeout(5 * time.Second).
+		Build()
 
 	resp, err := client.Get(server.URL)
 	if err != nil {
@@ -47,7 +52,9 @@ func TestPost(t *testing.T) {
 	}))
 	defer server.Close()
 
-	client := NewClient("", 5*time.Second, nil)
+	client := NewClientBuilder().
+		WithTimeout(5 * time.Second).
+		Build()
 	resp, err := client.Post(server.URL, expectedContentType, []byte(expectedBody))
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -71,7 +78,10 @@ func (m *MockAuthenticator) Authenticate(req *http.Request) error {
 func TestDoAuthenticationFailure(t *testing.T) {
 	authErr := fmt.Errorf("auth failed")
 	auth := &MockAuthenticator{err: authErr}
-	client := NewClient("", 5*time.Second, auth)
+	client := NewClientBuilder().
+		WithTimeout(5 * time.Second).
+		WithAuthenticator(auth).
+		Build()
 
 	req, _ := http.NewRequest(http.MethodGet, "http://example.com", nil)
 	resp, err := client.Do(req)
@@ -85,7 +95,9 @@ func TestDoAuthenticationFailure(t *testing.T) {
 }
 
 func TestGetInvalidURL(t *testing.T) {
-	client := NewClient("", 5*time.Second, nil)
+	client := NewClientBuilder().
+		WithTimeout(5 * time.Second).
+		Build()
 	_, err := client.Get(":") // Invalid URL
 	if err == nil {
 		t.Error("expected error for invalid URL in Get")
@@ -109,7 +121,9 @@ func TestPostResolveURLError(t *testing.T) {
 }
 
 func TestPostInvalidURL(t *testing.T) {
-	client := NewClient("", 5*time.Second, nil)
+	client := NewClientBuilder().
+		WithTimeout(5 * time.Second).
+		Build()
 	_, err := client.Post("http://[::1]:80%2g/", "text/plain", nil) // Invalid URL
 	if err == nil {
 		t.Error("expected error for invalid URL in Post")
@@ -117,7 +131,10 @@ func TestPostInvalidURL(t *testing.T) {
 }
 
 func TestResolveURLPathError(t *testing.T) {
-	client := NewClient("http://example.com", 1*time.Second, nil)
+	client := NewClientBuilder().
+		WithBaseURL("http://example.com").
+		WithTimeout(1 * time.Second).
+		Build()
 	// Triggering url.Parse error on path is hard, but let's try something with control characters
 	_, _ = client.resolveURL("http://[::1]:80%2g/")
 	// Wait, if path has http:// prefix it returns early.
@@ -128,7 +145,7 @@ func TestResolveURLPathError(t *testing.T) {
 	}
 }
 
-func TestNewClientBaseURL(t *testing.T) {
+func TestClientBuilderBaseURL(t *testing.T) {
 	tests := []struct {
 		baseURL  string
 		expected string
@@ -139,7 +156,10 @@ func TestNewClientBaseURL(t *testing.T) {
 	}
 
 	for _, tc := range tests {
-		client := NewClient(tc.baseURL, 1*time.Second, nil)
+		client := NewClientBuilder().
+			WithBaseURL(tc.baseURL).
+			WithTimeout(1 * time.Second).
+			Build()
 		if client.BaseURL != tc.expected {
 			t.Errorf("expected BaseURL %q, got %q", tc.expected, client.BaseURL)
 		}
@@ -162,7 +182,10 @@ func TestResolveURL(t *testing.T) {
 	}
 
 	for _, tc := range tests {
-		client := NewClient(tc.baseURL, 1*time.Second, nil)
+		client := NewClientBuilder().
+			WithBaseURL(tc.baseURL).
+			WithTimeout(1 * time.Second).
+			Build()
 		got, err := client.resolveURL(tc.path)
 		if err != nil {
 			t.Errorf("unexpected error for baseURL %q and path %q: %v", tc.baseURL, tc.path, err)
@@ -197,7 +220,11 @@ func TestAuthLeakPrevention(t *testing.T) {
 	apiKey := "secret-key"
 	auth := NewAPIKeyAuthenticator(apiKey, "")
 	baseURL := "https://api.trusted.com"
-	client := NewClient(baseURL, 5*time.Second, auth)
+	client := NewClientBuilder().
+		WithBaseURL(baseURL).
+		WithTimeout(5 * time.Second).
+		WithAuthenticator(auth).
+		Build()
 
 	// Mock an external server
 	externalServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -222,5 +249,97 @@ func TestShouldAuthenticateInvalidBaseURL(t *testing.T) {
 	req, _ := http.NewRequest(http.MethodGet, "http://example.com", nil)
 	if client.shouldAuthenticate(req) {
 		t.Error("shouldAuthenticate should return false for invalid BaseURL")
+	}
+}
+
+func TestDoCustomMethod(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPatch {
+			t.Errorf("expected PATCH method, got %v", r.Method)
+		}
+		if got := r.Header.Get("X-Custom"); got != "1" {
+			t.Errorf("expected X-Custom header to be set, got %q", got)
+		}
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	defer server.Close()
+
+	client := NewClientBuilder().
+		WithTimeout(5 * time.Second).
+		Build()
+
+	req, err := http.NewRequest(http.MethodPatch, server.URL, nil)
+	if err != nil {
+		t.Fatalf("unexpected error creating request: %v", err)
+	}
+	req.Header.Set("X-Custom", "1")
+
+	resp, err := client.Do(req)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusNoContent {
+		t.Errorf("expected status NoContent, got %v", resp.Status)
+	}
+}
+
+func TestDoNilRequest(t *testing.T) {
+	client := NewClientBuilder().
+		WithTimeout(5 * time.Second).
+		Build()
+
+	resp, err := client.Do(nil)
+	if err == nil {
+		t.Fatal("expected error for nil request")
+	}
+	if err.Error() != "http request is nil" {
+		t.Fatalf("expected nil request error, got %v", err)
+	}
+	if resp != nil {
+		t.Fatal("expected nil response for nil request")
+	}
+}
+
+// ContextCapturingAuthenticator captures the context from the request for inspection.
+type ContextCapturingAuthenticator struct {
+	capturedCtx context.Context
+}
+
+func (c *ContextCapturingAuthenticator) Authenticate(req *http.Request) error {
+	c.capturedCtx = req.Context()
+	return nil
+}
+
+func TestDoInjectsHTTPClientIntoContext(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	auth := &ContextCapturingAuthenticator{}
+	client := NewClientBuilder().
+		WithTimeout(5 * time.Second).
+		WithBaseURL(server.URL).
+		WithAuthenticator(auth).
+		Build()
+
+	req, _ := http.NewRequest(http.MethodGet, server.URL, nil)
+	resp, err := client.Do(req)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	defer resp.Body.Close()
+
+	// Verify the oauth2.HTTPClient was injected into the context the authenticator received
+	injected, ok := auth.capturedCtx.Value(oauth2.HTTPClient).(*http.Client)
+	if !ok || injected == nil {
+		t.Fatal("expected oauth2.HTTPClient to be injected into request context")
+	}
+
+	// Verify it is exactly the client's own httpClient (same pointer)
+	if injected != client.httpClient {
+		t.Error("injected HTTP client does not match the client's internal httpClient")
 	}
 }

--- a/oga/pkg/httpclient/integration_test.go
+++ b/oga/pkg/httpclient/integration_test.go
@@ -1,0 +1,592 @@
+package httpclient
+
+import (
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+)
+
+// TestClientBuilder tests the ClientBuilder fluent API
+func TestClientBuilder(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	client := NewClientBuilder().
+		WithBaseURL(server.URL).
+		WithTimeout(5 * time.Second).
+		Build()
+
+	if client.BaseURL != server.URL+"/" {
+		t.Errorf("expected base URL %q, got %q", server.URL+"/", client.BaseURL)
+	}
+
+	resp, err := client.Get("/path")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		t.Errorf("expected status OK, got %v", resp.Status)
+	}
+}
+
+// TestClientBuilderWithAuthenticator tests the builder with an authenticator
+func TestClientBuilderWithAuthenticator(t *testing.T) {
+	expectedAPIKey := "test-api-key"
+
+	apiServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		auth := r.Header.Get("X-API-Key")
+		if auth != expectedAPIKey {
+			t.Errorf("expected API key %q, got %q", expectedAPIKey, auth)
+			w.WriteHeader(http.StatusUnauthorized)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer apiServer.Close()
+
+	apiKeyAuth := NewAPIKeyAuthenticator(expectedAPIKey, "X-API-Key")
+	client := NewClientBuilder().
+		WithBaseURL(apiServer.URL).
+		WithAuthenticator(apiKeyAuth).
+		Build()
+
+	resp, err := client.Get("/api/data")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		t.Errorf("expected status OK, got %v", resp.Status)
+	}
+}
+
+// TestClientBuilderWithTLS tests the builder with TLS configuration
+func TestClientBuilderWithTLS(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	tlsConfig := &TLSConfig{
+		InsecureSkipVerify: false, // Secure by default
+	}
+
+	client := NewClientBuilder().
+		WithBaseURL(server.URL).
+		WithTLS(tlsConfig).
+		Build()
+
+	resp, err := client.Get("/")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		t.Errorf("expected status OK, got %v", resp.Status)
+	}
+}
+
+// TestNewHTTPClientWithConfig tests HTTPClient creation with Config
+func TestNewHTTPClientWithConfig(t *testing.T) {
+	config := Config{
+		Timeout: 10 * time.Second,
+		TLS: &TLSConfig{
+			InsecureSkipVerify: false,
+		},
+	}
+
+	httpClient := NewHTTPClient(config)
+
+	if httpClient.Timeout != 10*time.Second {
+		t.Errorf("expected timeout 10s, got %v", httpClient.Timeout)
+	}
+
+	// Verify transport has TLS config
+	transport, ok := httpClient.Transport.(*http.Transport)
+	if !ok {
+		t.Fatal("expected http.Transport")
+	}
+
+	if transport.TLSClientConfig == nil {
+		t.Error("expected TLSClientConfig to be set when TLS is configured")
+	} else if transport.TLSClientConfig.InsecureSkipVerify {
+		t.Error("expected InsecureSkipVerify to be false")
+	}
+}
+
+// TestNewHTTPClientWithoutTLS tests HTTPClient creation without TLS
+func TestNewHTTPClientWithoutTLS(t *testing.T) {
+	config := Config{
+		Timeout: 10 * time.Second,
+		TLS:     nil, // No TLS config
+	}
+
+	httpClient := NewHTTPClient(config)
+
+	if httpClient.Timeout != 10*time.Second {
+		t.Errorf("expected timeout 10s, got %v", httpClient.Timeout)
+	}
+
+	// Verify transport doesn't have TLS config
+	transport, ok := httpClient.Transport.(*http.Transport)
+	if !ok {
+		t.Fatal("expected http.Transport")
+	}
+
+	if transport.TLSClientConfig != nil && transport.TLSClientConfig.InsecureSkipVerify {
+		t.Error("expected InsecureSkipVerify to be false when TLS is not configured")
+	}
+}
+
+// TestNewHTTPClientWithInsecureTLS tests HTTPClient creation with insecure TLS
+func TestNewHTTPClientWithInsecureTLS(t *testing.T) {
+	config := Config{
+		Timeout: 5 * time.Second,
+		TLS: &TLSConfig{
+			InsecureSkipVerify: true, // Development only
+		},
+	}
+
+	httpClient := NewHTTPClient(config)
+
+	transport, ok := httpClient.Transport.(*http.Transport)
+	if !ok {
+		t.Fatal("expected http.Transport")
+	}
+
+	if !transport.TLSClientConfig.InsecureSkipVerify {
+		t.Error("expected InsecureSkipVerify to be true")
+	}
+}
+
+// TestClientBuilderFullIntegration tests a complete flow with builder, OAuth2, and TLS config
+func TestClientBuilderFullIntegration(t *testing.T) {
+	clientID := "integration-test-client"
+	clientSecret := "integration-test-secret"
+	expectedToken := "integration-test-token"
+
+	// Mock token server
+	tokenServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprintf(w, `{
+			"access_token": "%s",
+			"token_type": "Bearer",
+			"expires_in": 3600
+		}`, expectedToken)
+	}))
+	defer tokenServer.Close()
+
+	// Mock API server
+	apiServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodGet && r.URL.Path == "/api/data" {
+			auth := r.Header.Get("Authorization")
+			if auth == "Bearer "+expectedToken {
+				w.Header().Set("Content-Type", "application/json")
+				w.WriteHeader(http.StatusOK)
+				w.Write([]byte(`{"data": "test"}`))
+				return
+			}
+		}
+		w.WriteHeader(http.StatusUnauthorized)
+	}))
+	defer apiServer.Close()
+
+	// Create OAuth2 authenticator
+	oauth2Auth := NewOAuth2Authenticator(
+		clientID,
+		clientSecret,
+		tokenServer.URL,
+		[]string{"read", "write"},
+	)
+
+	// Build client with fluent API
+	client := NewClientBuilder().
+		WithBaseURL(apiServer.URL).
+		WithTimeout(10 * time.Second).
+		WithTLS(&TLSConfig{InsecureSkipVerify: false}).
+		WithAuthenticator(oauth2Auth).
+		Build()
+
+	// Make request
+	resp, err := client.Get("/api/data")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		t.Errorf("expected status OK, got %v", resp.Status)
+	}
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		t.Fatalf("unexpected error reading body: %v", err)
+	}
+
+	if string(body) != `{"data": "test"}` {
+		t.Errorf("expected response body %q, got %q", `{"data": "test"}`, string(body))
+	}
+}
+
+// TestClientBuilderExplicitTimeout verifies timeout is explicitly configured via WithTimeout.
+func TestClientBuilderExplicitTimeout(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	// Callers should explicitly select timeout behavior.
+	client := NewClientBuilder().
+		WithBaseURL(server.URL).
+		WithTimeout(5 * time.Second).
+		Build()
+
+	if client.httpClient.Timeout != 5*time.Second {
+		t.Fatalf("expected timeout 5s, got %v", client.httpClient.Timeout)
+	}
+
+	resp, err := client.Get("/")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		t.Errorf("expected status OK, got %v", resp.Status)
+	}
+}
+
+// TestClientBuilderMultipleAuthenticators tests builder with different authenticators
+func TestClientBuilderMultipleAuthenticators(t *testing.T) {
+	testCases := []struct {
+		name          string
+		authenticator Authenticator
+		headerName    string
+		headerValue   string
+		expectedAuth  string
+	}{
+		{
+			name:          "APIKey",
+			authenticator: NewAPIKeyAuthenticator("secret-key", "X-API-Key"),
+			headerName:    "X-API-Key",
+			headerValue:   "secret-key",
+			expectedAuth:  "secret-key",
+		},
+		{
+			name:          "APIKeyDefault",
+			authenticator: NewAPIKeyAuthenticator("another-key", ""),
+			headerName:    "X-API-Key",
+			headerValue:   "another-key",
+			expectedAuth:  "another-key",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				auth := r.Header.Get(tc.headerName)
+				if auth != tc.expectedAuth {
+					t.Errorf("expected header %q to be %q, got %q", tc.headerName, tc.expectedAuth, auth)
+					w.WriteHeader(http.StatusUnauthorized)
+					return
+				}
+				w.WriteHeader(http.StatusOK)
+			}))
+			defer server.Close()
+
+			client := NewClientBuilder().
+				WithBaseURL(server.URL).
+				WithAuthenticator(tc.authenticator).
+				Build()
+
+			resp, err := client.Get("/protected")
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			defer resp.Body.Close()
+
+			if resp.StatusCode != http.StatusOK {
+				t.Errorf("expected status OK, got %v", resp.Status)
+			}
+		})
+	}
+}
+
+// TestBuilderConstruction validates the canonical builder construction path.
+func TestBuilderConstruction(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	client := NewClientBuilder().
+		WithBaseURL(server.URL).
+		WithTimeout(5 * time.Second).
+		Build()
+
+	resp, err := client.Get("/")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		t.Errorf("expected status OK, got %v", resp.Status)
+	}
+}
+
+// TestConfigURLResolution tests URL resolution with base URL
+func TestConfigURLResolution(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/api/v1/users/123" {
+			t.Errorf("expected path /api/v1/users/123, got %v", r.URL.Path)
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	client := NewClientBuilder().
+		WithBaseURL(server.URL + "/api/v1").
+		Build()
+
+	resp, err := client.Get("users/123")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		t.Errorf("expected status OK, got %v", resp.Status)
+	}
+}
+
+// TestClientBuilderPost tests POST requests with the builder pattern
+func TestClientBuilderPost(t *testing.T) {
+	expectedBody := "test data"
+	expectedContentType := "application/json"
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			t.Errorf("expected POST, got %v", r.Method)
+		}
+		if ct := r.Header.Get("Content-Type"); ct != expectedContentType {
+			t.Errorf("expected Content-Type %q, got %q", expectedContentType, ct)
+		}
+		body, _ := io.ReadAll(r.Body)
+		if string(body) != expectedBody {
+			t.Errorf("expected body %q, got %q", expectedBody, string(body))
+		}
+		w.WriteHeader(http.StatusCreated)
+	}))
+	defer server.Close()
+
+	client := NewClientBuilder().
+		WithBaseURL(server.URL).
+		Build()
+
+	resp, err := client.Post("/data", expectedContentType, []byte(expectedBody))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusCreated {
+		t.Errorf("expected status Created, got %v", resp.Status)
+	}
+}
+
+// TestTLSConfigTransport verifies TLS transport is properly configured
+func TestTLSConfigTransport(t *testing.T) {
+	testCases := []struct {
+		name                string
+		tlsConfig           *TLSConfig
+		expectedInsecure    bool
+		shouldHaveTLSConfig bool
+	}{
+		{
+			name:                "NoTLS",
+			tlsConfig:           nil,
+			expectedInsecure:    false,
+			shouldHaveTLSConfig: false,
+		},
+		{
+			name:                "SecureTLS",
+			tlsConfig:           &TLSConfig{InsecureSkipVerify: false},
+			expectedInsecure:    false,
+			shouldHaveTLSConfig: true,
+		},
+		{
+			name:                "InsecureTLS",
+			tlsConfig:           &TLSConfig{InsecureSkipVerify: true},
+			expectedInsecure:    true,
+			shouldHaveTLSConfig: true,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			config := Config{
+				Timeout: 5 * time.Second,
+				TLS:     tc.tlsConfig,
+			}
+
+			httpClient := NewHTTPClient(config)
+			transport, ok := httpClient.Transport.(*http.Transport)
+			if !ok {
+				t.Fatal("expected *http.Transport")
+			}
+
+			if !tc.shouldHaveTLSConfig && transport.TLSClientConfig != nil {
+				if transport.TLSClientConfig.InsecureSkipVerify {
+					t.Error("expected InsecureSkipVerify to be false when TLS config is not provided")
+				}
+			}
+
+			if tc.shouldHaveTLSConfig {
+				if transport.TLSClientConfig == nil {
+					t.Fatal("expected TLSClientConfig to be set")
+				}
+				if transport.TLSClientConfig.InsecureSkipVerify != tc.expectedInsecure {
+					t.Errorf("expected InsecureSkipVerify %v, got %v",
+						tc.expectedInsecure,
+						transport.TLSClientConfig.InsecureSkipVerify)
+				}
+			}
+		})
+	}
+}
+
+func TestClientBuilderWithSharedTransport(t *testing.T) {
+	sharedTransport := &http.Transport{}
+
+	clientA := NewClientBuilder().
+		WithTimeout(5 * time.Second).
+		WithTransport(sharedTransport).
+		Build()
+
+	clientB := NewClientBuilder().
+		WithTimeout(10 * time.Second).
+		WithTransport(sharedTransport).
+		Build()
+
+	transportA, ok := clientA.httpClient.Transport.(*http.Transport)
+	if !ok {
+		t.Fatal("expected clientA transport to be *http.Transport")
+	}
+
+	transportB, ok := clientB.httpClient.Transport.(*http.Transport)
+	if !ok {
+		t.Fatal("expected clientB transport to be *http.Transport")
+	}
+
+	if transportA != sharedTransport {
+		t.Fatal("expected clientA to use the shared transport instance")
+	}
+
+	if transportB != sharedTransport {
+		t.Fatal("expected clientB to use the shared transport instance")
+	}
+}
+
+func TestClientBuilderWithHTTPClientReuse(t *testing.T) {
+	sharedClient := &http.Client{
+		Timeout:   42 * time.Second,
+		Transport: &http.Transport{},
+	}
+
+	client := NewClientBuilder().
+		WithTimeout(1 * time.Second).
+		WithTLS(&TLSConfig{InsecureSkipVerify: true}).
+		WithHTTPClient(sharedClient).
+		Build()
+
+	if client.httpClient != sharedClient {
+		t.Fatal("expected builder to use the provided HTTP client instance")
+	}
+
+	if client.httpClient.Timeout != 42*time.Second {
+		t.Fatalf("expected provided client timeout to be preserved, got %v", client.httpClient.Timeout)
+	}
+}
+
+func TestOAuth2TokenFetchUsesClientTLSConfig(t *testing.T) {
+	expectedToken := "tls-test-token"
+
+	// TLS token server — has a self-signed cert that would normally fail verification
+	tokenServer := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprintf(w, `{"access_token": "%s", "token_type": "Bearer", "expires_in": 3600}`, expectedToken)
+	}))
+	defer tokenServer.Close()
+
+	// Plain API server — TLS is only relevant for the token fetch
+	apiServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Header.Get("Authorization") != "Bearer "+expectedToken {
+			w.WriteHeader(http.StatusUnauthorized)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer apiServer.Close()
+
+	oauth2Auth := NewOAuth2Authenticator(
+		"client-id",
+		"client-secret",
+		tokenServer.URL+"/token",
+		nil,
+	)
+
+	// InsecureSkipVerify: true — required for the self-signed cert on tokenServer
+	client := NewClientBuilder().
+		WithBaseURL(apiServer.URL).
+		WithTimeout(5 * time.Second).
+		WithTLS(&TLSConfig{InsecureSkipVerify: true}).
+		WithAuthenticator(oauth2Auth).
+		Build()
+
+	resp, err := client.Get("/")
+	if err != nil {
+		t.Fatalf("unexpected error (token fetch likely failed TLS verification): %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		t.Errorf("expected 200 OK, got %v", resp.Status)
+	}
+}
+
+func TestOAuth2TokenFetchFailsWithoutInsecureSkipVerify(t *testing.T) {
+	tokenServer := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprintf(w, `{"access_token": "token", "token_type": "Bearer", "expires_in": 3600}`)
+	}))
+	defer tokenServer.Close()
+
+	apiServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer apiServer.Close()
+
+	oauth2Auth := NewOAuth2Authenticator("id", "secret", tokenServer.URL+"/token", nil)
+
+	// No InsecureSkipVerify — token fetch should fail certificate verification
+	client := NewClientBuilder().
+		WithBaseURL(apiServer.URL).
+		WithTimeout(5 * time.Second).
+		WithAuthenticator(oauth2Auth).
+		Build()
+
+	_, err := client.Get("/")
+	if err == nil {
+		t.Fatal("expected TLS certificate verification error, got nil")
+	}
+}

--- a/oga/pkg/httpclient/oauth2_test.go
+++ b/oga/pkg/httpclient/oauth2_test.go
@@ -1,6 +1,7 @@
 package httpclient
 
 import (
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -38,7 +39,10 @@ func TestOAuth2Authenticator(t *testing.T) {
 	defer apiServer.Close()
 
 	auth := NewOAuth2Authenticator(clientID, clientSecret, tokenServer.URL, nil)
-	client := NewClient("", 5*time.Second, auth)
+	client := NewClientBuilder().
+		WithTimeout(5 * time.Second).
+		WithAuthenticator(auth).
+		Build()
 
 	resp, err := client.Get(apiServer.URL)
 	if err != nil {
@@ -59,10 +63,50 @@ func TestOAuth2AuthenticatorFailure(t *testing.T) {
 	defer tokenServer.Close()
 
 	auth := NewOAuth2Authenticator("id", "secret", tokenServer.URL, nil)
-	client := NewClient("", 5*time.Second, auth)
+	client := NewClientBuilder().
+		WithTimeout(5 * time.Second).
+		WithAuthenticator(auth).
+		Build()
 
 	_, err := client.Get("http://example.com")
 	if err == nil {
 		t.Error("expected error on token fetch failure")
+	}
+}
+
+func TestOAuth2AuthenticatorWithInsecureTLS(t *testing.T) {
+	token := "tls-bearer-token"
+
+	// Self-signed cert token server — would fail without InsecureSkipVerify
+	tokenServer := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprintf(w, `{"access_token": "%s", "token_type": "Bearer", "expires_in": 3600}`, token)
+	}))
+	defer tokenServer.Close()
+
+	apiServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Header.Get("Authorization") != "Bearer "+token {
+			w.WriteHeader(http.StatusUnauthorized)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer apiServer.Close()
+
+	auth := NewOAuth2Authenticator("id", "secret", tokenServer.URL+"/token", nil)
+	client := NewClientBuilder().
+		WithTimeout(5 * time.Second).
+		WithTLS(&TLSConfig{InsecureSkipVerify: true}).
+		WithAuthenticator(auth).
+		Build()
+
+	resp, err := client.Get(apiServer.URL)
+	if err != nil {
+		t.Fatalf("token fetch failed TLS verification: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		t.Errorf("expected 200 OK, got %v", resp.Status)
 	}
 }


### PR DESCRIPTION
## Summary

Introduce a fluent HTTP client builder to make client construction more composable and reusable across the codebase.  
This PR replaces ad-hoc client setup patterns with a structured builder API and updates OGA server wiring to use the new builder.

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [x] Refactoring (no functional changes)
- [x] Performance improvement
- [ ] Other (please describe):

## Changes Made

- Implemented `ClientBuilder` fluent API for HTTP client construction in the `httpclient` package
- Added support for:
  - Base URL configuration
  - Explicit timeout configuration
  - TLS configuration
  - Authenticator injection
  - Shared `http.Transport` reuse
  - Preconfigured `http.Client` injection
- Updated `NewHTTPClient` transport behavior to preserve sane Go defaults while allowing TLS overrides
- Added request safety guard in `Client.Do` for nil requests
- Centralized and expanded tests for builder behavior, transport reuse, auth behavior, and edge cases
- Updated package usage documentation to reflect the builder-first API
- Updated OGA server wiring to use `ClientBuilder` in main.go

## Testing

- [x] I have tested this change locally
- [x] I have added unit tests for new functionality
- [x] I have tested edge cases
- [x] All existing tests pass

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have checked that there are no merge conflicts

## Related Issues

Related to #342

## Additional Notes

This PR focuses on the HTTP client foundation and builder adoption.  
The server integration was updated to consume the new builder API for consistency and future extensibility.

## Deployment Notes

No special deployment steps required.