### PR TITLE
feat(upload part 1): implement pre-signed URLs in upload service 

### DIFF
--- a/api/openapi-uploads.yaml
+++ b/api/openapi-uploads.yaml
@@ -29,19 +29,24 @@ paths:
       requestBody:
         required: true
         content:
-          multipart/form-data:
+          application/json:
             schema:
               type: object
               required:
-                - file
+                - filename
+                - mime_type
+                - size
               properties:
-                file:
+                filename:
                   type: string
-                  format: binary
-                  description: The file to upload
-            encoding:
-              file:
-                contentType: application/octet-stream
+                  description: The original filename
+                mime_type:
+                  type: string
+                  description: The MIME type of the file
+                size:
+                  type: integer
+                  format: int64
+                  description: The file size in bytes
       responses:
         "200":
           description: File uploaded successfully
@@ -53,9 +58,10 @@ paths:
                 id: "550e8400-e29b-41d4-a716-446655440000"
                 name: "document.pdf"
                 key: "550e8400-e29b-41d4-a716-446655440000.pdf"
-                url: "/bucket/550e8400-e29b-41d4-a716-446655440000.pdf"
+                url: "/api/v1/uploads/550e8400-e29b-41d4-a716-446655440000.pdf/content"
+                upload_url: "/api/v1/uploads/local-put/550e8400-e29b-41d4-a716-446655440000.pdf?token=..."
                 size: 1024000
-                mimeType: "application/pdf"
+                mime_type: "application/pdf"
         "400":
           description: Bad request - file is required or invalid
           content:
@@ -75,11 +81,10 @@ paths:
 
   /uploads/{key}:
     get:
-      summary: Download File
+      summary: Get File Download URL
       description: >
-        Download a previously uploaded file by its unique key.
-        Returns the file content with the appropriate content type.
-      operationId: downloadFile
+        Fetches a presigned or limited-time URL to securely download the file content.
+      operationId: getDownloadUrl
       tags:
         - Uploads
       parameters:
@@ -92,20 +97,20 @@ paths:
           example: "550e8400-e29b-41d4-a716-446655440000.pdf"
       responses:
         "200":
-          description: File retrieved successfully
+          description: Download URL generated successfully
           content:
-            application/octet-stream:
+            application/json:
               schema:
-                type: string
-                format: binary
-            application/pdf:
-              schema:
-                type: string
-                format: binary
-            image/*:
-              schema:
-                type: string
-                format: binary
+                type: object
+                properties:
+                  download_url:
+                    type: string
+                    description: The presigned URL to download the actual file contents
+                    example: "/api/v1/uploads/550e8400-e29b-41d4-a716-446655440000.pdf/content?token=12345&expiresAt=123"
+                  expires_at:
+                    type: integer
+                    description: Unix timestamp indicating when the link expires
+                    example: 1713256000
         "400":
           description: Bad request - key is required or invalid
           content:
@@ -168,11 +173,9 @@ components:
       type: object
       required:
         - id
-        - name
         - key
-        - url
         - size
-        - mimeType
+        - mime_type
       properties:
         id:
           type: string
@@ -190,13 +193,17 @@ components:
         url:
           type: string
           description: Public URL to access the file
-          example: "/bucket/550e8400-e29b-41d4-a716-446655440000.pdf"
+          example: "/api/v1/uploads/550e8400-e29b-41d4-a716-446655440000.pdf/content"
+        upload_url:
+          type: string
+          description: Presigned or local URL for uploading the file content
+          example: "/api/v1/uploads/local-put/550e8400-e29b-41d4-a716-446655440000.pdf?token=..."
         size:
           type: integer
           format: int64
           description: File size in bytes
           example: 1024000
-        mimeType:
+        mime_type:
           type: string
           description: MIME type of the uploaded file
           example: "application/pdf"

--- a/api/openapi-uploads.yaml
+++ b/api/openapi-uploads.yaml
@@ -173,6 +173,7 @@ components:
       type: object
       required:
         - id
+        - name
         - key
         - size
         - mime_type

--- a/api/openapi-uploads.yaml
+++ b/api/openapi-uploads.yaml
@@ -30,6 +30,9 @@ paths:
         required: true
         content:
           application/json:
+            description: >
+              New pre-signed URL flow. Returns upload metadata including a pre-signed
+              URL to PUT the file contents directly to storage.
             schema:
               type: object
               required:
@@ -47,6 +50,19 @@ paths:
                   type: integer
                   format: int64
                   description: The file size in bytes
+          multipart/form-data:
+            description: >
+              Legacy flow for backwards compatibility. Uploads the file directly
+              to the server in a single request.
+            schema:
+              type: object
+              required:
+                - file
+              properties:
+                file:
+                  type: string
+                  format: binary
+                  description: The file to upload
       responses:
         "200":
           description: File uploaded successfully

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -29,6 +29,8 @@ CORS_MAX_AGE=3600
 # Storage Configuration
 STORAGE_TYPE=local # Options: 'local' or 's3'
 STORAGE_LOCAL_BASE_DIR=./bucket
+STORAGE_LOCAL_PUT_SECRET=local-dev-secret
+
 # S3 Configuration (only needed if STORAGE_TYPE=s3)
 # STORAGE_S3_ENDPOINT=
 # STORAGE_S3_BUCKET=nsw-uploads

--- a/backend/internal/app/bootstrap/app.go
+++ b/backend/internal/app/bootstrap/app.go
@@ -292,9 +292,9 @@ func Build(ctx context.Context, cfg *config.Config) (*App, error) {
 	mux.Handle("POST /api/v1/payments/webhook", http.HandlerFunc(paymentHandler.HandleWebhook))
 	mux.Handle("POST /api/v1/payments/validate", http.HandlerFunc(paymentHandler.HandleValidateReference))
 
-	// When using local storage, this endpoint serves the actual file bytes.
-	// It's made public since it's the equivalent of a presigned URL when using S3.
+	// When using local storage, these endpoints serve as mocks for S3.
 	if _, ok := storageDriver.(*drivers.LocalFSDriver); ok {
+		mux.HandleFunc("PUT /api/v1/uploads/local-put/{key}", uploadHandler.UploadContentLocal)
 		mux.HandleFunc("GET /api/v1/uploads/{key}/content", uploadHandler.DownloadContent)
 	}
 

--- a/backend/internal/app/bootstrap/app.go
+++ b/backend/internal/app/bootstrap/app.go
@@ -294,7 +294,7 @@ func Build(ctx context.Context, cfg *config.Config) (*App, error) {
 
 	// When using local storage, these endpoints serve as mocks for S3.
 	if _, ok := storageDriver.(*drivers.LocalFSDriver); ok {
-		mux.HandleFunc("PUT /api/v1/uploads/local-put/{key}", uploadHandler.UploadContentLocal)
+		mux.HandleFunc("PUT /api/v1/uploads/{key}/content", uploadHandler.UploadContentLocal)
 		mux.HandleFunc("GET /api/v1/uploads/{key}/content", uploadHandler.DownloadContent)
 	}
 

--- a/backend/internal/config/config.go
+++ b/backend/internal/config/config.go
@@ -62,6 +62,7 @@ type StorageConfig struct {
 	S3SecretKey    string
 	S3UseSSL       bool
 	S3PublicURL    string
+	LocalPutSecret string
 }
 
 type AuthConfig struct {
@@ -133,6 +134,7 @@ func Load() (*Config, error) {
 			S3SecretKey:    os.Getenv("STORAGE_S3_SECRET_KEY"),
 			S3UseSSL:       getBoolOrDefault("STORAGE_S3_USE_SSL", true),
 			S3PublicURL:    os.Getenv("STORAGE_S3_PUBLIC_URL"),
+			LocalPutSecret: getEnvOrDefault("STORAGE_LOCAL_PUT_SECRET", "local-dev-secret"),
 		},
 		Auth: AuthConfig{
 			JWKSURL:               getEnvOrDefault("AUTH_JWKS_URL", "https://localhost:8090/oauth2/jwks"),

--- a/backend/internal/config/config.go
+++ b/backend/internal/config/config.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"strconv"
 	"strings"
+	"time"
 )
 
 // Config holds all configuration for the application
@@ -63,6 +64,7 @@ type StorageConfig struct {
 	S3UseSSL       bool
 	S3PublicURL    string
 	LocalPutSecret string
+	PresignTTL     time.Duration
 }
 
 type AuthConfig struct {
@@ -135,6 +137,7 @@ func Load() (*Config, error) {
 			S3UseSSL:       getBoolOrDefault("STORAGE_S3_USE_SSL", true),
 			S3PublicURL:    os.Getenv("STORAGE_S3_PUBLIC_URL"),
 			LocalPutSecret: getEnvOrDefault("STORAGE_LOCAL_PUT_SECRET", "local-dev-secret"),
+			PresignTTL:     parseDurationOrDefault(getEnvOrDefault("STORAGE_PRESIGN_TTL", "15m"), 15*time.Minute),
 		},
 		Auth: AuthConfig{
 			JWKSURL:               getEnvOrDefault("AUTH_JWKS_URL", "https://localhost:8090/oauth2/jwks"),
@@ -248,6 +251,16 @@ func getBoolOrDefault(key string, defaultValue bool) bool {
 // getDefaultInsecureJWKS returns true if the JWKS URL is a localhost URL, indicating that TLS verification can be skipped in development
 func getDefaultInsecureJWKS(jwksURL string) bool {
 	return strings.HasPrefix(jwksURL, "https://localhost") || strings.HasPrefix(jwksURL, "https://127.0.0.1")
+}
+
+// parseDurationOrDefault returns the time.Duration value of a string or a default value
+func parseDurationOrDefault(value string, defaultValue time.Duration) time.Duration {
+	if value != "" {
+		if d, err := time.ParseDuration(value); err == nil {
+			return d
+		}
+	}
+	return defaultValue
 }
 
 // parseCommaSeparated splits a comma-separated string into a slice of trimmed strings

--- a/backend/internal/uploads/drivers/constants.go
+++ b/backend/internal/uploads/drivers/constants.go
@@ -1,0 +1,9 @@
+package drivers
+
+import "time"
+
+// DefaultPresignTTL is the default time-to-live for presigned upload and download URLs.
+const DefaultPresignTTL = 15 * time.Minute
+
+// DefaultMime is the fallback MIME type when none is provided.
+const DefaultMime = "application/octet-stream"

--- a/backend/internal/uploads/drivers/local_fs.go
+++ b/backend/internal/uploads/drivers/local_fs.go
@@ -5,8 +5,10 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"net/url"
 	"os"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"time"
 )
@@ -24,16 +26,18 @@ var (
 type LocalFSDriver struct {
 	BaseDir   string
 	PublicURL string
+	secretKey string
 }
 
 // NewLocalFSDriver creates a new LocalFSDriver.
 // baseDir is where files will be stored.
 // publicURL is the base URL used to generate public links (e.g., /api/uploads).
-func NewLocalFSDriver(baseDir, publicURL string) (*LocalFSDriver, error) {
+// secretKey is the secret used for HMAC signing of local-put upload URLs.
+func NewLocalFSDriver(baseDir, publicURL, secretKey string) (*LocalFSDriver, error) {
 	if err := os.MkdirAll(baseDir, 0755); err != nil {
 		return nil, fmt.Errorf("failed to create base directory: %w", err)
 	}
-	return &LocalFSDriver{BaseDir: baseDir, PublicURL: publicURL}, nil
+	return &LocalFSDriver{BaseDir: baseDir, PublicURL: publicURL, secretKey: secretKey}, nil
 }
 
 // getHashedPath generates a two-level deep path for a key to avoid flat directory issues.
@@ -139,5 +143,49 @@ func (d *LocalFSDriver) GetDownloadURL(ctx context.Context, key string, ttl time
 	if d.PublicURL == "" {
 		return key, nil
 	}
-	return fmt.Sprintf("%s/api/v1/uploads/%s/content", d.PublicURL, key), nil
+
+	if ttl == 0 {
+		ttl = 15 * time.Minute
+	}
+	expiresAt := time.Now().Add(ttl).Unix()
+	token := GenerateDownloadToken(key, d.secretKey, expiresAt)
+
+	// Returns a URL with security token and expiration
+	v := url.Values{}
+	v.Set("token", token)
+	v.Set("expiresAt", strconv.FormatInt(expiresAt, 10))
+
+	return fmt.Sprintf("%s/api/v1/uploads/%s/content?%s", d.PublicURL, key, v.Encode()), nil
+}
+
+// VerifyDownloadToken checks if a provided download token is valid and not expired.
+func (d *LocalFSDriver) VerifyDownloadToken(key, token string, expiresAt int64) bool {
+	return VerifyDownloadToken(key, token, d.secretKey, expiresAt)
+}
+
+func (d *LocalFSDriver) GetUploadURL(ctx context.Context, key string, ttl time.Duration, contentType string, maxSizeBytes int64) (string, error) {
+	if d.PublicURL == "" {
+		return "", fmt.Errorf("public URL not configured for local storage")
+	}
+
+	if ttl == 0 {
+		ttl = 15 * time.Minute
+	}
+	expiresAt := time.Now().Add(ttl).Unix()
+	token := GenerateToken(key, d.secretKey, expiresAt, contentType, maxSizeBytes)
+
+	// Returns a URL pointing back to our local PUT handler with security constraints encoded
+	v := url.Values{}
+	v.Set("token", token)
+	v.Set("expiresAt", strconv.FormatInt(expiresAt, 10))
+	v.Set("contentType", contentType)
+	v.Set("maxSizeBytes", strconv.FormatInt(maxSizeBytes, 10))
+
+	return fmt.Sprintf("%s/api/v1/uploads/local-put/%s?%s",
+		d.PublicURL, key, v.Encode()), nil
+}
+
+// VerifyToken checks if a token is valid for a given key and constraints using the driver's secret.
+func (d *LocalFSDriver) VerifyToken(key, token string, expiresAt int64, contentType string, maxSizeBytes int64) bool {
+	return VerifyToken(key, token, d.secretKey, expiresAt, contentType, maxSizeBytes)
 }

--- a/backend/internal/uploads/drivers/local_fs.go
+++ b/backend/internal/uploads/drivers/local_fs.go
@@ -144,7 +144,7 @@ func (d *LocalFSDriver) Delete(ctx context.Context, key string) error {
 	return nil
 }
 
-func (d *LocalFSDriver) GetDownloadURL(ctx context.Context, key string) (string, error) {
+func (d *LocalFSDriver) GetDownloadURL(_ context.Context, key string) (string, error) {
 	if d.PublicURL == "" {
 		return key, nil
 	}
@@ -170,7 +170,7 @@ func (d *LocalFSDriver) VerifyDownloadToken(key, token string, expiresAt int64) 
 // Note: This method does NOT create the file on disk. It only signs the security constraints
 // (key, expiration, size limit). The actual resource allocation (file creation) happens in
 // Save() when the PUT request is eventually processed, matching S3's deferred behavior.
-func (d *LocalFSDriver) GetUploadURL(ctx context.Context, key string, contentType string, maxSizeBytes int64) (string, error) {
+func (d *LocalFSDriver) GetUploadURL(_ context.Context, key string, contentType string, maxSizeBytes int64) (string, error) {
 	if d.PublicURL == "" {
 		return "", fmt.Errorf("public URL not configured for local storage")
 	}

--- a/backend/internal/uploads/drivers/local_fs.go
+++ b/backend/internal/uploads/drivers/local_fs.go
@@ -124,7 +124,7 @@ func (d *LocalFSDriver) Get(ctx context.Context, key string) (io.ReadCloser, str
 	}
 
 	metaPath := fullAbs + ".meta"
-	contentType := "application/octet-stream"
+	contentType := DefaultMime
 	if metaBytes, err := os.ReadFile(metaPath); err == nil {
 		contentType = string(metaBytes)
 	}

--- a/backend/internal/uploads/drivers/local_fs.go
+++ b/backend/internal/uploads/drivers/local_fs.go
@@ -40,7 +40,7 @@ func NewLocalFSDriver(baseDir, publicURL, secretKey string, presignTTL time.Dura
 		return nil, fmt.Errorf("failed to create base directory: %w", err)
 	}
 	if presignTTL == 0 {
-		presignTTL = 15 * time.Minute
+		presignTTL = DefaultPresignTTL
 	}
 	return &LocalFSDriver{BaseDir: baseDir, PublicURL: publicURL, secretKey: secretKey, presignTTL: presignTTL}, nil
 }
@@ -144,14 +144,12 @@ func (d *LocalFSDriver) Delete(ctx context.Context, key string) error {
 	return nil
 }
 
-func (d *LocalFSDriver) GetDownloadURL(ctx context.Context, key string, ttl time.Duration) (string, error) {
+func (d *LocalFSDriver) GetDownloadURL(ctx context.Context, key string) (string, error) {
 	if d.PublicURL == "" {
 		return key, nil
 	}
 
-	if ttl == 0 {
-		ttl = d.presignTTL
-	}
+	ttl := d.presignTTL
 	expiresAt := time.Now().Add(ttl).Unix()
 	token := GenerateDownloadToken(key, d.secretKey, expiresAt)
 
@@ -168,14 +166,16 @@ func (d *LocalFSDriver) VerifyDownloadToken(key, token string, expiresAt int64) 
 	return VerifyDownloadToken(key, token, d.secretKey, expiresAt)
 }
 
-func (d *LocalFSDriver) GetUploadURL(ctx context.Context, key string, ttl time.Duration, contentType string, maxSizeBytes int64) (string, error) {
+// GetUploadURL returns a presigned URL pointing to a local PUT handler.
+// Note: This method does NOT create the file on disk. It only signs the security constraints
+// (key, expiration, size limit). The actual resource allocation (file creation) happens in
+// Save() when the PUT request is eventually processed, matching S3's deferred behavior.
+func (d *LocalFSDriver) GetUploadURL(ctx context.Context, key string, contentType string, maxSizeBytes int64) (string, error) {
 	if d.PublicURL == "" {
 		return "", fmt.Errorf("public URL not configured for local storage")
 	}
 
-	if ttl == 0 {
-		ttl = d.presignTTL
-	}
+	ttl := d.presignTTL
 	expiresAt := time.Now().Add(ttl).Unix()
 	token := GenerateToken(key, d.secretKey, expiresAt, contentType, maxSizeBytes)
 

--- a/backend/internal/uploads/drivers/local_fs.go
+++ b/backend/internal/uploads/drivers/local_fs.go
@@ -24,20 +24,25 @@ var (
 
 // LocalFSDriver implements StorageDriver for local disk with directory hashing
 type LocalFSDriver struct {
-	BaseDir   string
-	PublicURL string
-	secretKey string
+	BaseDir    string
+	PublicURL  string
+	secretKey  string
+	presignTTL time.Duration
 }
 
 // NewLocalFSDriver creates a new LocalFSDriver.
 // baseDir is where files will be stored.
 // publicURL is the base URL used to generate public links (e.g., /api/uploads).
 // secretKey is the secret used for HMAC signing of local-put upload URLs.
-func NewLocalFSDriver(baseDir, publicURL, secretKey string) (*LocalFSDriver, error) {
+// presignTTL is the default time-to-live for presigned URLs.
+func NewLocalFSDriver(baseDir, publicURL, secretKey string, presignTTL time.Duration) (*LocalFSDriver, error) {
 	if err := os.MkdirAll(baseDir, 0755); err != nil {
 		return nil, fmt.Errorf("failed to create base directory: %w", err)
 	}
-	return &LocalFSDriver{BaseDir: baseDir, PublicURL: publicURL, secretKey: secretKey}, nil
+	if presignTTL == 0 {
+		presignTTL = 15 * time.Minute
+	}
+	return &LocalFSDriver{BaseDir: baseDir, PublicURL: publicURL, secretKey: secretKey, presignTTL: presignTTL}, nil
 }
 
 // getHashedPath generates a two-level deep path for a key to avoid flat directory issues.
@@ -145,7 +150,7 @@ func (d *LocalFSDriver) GetDownloadURL(ctx context.Context, key string, ttl time
 	}
 
 	if ttl == 0 {
-		ttl = 15 * time.Minute
+		ttl = d.presignTTL
 	}
 	expiresAt := time.Now().Add(ttl).Unix()
 	token := GenerateDownloadToken(key, d.secretKey, expiresAt)
@@ -169,7 +174,7 @@ func (d *LocalFSDriver) GetUploadURL(ctx context.Context, key string, ttl time.D
 	}
 
 	if ttl == 0 {
-		ttl = 15 * time.Minute
+		ttl = d.presignTTL
 	}
 	expiresAt := time.Now().Add(ttl).Unix()
 	token := GenerateToken(key, d.secretKey, expiresAt, contentType, maxSizeBytes)
@@ -181,7 +186,7 @@ func (d *LocalFSDriver) GetUploadURL(ctx context.Context, key string, ttl time.D
 	v.Set("contentType", contentType)
 	v.Set("maxSizeBytes", strconv.FormatInt(maxSizeBytes, 10))
 
-	return fmt.Sprintf("%s/api/v1/uploads/local-put/%s?%s",
+	return fmt.Sprintf("%s/api/v1/uploads/%s/content?%s",
 		d.PublicURL, key, v.Encode()), nil
 }
 

--- a/backend/internal/uploads/drivers/local_fs_test.go
+++ b/backend/internal/uploads/drivers/local_fs_test.go
@@ -228,7 +228,7 @@ func BenchmarkLocalFSDriver_Get(b *testing.B) {
 	key := "aabbccdd-1234-5678-90ab-cdef00000000.bin"
 	// 1MB payload
 	payload := bytes.Repeat([]byte("x"), 1024*1024)
-	err = driver.Save(ctx, key, bytes.NewReader(payload), "application/octet-stream")
+	err = driver.Save(ctx, key, bytes.NewReader(payload), DefaultMime)
 	if err != nil {
 		b.Fatal(err)
 	}

--- a/backend/internal/uploads/drivers/local_fs_test.go
+++ b/backend/internal/uploads/drivers/local_fs_test.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 	"sync"
 	"testing"
+	"time"
 )
 
 func TestLocalFSDriver_DirectoryHashing(t *testing.T) {
@@ -19,7 +20,7 @@ func TestLocalFSDriver_DirectoryHashing(t *testing.T) {
 	}
 	defer os.RemoveAll(tempDir)
 
-	driver, err := NewLocalFSDriver(tempDir, "/uploads")
+	driver, err := NewLocalFSDriver(tempDir, "/uploads", "local-dev-secret")
 	if err != nil {
 		t.Fatalf("failed to create driver: %v", err)
 	}
@@ -53,14 +54,13 @@ func TestLocalFSDriver_DirectoryHashing(t *testing.T) {
 		t.Errorf("expected content type application/pdf, got %s", contentType)
 	}
 
-	// Verify GetDownloadURL
+	// Verify GetDownloadURL: should be tokenized and include /uploads
 	url, err := driver.GetDownloadURL(ctx, key, 0)
 	if err != nil {
 		t.Errorf("GetDownloadURL failed: %v", err)
 	}
-	expectedSuffix := key + "/content"
-	if !strings.HasSuffix(url, expectedSuffix) || !strings.Contains(url, "/uploads") {
-		t.Errorf("unexpected URL: %s", url)
+	if !strings.Contains(url, "/uploads") || !strings.Contains(url, "token=") || !strings.Contains(url, "expiresAt=") {
+		t.Errorf("unexpected URL format: %s", url)
 	}
 
 	// Test Delete
@@ -81,7 +81,7 @@ func TestLocalFSDriver_RejectsPathTraversal(t *testing.T) {
 	}
 	defer os.RemoveAll(tempDir)
 
-	driver, err := NewLocalFSDriver(tempDir, "/uploads")
+	driver, err := NewLocalFSDriver(tempDir, "/uploads", "local-dev-secret")
 	if err != nil {
 		t.Fatalf("failed to create driver: %v", err)
 	}
@@ -113,7 +113,7 @@ func TestLocalFSDriver_ConcurrentWritesSameDir(t *testing.T) {
 	}
 	defer os.RemoveAll(tempDir)
 
-	driver, err := NewLocalFSDriver(tempDir, "/uploads")
+	driver, err := NewLocalFSDriver(tempDir, "/uploads", "local-dev-secret")
 	if err != nil {
 		t.Fatalf("failed to create driver: %v", err)
 	}
@@ -168,7 +168,7 @@ func TestLocalFSDriver_RejectsKeyWithNullOrSpecialChars(t *testing.T) {
 	}
 	defer os.RemoveAll(tempDir)
 
-	driver, err := NewLocalFSDriver(tempDir, "/uploads")
+	driver, err := NewLocalFSDriver(tempDir, "/uploads", "local-dev-secret")
 	if err != nil {
 		t.Fatalf("failed to create driver: %v", err)
 	}
@@ -196,7 +196,7 @@ func TestLocalFSDriver_PathTraversal(t *testing.T) {
 	}
 	defer os.RemoveAll(tempDir)
 
-	driver, err := NewLocalFSDriver(tempDir, "/uploads")
+	driver, err := NewLocalFSDriver(tempDir, "/uploads", "local-dev-secret")
 	if err != nil {
 		t.Fatalf("failed to create driver: %v", err)
 	}
@@ -219,7 +219,7 @@ func BenchmarkLocalFSDriver_Get(b *testing.B) {
 	}
 	defer os.RemoveAll(tempDir)
 
-	driver, err := NewLocalFSDriver(tempDir, "/uploads")
+	driver, err := NewLocalFSDriver(tempDir, "/uploads", "local-dev-secret")
 	if err != nil {
 		b.Fatal(err)
 	}
@@ -241,5 +241,36 @@ func BenchmarkLocalFSDriver_Get(b *testing.B) {
 		}
 		_, _ = io.Copy(io.Discard, r)
 		r.Close()
+	}
+}
+
+func TestLocalFSDriver_LinkVerification(t *testing.T) {
+	tempDir, _ := os.MkdirTemp("", "localfs-link")
+	defer os.RemoveAll(tempDir)
+
+	secret := "test-secret"
+	driver, _ := NewLocalFSDriver(tempDir, "/uploads", secret)
+	key := "test-file.pdf"
+
+	// 1. Valid Link
+	expiresAt := time.Now().Add(time.Hour).Unix()
+	token := GenerateDownloadToken(key, secret, expiresAt)
+	if !driver.VerifyDownloadToken(key, token, expiresAt) {
+		t.Error("valid token failed verification")
+	}
+
+	// 2. Invalid Key
+	if driver.VerifyDownloadToken("wrong-key.pdf", token, expiresAt) {
+		t.Error("token verified for wrong key")
+	}
+
+	// 3. Modified Expiration
+	if driver.VerifyDownloadToken(key, token, expiresAt+1) {
+		t.Error("token verified despite modified expiration")
+	}
+
+	// 4. Invalid Signature
+	if driver.VerifyDownloadToken(key, "invalid-token", expiresAt) {
+		t.Error("invalid token signature was accepted")
 	}
 }

--- a/backend/internal/uploads/drivers/local_fs_test.go
+++ b/backend/internal/uploads/drivers/local_fs_test.go
@@ -55,7 +55,7 @@ func TestLocalFSDriver_DirectoryHashing(t *testing.T) {
 	}
 
 	// Verify GetDownloadURL: should be tokenized and include /uploads
-	url, err := driver.GetDownloadURL(ctx, key, 0)
+	url, err := driver.GetDownloadURL(ctx, key)
 	if err != nil {
 		t.Errorf("GetDownloadURL failed: %v", err)
 	}

--- a/backend/internal/uploads/drivers/local_fs_test.go
+++ b/backend/internal/uploads/drivers/local_fs_test.go
@@ -20,7 +20,7 @@ func TestLocalFSDriver_DirectoryHashing(t *testing.T) {
 	}
 	defer os.RemoveAll(tempDir)
 
-	driver, err := NewLocalFSDriver(tempDir, "/uploads", "local-dev-secret")
+	driver, err := NewLocalFSDriver(tempDir, "/uploads", "local-dev-secret", 15*time.Minute)
 	if err != nil {
 		t.Fatalf("failed to create driver: %v", err)
 	}
@@ -81,7 +81,7 @@ func TestLocalFSDriver_RejectsPathTraversal(t *testing.T) {
 	}
 	defer os.RemoveAll(tempDir)
 
-	driver, err := NewLocalFSDriver(tempDir, "/uploads", "local-dev-secret")
+	driver, err := NewLocalFSDriver(tempDir, "/uploads", "local-dev-secret", 15*time.Minute)
 	if err != nil {
 		t.Fatalf("failed to create driver: %v", err)
 	}
@@ -113,7 +113,7 @@ func TestLocalFSDriver_ConcurrentWritesSameDir(t *testing.T) {
 	}
 	defer os.RemoveAll(tempDir)
 
-	driver, err := NewLocalFSDriver(tempDir, "/uploads", "local-dev-secret")
+	driver, err := NewLocalFSDriver(tempDir, "/uploads", "local-dev-secret", 15*time.Minute)
 	if err != nil {
 		t.Fatalf("failed to create driver: %v", err)
 	}
@@ -168,7 +168,7 @@ func TestLocalFSDriver_RejectsKeyWithNullOrSpecialChars(t *testing.T) {
 	}
 	defer os.RemoveAll(tempDir)
 
-	driver, err := NewLocalFSDriver(tempDir, "/uploads", "local-dev-secret")
+	driver, err := NewLocalFSDriver(tempDir, "/uploads", "local-dev-secret", 15*time.Minute)
 	if err != nil {
 		t.Fatalf("failed to create driver: %v", err)
 	}
@@ -196,7 +196,7 @@ func TestLocalFSDriver_PathTraversal(t *testing.T) {
 	}
 	defer os.RemoveAll(tempDir)
 
-	driver, err := NewLocalFSDriver(tempDir, "/uploads", "local-dev-secret")
+	driver, err := NewLocalFSDriver(tempDir, "/uploads", "local-dev-secret", 15*time.Minute)
 	if err != nil {
 		t.Fatalf("failed to create driver: %v", err)
 	}
@@ -219,7 +219,7 @@ func BenchmarkLocalFSDriver_Get(b *testing.B) {
 	}
 	defer os.RemoveAll(tempDir)
 
-	driver, err := NewLocalFSDriver(tempDir, "/uploads", "local-dev-secret")
+	driver, err := NewLocalFSDriver(tempDir, "/uploads", "local-dev-secret", 15*time.Minute)
 	if err != nil {
 		b.Fatal(err)
 	}
@@ -249,7 +249,7 @@ func TestLocalFSDriver_LinkVerification(t *testing.T) {
 	defer os.RemoveAll(tempDir)
 
 	secret := "test-secret"
-	driver, _ := NewLocalFSDriver(tempDir, "/uploads", secret)
+	driver, _ := NewLocalFSDriver(tempDir, "/uploads", secret, 15*time.Minute)
 	key := "test-file.pdf"
 
 	// 1. Valid Link

--- a/backend/internal/uploads/drivers/s3_driver.go
+++ b/backend/internal/uploads/drivers/s3_driver.go
@@ -17,14 +17,19 @@ type S3Driver struct {
 	PresignClient *s3.PresignClient
 	Bucket        string
 	PublicURL     string // Optional: Base URL if files are public
+	presignTTL    time.Duration
 }
 
-func NewS3Driver(client *s3.Client, bucket string, publicURL string) *S3Driver {
+func NewS3Driver(client *s3.Client, bucket string, publicURL string, presignTTL time.Duration) *S3Driver {
+	if presignTTL == 0 {
+		presignTTL = 15 * time.Minute
+	}
 	return &S3Driver{
 		Client:        client,
 		PresignClient: s3.NewPresignClient(client),
 		Bucket:        bucket,
 		PublicURL:     publicURL,
+		presignTTL:    presignTTL,
 	}
 }
 
@@ -72,7 +77,7 @@ func (d *S3Driver) Delete(ctx context.Context, key string) error {
 // presignGet returns a presigned GET URL for the key; used by both GenerateURL and GetDownloadURL.
 func (d *S3Driver) presignGet(ctx context.Context, key string, ttl time.Duration) (string, error) {
 	if ttl == 0 {
-		ttl = time.Hour
+		ttl = d.presignTTL
 	}
 	presignedReq, err := d.PresignClient.PresignGetObject(ctx, &s3.GetObjectInput{
 		Bucket: aws.String(d.Bucket),
@@ -86,14 +91,14 @@ func (d *S3Driver) presignGet(ctx context.Context, key string, ttl time.Duration
 
 func (d *S3Driver) GetDownloadURL(ctx context.Context, key string, ttl time.Duration) (string, error) {
 	if ttl == 0 {
-		ttl = 15 * time.Minute
+		ttl = d.presignTTL
 	}
 	return d.presignGet(ctx, key, ttl)
 }
 
 func (d *S3Driver) GetUploadURL(ctx context.Context, key string, ttl time.Duration, contentType string, maxSizeBytes int64) (string, error) {
 	if ttl == 0 {
-		ttl = 15 * time.Minute
+		ttl = d.presignTTL
 	}
 
 	presignedReq, err := d.PresignClient.PresignPutObject(ctx, &s3.PutObjectInput{

--- a/backend/internal/uploads/drivers/s3_driver.go
+++ b/backend/internal/uploads/drivers/s3_driver.go
@@ -55,7 +55,7 @@ func (d *S3Driver) Get(ctx context.Context, key string) (io.ReadCloser, string, 
 		return nil, "", fmt.Errorf("failed to get from S3: %w", err)
 	}
 
-	contentType := "application/octet-stream"
+	contentType := DefaultMime
 	if resp.ContentType != nil {
 		contentType = *resp.ContentType
 	}

--- a/backend/internal/uploads/drivers/s3_driver.go
+++ b/backend/internal/uploads/drivers/s3_driver.go
@@ -90,3 +90,21 @@ func (d *S3Driver) GetDownloadURL(ctx context.Context, key string, ttl time.Dura
 	}
 	return d.presignGet(ctx, key, ttl)
 }
+
+func (d *S3Driver) GetUploadURL(ctx context.Context, key string, ttl time.Duration, contentType string, maxSizeBytes int64) (string, error) {
+	if ttl == 0 {
+		ttl = 15 * time.Minute
+	}
+
+	presignedReq, err := d.PresignClient.PresignPutObject(ctx, &s3.PutObjectInput{
+		Bucket:        aws.String(d.Bucket),
+		Key:           aws.String(key),
+		ContentType:   aws.String(contentType),
+		ContentLength: aws.Int64(maxSizeBytes),
+	}, s3.WithPresignExpires(ttl))
+	if err != nil {
+		return "", fmt.Errorf("failed to presign upload URL: %w", err)
+	}
+
+	return presignedReq.URL, nil
+}

--- a/backend/internal/uploads/drivers/s3_driver.go
+++ b/backend/internal/uploads/drivers/s3_driver.go
@@ -22,7 +22,7 @@ type S3Driver struct {
 
 func NewS3Driver(client *s3.Client, bucket string, publicURL string, presignTTL time.Duration) *S3Driver {
 	if presignTTL == 0 {
-		presignTTL = 15 * time.Minute
+		presignTTL = DefaultPresignTTL
 	}
 	return &S3Driver{
 		Client:        client,
@@ -75,10 +75,8 @@ func (d *S3Driver) Delete(ctx context.Context, key string) error {
 }
 
 // presignGet returns a presigned GET URL for the key; used by both GenerateURL and GetDownloadURL.
-func (d *S3Driver) presignGet(ctx context.Context, key string, ttl time.Duration) (string, error) {
-	if ttl == 0 {
-		ttl = d.presignTTL
-	}
+func (d *S3Driver) presignGet(ctx context.Context, key string) (string, error) {
+	ttl := d.presignTTL
 	presignedReq, err := d.PresignClient.PresignGetObject(ctx, &s3.GetObjectInput{
 		Bucket: aws.String(d.Bucket),
 		Key:    aws.String(key),
@@ -89,18 +87,13 @@ func (d *S3Driver) presignGet(ctx context.Context, key string, ttl time.Duration
 	return presignedReq.URL, nil
 }
 
-func (d *S3Driver) GetDownloadURL(ctx context.Context, key string, ttl time.Duration) (string, error) {
-	if ttl == 0 {
-		ttl = d.presignTTL
-	}
-	return d.presignGet(ctx, key, ttl)
+func (d *S3Driver) GetDownloadURL(ctx context.Context, key string) (string, error) {
+	return d.presignGet(ctx, key)
 }
 
-func (d *S3Driver) GetUploadURL(ctx context.Context, key string, ttl time.Duration, contentType string, maxSizeBytes int64) (string, error) {
-	if ttl == 0 {
-		ttl = d.presignTTL
-	}
-
+// presignPut returns a presigned PUT URL for the key and constraints.
+func (d *S3Driver) presignPut(ctx context.Context, key, contentType string, maxSizeBytes int64) (string, error) {
+	ttl := d.presignTTL
 	presignedReq, err := d.PresignClient.PresignPutObject(ctx, &s3.PutObjectInput{
 		Bucket:        aws.String(d.Bucket),
 		Key:           aws.String(key),
@@ -112,4 +105,8 @@ func (d *S3Driver) GetUploadURL(ctx context.Context, key string, ttl time.Durati
 	}
 
 	return presignedReq.URL, nil
+}
+
+func (d *S3Driver) GetUploadURL(ctx context.Context, key string, contentType string, maxSizeBytes int64) (string, error) {
+	return d.presignPut(ctx, key, contentType, maxSizeBytes)
 }

--- a/backend/internal/uploads/drivers/token.go
+++ b/backend/internal/uploads/drivers/token.go
@@ -5,7 +5,11 @@ import (
 	"crypto/sha256"
 	"encoding/hex"
 	"fmt"
+	"time"
 )
+
+// DefaultPresignTTL is the default time-to-live for presigned upload and download URLs.
+const DefaultPresignTTL = 15 * time.Minute
 
 // GenerateToken creates an HMAC-SHA256 token signing multiple constraints.
 func GenerateToken(key, secret string, expiresAt int64, contentType string, maxSizeBytes int64) string {

--- a/backend/internal/uploads/drivers/token.go
+++ b/backend/internal/uploads/drivers/token.go
@@ -9,7 +9,7 @@ import (
 
 // GenerateToken creates an HMAC-SHA256 token signing multiple constraints.
 func GenerateToken(key, secret string, expiresAt int64, contentType string, maxSizeBytes int64) string {
-	payload := fmt.Sprintf("%s:%d:%s:%d", key, expiresAt, contentType, maxSizeBytes)
+	payload := fmt.Sprintf("%s\x00%d\x00%s\x00%d", key, expiresAt, contentType, maxSizeBytes)
 	mac := hmac.New(sha256.New, []byte(secret))
 	mac.Write([]byte(payload))
 	return hex.EncodeToString(mac.Sum(nil))
@@ -26,7 +26,7 @@ func VerifyToken(key, token, secret string, expiresAt int64, contentType string,
 
 // GenerateDownloadToken creates an HMAC-SHA256 token specifically for download links (only signs key and expiration).
 func GenerateDownloadToken(key, secret string, expiresAt int64) string {
-	payload := fmt.Sprintf("%s:%d", key, expiresAt)
+	payload := fmt.Sprintf("%s\x00%d", key, expiresAt)
 	mac := hmac.New(sha256.New, []byte(secret))
 	mac.Write([]byte(payload))
 	return hex.EncodeToString(mac.Sum(nil))

--- a/backend/internal/uploads/drivers/token.go
+++ b/backend/internal/uploads/drivers/token.go
@@ -5,38 +5,50 @@ import (
 	"crypto/sha256"
 	"encoding/hex"
 	"fmt"
+	"strings"
 )
+
+// sign creates an HMAC-SHA256 signature from given parts
+func sign(secret string, parts ...any) string {
+	strParts := make([]string, len(parts))
+	for i, p := range parts {
+		strParts[i] = fmt.Sprintf("%v", p)
+	}
+
+	payload := strings.Join(strParts, "\x00")
+
+	mac := hmac.New(sha256.New, []byte(secret))
+	mac.Write([]byte(payload))
+
+	return hex.EncodeToString(mac.Sum(nil))
+}
+
+// verify checks token validity using constant-time comparison
+func verify(token, secret string, parts ...any) bool {
+	if token == "" || secret == "" {
+		return false
+	}
+
+	expected := sign(secret, parts...)
+	return hmac.Equal([]byte(token), []byte(expected))
+}
 
 // GenerateToken creates an HMAC-SHA256 token signing multiple constraints.
 func GenerateToken(key, secret string, expiresAt int64, contentType string, maxSizeBytes int64) string {
-	payload := fmt.Sprintf("%s\x00%d\x00%s\x00%d", key, expiresAt, contentType, maxSizeBytes)
-	mac := hmac.New(sha256.New, []byte(secret))
-	mac.Write([]byte(payload))
-	return hex.EncodeToString(mac.Sum(nil))
+	return sign(secret, key, expiresAt, contentType, maxSizeBytes)
 }
 
 // VerifyToken checks if a provided token matches the expected signature for given constraints.
 func VerifyToken(key, token, secret string, expiresAt int64, contentType string, maxSizeBytes int64) bool {
-	if token == "" || secret == "" {
-		return false
-	}
-	expected := GenerateToken(key, secret, expiresAt, contentType, maxSizeBytes)
-	return hmac.Equal([]byte(token), []byte(expected))
+	return verify(token, secret, key, expiresAt, contentType, maxSizeBytes)
 }
 
 // GenerateDownloadToken creates an HMAC-SHA256 token specifically for download links (only signs key and expiration).
 func GenerateDownloadToken(key, secret string, expiresAt int64) string {
-	payload := fmt.Sprintf("%s\x00%d", key, expiresAt)
-	mac := hmac.New(sha256.New, []byte(secret))
-	mac.Write([]byte(payload))
-	return hex.EncodeToString(mac.Sum(nil))
+	return sign(secret, key, expiresAt)
 }
 
 // VerifyDownloadToken checks if a provided download token matches the expected signature.
 func VerifyDownloadToken(key, token, secret string, expiresAt int64) bool {
-	if token == "" || secret == "" {
-		return false
-	}
-	expected := GenerateDownloadToken(key, secret, expiresAt)
-	return hmac.Equal([]byte(token), []byte(expected))
+	return verify(token, secret, key, expiresAt)
 }

--- a/backend/internal/uploads/drivers/token.go
+++ b/backend/internal/uploads/drivers/token.go
@@ -5,11 +5,7 @@ import (
 	"crypto/sha256"
 	"encoding/hex"
 	"fmt"
-	"time"
 )
-
-// DefaultPresignTTL is the default time-to-live for presigned upload and download URLs.
-const DefaultPresignTTL = 15 * time.Minute
 
 // GenerateToken creates an HMAC-SHA256 token signing multiple constraints.
 func GenerateToken(key, secret string, expiresAt int64, contentType string, maxSizeBytes int64) string {

--- a/backend/internal/uploads/drivers/token.go
+++ b/backend/internal/uploads/drivers/token.go
@@ -1,0 +1,42 @@
+package drivers
+
+import (
+	"crypto/hmac"
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+)
+
+// GenerateToken creates an HMAC-SHA256 token signing multiple constraints.
+func GenerateToken(key, secret string, expiresAt int64, contentType string, maxSizeBytes int64) string {
+	payload := fmt.Sprintf("%s:%d:%s:%d", key, expiresAt, contentType, maxSizeBytes)
+	mac := hmac.New(sha256.New, []byte(secret))
+	mac.Write([]byte(payload))
+	return hex.EncodeToString(mac.Sum(nil))
+}
+
+// VerifyToken checks if a provided token matches the expected signature for given constraints.
+func VerifyToken(key, token, secret string, expiresAt int64, contentType string, maxSizeBytes int64) bool {
+	if token == "" || secret == "" {
+		return false
+	}
+	expected := GenerateToken(key, secret, expiresAt, contentType, maxSizeBytes)
+	return hmac.Equal([]byte(token), []byte(expected))
+}
+
+// GenerateDownloadToken creates an HMAC-SHA256 token specifically for download links (only signs key and expiration).
+func GenerateDownloadToken(key, secret string, expiresAt int64) string {
+	payload := fmt.Sprintf("%s:%d", key, expiresAt)
+	mac := hmac.New(sha256.New, []byte(secret))
+	mac.Write([]byte(payload))
+	return hex.EncodeToString(mac.Sum(nil))
+}
+
+// VerifyDownloadToken checks if a provided download token matches the expected signature.
+func VerifyDownloadToken(key, token, secret string, expiresAt int64) bool {
+	if token == "" || secret == "" {
+		return false
+	}
+	expected := GenerateDownloadToken(key, secret, expiresAt)
+	return hmac.Equal([]byte(token), []byte(expected))
+}

--- a/backend/internal/uploads/factory.go
+++ b/backend/internal/uploads/factory.go
@@ -20,7 +20,7 @@ func NewStorageFromConfig(ctx context.Context, cfg config.StorageConfig) (Storag
 	switch strings.TrimSpace(cfg.Type) {
 	case "local":
 		slog.Info("Initializing local storage", "dir", cfg.LocalBaseDir)
-		return drivers.NewLocalFSDriver(cfg.LocalBaseDir, cfg.LocalPublicURL, cfg.LocalPutSecret)
+		return drivers.NewLocalFSDriver(cfg.LocalBaseDir, cfg.LocalPublicURL, cfg.LocalPutSecret, cfg.PresignTTL)
 	case "s3":
 		slog.Info("Initializing S3 storage", "endpoint", cfg.S3Endpoint, "bucket", cfg.S3Bucket)
 
@@ -49,7 +49,7 @@ func NewStorageFromConfig(ctx context.Context, cfg config.StorageConfig) (Storag
 			o.RequestChecksumCalculation = aws.RequestChecksumCalculationWhenSupported
 		})
 
-		return drivers.NewS3Driver(client, cfg.S3Bucket, cfg.S3PublicURL), nil
+		return drivers.NewS3Driver(client, cfg.S3Bucket, cfg.S3PublicURL, cfg.PresignTTL), nil
 	default:
 		return nil, fmt.Errorf("unsupported storage type: %s", cfg.Type)
 	}

--- a/backend/internal/uploads/factory.go
+++ b/backend/internal/uploads/factory.go
@@ -20,7 +20,7 @@ func NewStorageFromConfig(ctx context.Context, cfg config.StorageConfig) (Storag
 	switch strings.TrimSpace(cfg.Type) {
 	case "local":
 		slog.Info("Initializing local storage", "dir", cfg.LocalBaseDir)
-		return drivers.NewLocalFSDriver(cfg.LocalBaseDir, cfg.LocalPublicURL)
+		return drivers.NewLocalFSDriver(cfg.LocalBaseDir, cfg.LocalPublicURL, cfg.LocalPutSecret)
 	case "s3":
 		slog.Info("Initializing S3 storage", "endpoint", cfg.S3Endpoint, "bucket", cfg.S3Bucket)
 

--- a/backend/internal/uploads/http_handler.go
+++ b/backend/internal/uploads/http_handler.go
@@ -80,7 +80,7 @@ func (h *HTTPHandler) Upload(w http.ResponseWriter, r *http.Request) {
 
 		mimeType := header.Header.Get("Content-Type")
 		if mimeType == "" {
-			mimeType = "application/octet-stream"
+			mimeType = drivers.DefaultMime
 		}
 
 		if !isAllowedContentType(mimeType) {
@@ -88,6 +88,7 @@ func (h *HTTPHandler) Upload(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 
+		// TODO: Remove legacy multipart upload support once all clients migrate to presigned URLs
 		metadata, err := h.Service.UploadLegacy(r.Context(), header.Filename, file, header.Size, mimeType)
 		if err != nil {
 			slog.ErrorContext(r.Context(), "Legacy upload failed", "error", err)
@@ -216,7 +217,7 @@ func (h *HTTPHandler) UploadContentLocal(w http.ResponseWriter, r *http.Request)
 	var contentType string
 	contentType = r.Header.Get("Content-Type")
 	if contentType == "" {
-		contentType = "application/octet-stream"
+		contentType = drivers.DefaultMime
 	}
 	if contentType != encodedContentType {
 		writeJSONError(w, http.StatusUnsupportedMediaType, "content-type mismatch")

--- a/backend/internal/uploads/http_handler.go
+++ b/backend/internal/uploads/http_handler.go
@@ -2,6 +2,7 @@ package uploads
 
 import (
 	"encoding/json"
+	"errors"
 	"io"
 	"log/slog"
 	"net/http"
@@ -75,7 +76,7 @@ func (h *HTTPHandler) Upload(w http.ResponseWriter, r *http.Request) {
 			writeJSONError(w, http.StatusBadRequest, "file is required")
 			return
 		}
-		defer file.Close()
+		defer func() { _ = file.Close() }()
 
 		mimeType := header.Header.Get("Content-Type")
 		if mimeType == "" {
@@ -109,6 +110,7 @@ func (h *HTTPHandler) Upload(w http.ResponseWriter, r *http.Request) {
 		Size     int64  `json:"size"`
 	}
 
+	r.Body = http.MaxBytesReader(w, r.Body, 1<<20)
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
 		writeJSONError(w, http.StatusBadRequest, "invalid request body")
 		return
@@ -221,7 +223,8 @@ func (h *HTTPHandler) UploadContentLocal(w http.ResponseWriter, r *http.Request)
 	if err != nil {
 		slog.ErrorContext(r.Context(), "Local upload failed", "key", key, "error", err)
 		// MaxBytesReader returns a specific error when exceeded
-		if strings.Contains(err.Error(), "http: request body too large") {
+		var maxBytesError *http.MaxBytesError
+		if errors.As(err, &maxBytesError) {
 			writeJSONError(w, http.StatusRequestEntityTooLarge, "file size exceeds specified limit")
 		} else {
 			writeJSONError(w, http.StatusInternalServerError, "failed to save file")

--- a/backend/internal/uploads/http_handler.go
+++ b/backend/internal/uploads/http_handler.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"regexp"
 	"strconv"
+	"strings"
 	"time"
 
 	"github.com/OpenNSW/nsw/internal/auth"
@@ -55,47 +56,83 @@ func (h *HTTPHandler) Upload(w http.ResponseWriter, r *http.Request) {
 		writeJSONError(w, http.StatusUnauthorized, "Unauthorized")
 		return
 	}
-	r.Body = http.MaxBytesReader(w, r.Body, 32<<20)
 
-	if err := r.ParseMultipartForm(32 << 20); err != nil {
-		writeJSONError(w, http.StatusBadRequest, "failed to parse form or request too large")
-		return
-	}
+	contentType := r.Header.Get("Content-Type")
 
-	file, header, err := r.FormFile("file")
-	if err != nil {
-		writeJSONError(w, http.StatusBadRequest, "file is required")
-		return
-	}
-	defer func() { _ = file.Close() }()
-
-	// Derive a trustworthy content type from the actual bytes when possible.
-	// We avoid trusting client-supplied multipart headers for security and accuracy.
-	mimeType := header.Header.Get("Content-Type")
-	if seeker, ok := file.(io.ReadSeeker); ok {
-		// Sniff content type from the first 512 bytes.
-		sniffBuf := make([]byte, 512)
-		n, _ := seeker.Read(sniffBuf)
-		if n > 0 {
-			mimeType = http.DetectContentType(sniffBuf[:n])
+	// Legacy backward compatibility for existing UI
+	if strings.Contains(contentType, "multipart/form-data") {
+		// Parse multipart form
+		// Enforce 32MB limit as per requirements
+		r.Body = http.MaxBytesReader(w, r.Body, 32<<20)
+		if err := r.ParseMultipartForm(32 << 20); err != nil {
+			slog.ErrorContext(r.Context(), "Failed to parse multipart form", "error", err)
+			writeJSONError(w, http.StatusBadRequest, "file size exceeds 32MB limit or invalid form")
+			return
 		}
 
-		// Rewind so the upload service can read from the beginning. The service
-		// is responsible for reporting the actual number of bytes written.
-		_, _ = seeker.Seek(0, io.SeekStart)
+		file, header, err := r.FormFile("file")
+		if err != nil {
+			writeJSONError(w, http.StatusBadRequest, "file is required")
+			return
+		}
+		defer file.Close()
+
+		mimeType := header.Header.Get("Content-Type")
+		if mimeType == "" {
+			mimeType = "application/octet-stream"
+		}
+
+		if !isAllowedContentType(mimeType) {
+			writeJSONError(w, http.StatusUnsupportedMediaType, "invalid or prohibited file type")
+			return
+		}
+
+		metadata, err := h.Service.UploadLegacy(r.Context(), header.Filename, file, header.Size, mimeType)
+		if err != nil {
+			slog.ErrorContext(r.Context(), "Legacy upload failed", "error", err)
+			writeJSONError(w, http.StatusInternalServerError, "failed to process legacy upload")
+			return
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusCreated)
+		if err := json.NewEncoder(w).Encode(metadata); err != nil {
+			slog.ErrorContext(r.Context(), "Failed to encode legacy response", "error", err)
+		}
+		return
 	}
 
-	if !isAllowedContentType(mimeType) {
+	// New Presigned URL generation flow (application/json)
+	var req struct {
+		Filename string `json:"filename"`
+		MimeType string `json:"mime_type"`
+		Size     int64  `json:"size"`
+	}
+
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		writeJSONError(w, http.StatusBadRequest, "invalid request body")
+		return
+	}
+
+	if req.Filename == "" || req.MimeType == "" || req.Size <= 0 {
+		writeJSONError(w, http.StatusBadRequest, "filename, mime_type, and size are required")
+		return
+	}
+
+	if req.Size > 32<<20 {
+		writeJSONError(w, http.StatusBadRequest, "file size exceeds 32MB limit")
+		return
+	}
+
+	if !isAllowedContentType(req.MimeType) {
 		writeJSONError(w, http.StatusUnsupportedMediaType, "invalid or prohibited file type")
 		return
 	}
 
-	// NOTE: The service layer is responsible for determining the actual number
-	// of bytes written; the size passed here is treated only as a hint.
-	metadata, err := h.Service.Upload(r.Context(), header.Filename, file, header.Size, mimeType)
+	metadata, err := h.Service.Upload(r.Context(), req.Filename, req.Size, req.MimeType)
 	if err != nil {
-		slog.ErrorContext(r.Context(), "Upload failed", "error", err)
-		writeJSONError(w, http.StatusInternalServerError, "upload failed")
+		slog.ErrorContext(r.Context(), "Upload preparation failed", "error", err)
+		writeJSONError(w, http.StatusInternalServerError, "failed to prepare upload")
 		return
 	}
 
@@ -103,6 +140,96 @@ func (h *HTTPHandler) Upload(w http.ResponseWriter, r *http.Request) {
 	if err := json.NewEncoder(w).Encode(metadata); err != nil {
 		slog.ErrorContext(r.Context(), "Failed to encode response", "error", err)
 	}
+}
+
+// UploadContentLocal acts as a mock S3 bucket for local development.
+// It accepts a PUT request with the raw file body.
+func (h *HTTPHandler) UploadContentLocal(w http.ResponseWriter, r *http.Request) {
+	// This endpoint is only available when using LocalFSDriver (local development).
+	driver, ok := h.Service.Driver.(*drivers.LocalFSDriver)
+	if !ok {
+		writeJSONError(w, http.StatusNotFound, "not found")
+		return
+	}
+
+	if r.Method != http.MethodPut {
+		writeJSONError(w, http.StatusMethodNotAllowed, "method not allowed")
+		return
+	}
+
+	key := r.PathValue("key")
+	if key == "" {
+		writeJSONError(w, http.StatusBadRequest, "key is required")
+		return
+	}
+	if !validStorageKey(key) {
+		writeJSONError(w, http.StatusBadRequest, "invalid key format")
+		return
+	}
+
+	// Extract security constraints from query parameters
+	token := r.URL.Query().Get("token")
+	expiresAtStr := r.URL.Query().Get("expiresAt")
+	encodedContentType := r.URL.Query().Get("contentType")
+	maxSizeBytesStr := r.URL.Query().Get("maxSizeBytes")
+
+	if token == "" || expiresAtStr == "" || encodedContentType == "" || maxSizeBytesStr == "" {
+		writeJSONError(w, http.StatusUnauthorized, "missing security token or constraints")
+		return
+	}
+
+	expiresAt, err := strconv.ParseInt(expiresAtStr, 10, 64)
+	if err != nil {
+		writeJSONError(w, http.StatusBadRequest, "invalid expiration format")
+		return
+	}
+
+	maxSizeBytes, err := strconv.ParseInt(maxSizeBytesStr, 10, 64)
+	if err != nil {
+		writeJSONError(w, http.StatusBadRequest, "invalid max size format")
+		return
+	}
+
+	// Verify HMAC token (signs all constraints)
+	if !driver.VerifyToken(key, token, expiresAt, encodedContentType, maxSizeBytes) {
+		writeJSONError(w, http.StatusUnauthorized, "invalid security token")
+		return
+	}
+
+	// 1. Enforce TTL (Time-To-Live)
+	if time.Now().Unix() > expiresAt {
+		writeJSONError(w, http.StatusForbidden, "upload link expired")
+		return
+	}
+
+	// 2. Enforce Content-Type (Strict Check)
+	var contentType string
+	contentType = r.Header.Get("Content-Type")
+	if contentType == "" {
+		contentType = "application/octet-stream"
+	}
+	if contentType != encodedContentType {
+		writeJSONError(w, http.StatusUnsupportedMediaType, "content-type mismatch")
+		return
+	}
+
+	// 3. Prevent Local Disk Exhaustion (DoS) - enforce dynamic limit from URL
+	r.Body = http.MaxBytesReader(w, r.Body, maxSizeBytes)
+
+	// Save using the local driver
+	err = driver.Save(r.Context(), key, r.Body, contentType)
+	if err != nil {
+		slog.ErrorContext(r.Context(), "Local upload failed", "key", key, "error", err)
+		// MaxBytesReader returns a specific error when exceeded
+		if strings.Contains(err.Error(), "http: request body too large") {
+			writeJSONError(w, http.StatusRequestEntityTooLarge, "file size exceeds specified limit")
+		} else {
+			writeJSONError(w, http.StatusInternalServerError, "failed to save file")
+		}
+		return
+	}
+
+	w.WriteHeader(http.StatusNoContent)
 }
 
 func (h *HTTPHandler) Download(w http.ResponseWriter, r *http.Request) {
@@ -146,7 +273,8 @@ func (h *HTTPHandler) DownloadContent(w http.ResponseWriter, r *http.Request) {
 	// This endpoint is only available when using LocalFSDriver (local development).
 	// It serves the same role as an S3 presigned URL — no auth required since the
 	// caller was already authenticated when obtaining the URL via GET /uploads/{key}.
-	if _, ok := h.Service.Driver.(*drivers.LocalFSDriver); !ok {
+	driver, ok := h.Service.Driver.(*drivers.LocalFSDriver)
+	if !ok {
 		writeJSONError(w, http.StatusNotFound, "not found")
 		return
 	}
@@ -158,6 +286,32 @@ func (h *HTTPHandler) DownloadContent(w http.ResponseWriter, r *http.Request) {
 	}
 	if !validStorageKey(key) {
 		writeJSONError(w, http.StatusBadRequest, "invalid key format")
+		return
+	}
+
+	// Extract and verify security constraints
+	token := r.URL.Query().Get("token")
+	expiresAtStr := r.URL.Query().Get("expiresAt")
+	if token == "" || expiresAtStr == "" {
+		writeJSONError(w, http.StatusUnauthorized, "missing security token or expiration")
+		return
+	}
+
+	expiresAt, err := strconv.ParseInt(expiresAtStr, 10, 64)
+	if err != nil {
+		writeJSONError(w, http.StatusBadRequest, "invalid expiration format")
+		return
+	}
+
+	// Verify HMAC signature
+	if !driver.VerifyDownloadToken(key, token, expiresAt) {
+		writeJSONError(w, http.StatusUnauthorized, "invalid security token")
+		return
+	}
+
+	// Enforce TTL
+	if time.Now().Unix() > expiresAt {
+		writeJSONError(w, http.StatusForbidden, "download link expired")
 		return
 	}
 

--- a/backend/internal/uploads/http_handler.go
+++ b/backend/internal/uploads/http_handler.go
@@ -116,8 +116,16 @@ func (h *HTTPHandler) Upload(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if req.Filename == "" || req.MimeType == "" || req.Size <= 0 {
-		writeJSONError(w, http.StatusBadRequest, "filename, mime_type, and size are required")
+	if req.Filename == "" {
+		writeJSONError(w, http.StatusBadRequest, "filename is required")
+		return
+	}
+	if req.MimeType == "" {
+		writeJSONError(w, http.StatusBadRequest, "mime_type is required")
+		return
+	}
+	if req.Size <= 0 {
+		writeJSONError(w, http.StatusBadRequest, "size must be greater than 0")
 		return
 	}
 
@@ -253,7 +261,7 @@ func (h *HTTPHandler) Download(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	url, err := h.Service.GetDownloadURL(r.Context(), key, 15*time.Minute)
+	url, err := h.Service.GetDownloadURL(r.Context(), key)
 	if err != nil {
 		slog.ErrorContext(r.Context(), "Failed to generate download URL", "key", key, "error", err)
 		writeJSONError(w, http.StatusInternalServerError, "failed to generate access")
@@ -263,7 +271,7 @@ func (h *HTTPHandler) Download(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Content-Type", "application/json")
 	if err := json.NewEncoder(w).Encode(map[string]any{
 		"download_url": url,
-		"expires_at":   time.Now().Add(15 * time.Minute).Unix(),
+		"expires_at":   time.Now().Add(drivers.DefaultPresignTTL).Unix(),
 	}); err != nil {
 		slog.ErrorContext(r.Context(), "Failed to encode response", "error", err)
 	}

--- a/backend/internal/uploads/http_handler_test.go
+++ b/backend/internal/uploads/http_handler_test.go
@@ -32,8 +32,7 @@ func TestDownloadContent_LocalDriver_Success(t *testing.T) {
 	}
 
 	// Generate valid signed URL using the driver
-	ttl := 15 * time.Minute
-	downloadURL, err := driver.GetDownloadURL(ctx, key, ttl)
+	downloadURL, err := driver.GetDownloadURL(ctx, key)
 	if err != nil {
 		t.Fatalf("Failed to get download URL: %v", err)
 	}
@@ -246,7 +245,7 @@ func TestUploadContentLocal_Success(t *testing.T) {
 	contentType := "application/pdf"
 	maxSizeBytes := int64(32 << 20)
 
-	uploadURL, err := driver.GetUploadURL(context.Background(), key, 15*time.Minute, contentType, maxSizeBytes)
+	uploadURL, err := driver.GetUploadURL(context.Background(), key, contentType, maxSizeBytes)
 	if err != nil {
 		t.Fatalf("Failed to get upload URL: %v", err)
 	}

--- a/backend/internal/uploads/http_handler_test.go
+++ b/backend/internal/uploads/http_handler_test.go
@@ -5,10 +5,12 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
-	"mime/multipart"
+	"io"
 	"net/http"
 	"net/http/httptest"
+	"net/url"
 	"testing"
+	"time"
 
 	"github.com/OpenNSW/nsw/internal/auth"
 	"github.com/OpenNSW/nsw/internal/uploads/drivers"
@@ -18,7 +20,7 @@ import (
 
 func TestDownloadContent_LocalDriver_Success(t *testing.T) {
 	tempDir := t.TempDir()
-	driver, _ := drivers.NewLocalFSDriver(tempDir, "/api/v1/uploads")
+	driver, _ := drivers.NewLocalFSDriver(tempDir, "/api/v1/uploads", "local-dev-secret")
 	service := NewUploadService(driver)
 	handler := NewHTTPHandler(service)
 
@@ -29,15 +31,27 @@ func TestDownloadContent_LocalDriver_Success(t *testing.T) {
 		t.Fatalf("failed to save test file: %v", err)
 	}
 
-	req := httptest.NewRequest(http.MethodGet, "/uploads/"+key+"/content", nil)
+	// Generate valid signed URL using the driver
+	ttl := 15 * time.Minute
+	downloadURL, err := driver.GetDownloadURL(ctx, key, ttl)
+	if err != nil {
+		t.Fatalf("Failed to get download URL: %v", err)
+	}
+
+	parsedURL, err := url.Parse(downloadURL)
+	if err != nil {
+		t.Fatalf("Failed to parse download URL: %v", err)
+	}
+
+	req := httptest.NewRequest(http.MethodGet, parsedURL.String(), nil)
 	req.SetPathValue("key", key)
 	rec := httptest.NewRecorder()
 
-	// No auth context set — should still succeed because this endpoint is intended to be public.
+	// No auth context set — should still succeed because this endpoint is signature-secured instead of auth-secured.
 	handler.DownloadContent(rec, req)
 
 	if rec.Code != http.StatusOK {
-		t.Fatalf("expected status 200, got %d", rec.Code)
+		t.Fatalf("expected status 200, got %d. Body: %s", rec.Code, rec.Body.String())
 	}
 
 	if rec.Header().Get("Content-Type") != "application/pdf" {
@@ -163,18 +177,15 @@ func TestDownload_InvalidKeyFormat(t *testing.T) {
 func TestUpload_Unauthorized(t *testing.T) {
 	handler := NewHTTPHandler(NewUploadService(&MockDriver{}))
 
-	var buf bytes.Buffer
-	w := multipart.NewWriter(&buf)
-	part, _ := w.CreateFormFile("file", "test.pdf")
-	if _, err := part.Write([]byte("content")); err != nil {
-		t.Fatalf("failed to write multipart content: %v", err)
+	body := map[string]any{
+		"filename":  "test.pdf",
+		"mime_type": "application/pdf",
+		"size":      1024,
 	}
-	if err := w.Close(); err != nil {
-		t.Fatalf("failed to close multipart writer: %v", err)
-	}
+	jsonBody, _ := json.Marshal(body)
 
-	req := httptest.NewRequest(http.MethodPost, "/uploads", &buf)
-	req.Header.Set("Content-Type", w.FormDataContentType())
+	req := httptest.NewRequest(http.MethodPost, "/uploads", bytes.NewReader(jsonBody))
+	req.Header.Set("Content-Type", "application/json")
 	rec := httptest.NewRecorder()
 
 	handler.Upload(rec, req)
@@ -182,15 +193,92 @@ func TestUpload_Unauthorized(t *testing.T) {
 	if rec.Code != http.StatusUnauthorized {
 		t.Fatalf("expected status 401, got %d", rec.Code)
 	}
-	if ct := rec.Header().Get("Content-Type"); ct != "application/json" {
-		t.Errorf("expected Content-Type application/json, got %q", ct)
+}
+
+func TestUpload_Success(t *testing.T) {
+	mock := &MockDriver{}
+	handler := NewHTTPHandler(NewUploadService(mock))
+
+	body := map[string]any{
+		"filename":  "test.pdf",
+		"mime_type": "application/pdf",
+		"size":      1024,
 	}
-	var errBody map[string]string
-	if err := json.NewDecoder(rec.Body).Decode(&errBody); err != nil {
-		t.Errorf("expected JSON body: %v", err)
+	jsonBody, _ := json.Marshal(body)
+
+	req := httptest.NewRequest(http.MethodPost, "/uploads", bytes.NewReader(jsonBody))
+	req.Header.Set("Content-Type", "application/json")
+	ctx := withAuthContext(req.Context(), &auth.AuthContext{
+		UserID: "trader-1", UserContext: &auth.UserContext{UserID: "trader-1"},
+	})
+	req = req.WithContext(ctx)
+	rec := httptest.NewRecorder()
+
+	handler.Upload(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected status 200, got %d. Body: %s", rec.Code, rec.Body.String())
 	}
-	if errBody["error"] == "" {
-		t.Error("expected error message in body")
+
+	var metadata FileMetadata
+	if err := json.NewDecoder(rec.Body).Decode(&metadata); err != nil {
+		t.Fatalf("failed to decode response: %v", err)
+	}
+
+	if metadata.Name != "test.pdf" {
+		t.Errorf("expected name test.pdf, got %s", metadata.Name)
+	}
+	if metadata.UploadURL == "" {
+		t.Error("expected upload_url to be populated")
+	}
+}
+
+func TestUploadContentLocal_Success(t *testing.T) {
+	tempDir := t.TempDir()
+	driver, _ := drivers.NewLocalFSDriver(tempDir, "/api/v1/uploads", "local-dev-secret")
+	service := NewUploadService(driver)
+	handler := NewHTTPHandler(service)
+
+	key := "550e8400-e29b-41d4-a716-446655440000.pdf"
+	content := []byte("pdf content")
+
+	// Generate valid upload URL using the driver
+	contentType := "application/pdf"
+	maxSizeBytes := int64(32 << 20)
+
+	uploadURL, err := driver.GetUploadURL(context.Background(), key, 15*time.Minute, contentType, maxSizeBytes)
+	if err != nil {
+		t.Fatalf("Failed to get upload URL: %v", err)
+	}
+
+	parsedURL, err := url.Parse(uploadURL)
+	if err != nil {
+		t.Fatalf("Failed to parse upload URL: %v", err)
+	}
+
+	req := httptest.NewRequest(http.MethodPut, parsedURL.RequestURI(), bytes.NewReader(content))
+	req.SetPathValue("key", key)
+	req.Header.Set("Content-Type", "application/pdf")
+	rec := httptest.NewRecorder()
+
+	handler.UploadContentLocal(rec, req)
+
+	if rec.Code != http.StatusNoContent {
+		t.Fatalf("expected status 204, got %d. Body: %s", rec.Code, rec.Body.String())
+	}
+
+	// Verify file was saved
+	reader, ct, err := driver.Get(context.Background(), key)
+	if err != nil {
+		t.Fatalf("failed to get saved file: %v", err)
+	}
+	defer reader.Close()
+	if ct != "application/pdf" {
+		t.Errorf("expected content type application/pdf, got %s", ct)
+	}
+	savedContent, _ := io.ReadAll(reader)
+	if !bytes.Equal(savedContent, content) {
+		t.Error("saved content does not match")
 	}
 }
 

--- a/backend/internal/uploads/http_handler_test.go
+++ b/backend/internal/uploads/http_handler_test.go
@@ -20,7 +20,7 @@ import (
 
 func TestDownloadContent_LocalDriver_Success(t *testing.T) {
 	tempDir := t.TempDir()
-	driver, _ := drivers.NewLocalFSDriver(tempDir, "/api/v1/uploads", "local-dev-secret")
+	driver, _ := drivers.NewLocalFSDriver(tempDir, "/api/v1/uploads", "local-dev-secret", 15*time.Minute)
 	service := NewUploadService(driver)
 	handler := NewHTTPHandler(service)
 
@@ -235,7 +235,7 @@ func TestUpload_Success(t *testing.T) {
 
 func TestUploadContentLocal_Success(t *testing.T) {
 	tempDir := t.TempDir()
-	driver, _ := drivers.NewLocalFSDriver(tempDir, "/api/v1/uploads", "local-dev-secret")
+	driver, _ := drivers.NewLocalFSDriver(tempDir, "/api/v1/uploads", "local-dev-secret", 15*time.Minute)
 	service := NewUploadService(driver)
 	handler := NewHTTPHandler(service)
 

--- a/backend/internal/uploads/models.go
+++ b/backend/internal/uploads/models.go
@@ -2,10 +2,11 @@ package uploads
 
 // FileMetadata represents the metadata of an uploaded file
 type FileMetadata struct {
-	ID       string `json:"id"`
-	Name     string `json:"name"`
-	Key      string `json:"key"`
-	URL      string `json:"url"`
-	Size     int64  `json:"size"`
-	MimeType string `json:"mime_type"`
+	ID        string `json:"id"`
+	Name      string `json:"name"`
+	Key       string `json:"key"`
+	URL       string `json:"url,omitempty"`
+	UploadURL string `json:"upload_url,omitempty"`
+	Size      int64  `json:"size"`
+	MimeType  string `json:"mime_type"`
 }

--- a/backend/internal/uploads/service.go
+++ b/backend/internal/uploads/service.go
@@ -7,6 +7,7 @@ import (
 	"log/slog"
 	"path/filepath"
 
+	"github.com/OpenNSW/nsw/internal/uploads/drivers"
 	"github.com/google/uuid"
 )
 
@@ -47,7 +48,7 @@ func (c *countingReadSeeker) Seek(offset int64, whence int) (int64, error) {
 // Serves as a bridge for existing UI clients using multipart/form-data.
 func (s *UploadService) UploadLegacy(ctx context.Context, filename string, reader io.Reader, size int64, mime string) (*FileMetadata, error) {
 	if mime == "" {
-		mime = "application/octet-stream"
+		mime = drivers.DefaultMime
 	}
 	id := uuid.NewString()
 	ext := filepath.Ext(filename)
@@ -81,7 +82,7 @@ func (s *UploadService) UploadLegacy(ctx context.Context, filename string, reade
 // and a presigned/upload URL via the storage driver.
 func (s *UploadService) Upload(ctx context.Context, filename string, size int64, mime string) (*FileMetadata, error) {
 	if mime == "" {
-		mime = "application/octet-stream"
+		mime = drivers.DefaultMime
 	}
 	id := uuid.NewString()
 	ext := filepath.Ext(filename)

--- a/backend/internal/uploads/service.go
+++ b/backend/internal/uploads/service.go
@@ -16,6 +16,10 @@ type UploadService struct {
 	Driver StorageDriver
 }
 
+func NewUploadService(driver StorageDriver) *UploadService {
+	return &UploadService{Driver: driver}
+}
+
 type countingReader struct {
 	r io.Reader
 	n int64
@@ -27,9 +31,6 @@ func (c *countingReader) Read(p []byte) (int, error) {
 	return n, err
 }
 
-// countingReadSeeker extends countingReader with seeking support.
-// Constructed only when the underlying reader is an io.Seeker, so callers
-// (e.g. the S3 SDK) that type-assert to io.ReadSeeker get a truthful answer.
 type countingReadSeeker struct {
 	*countingReader
 	s io.Seeker
@@ -43,12 +44,9 @@ func (c *countingReadSeeker) Seek(offset int64, whence int) (int64, error) {
 	return pos, err
 }
 
-func NewUploadService(driver StorageDriver) *UploadService {
-	return &UploadService{Driver: driver}
-}
-
-// Upload handles the incoming file, saves it via driver, and returns metadata
-func (s *UploadService) Upload(ctx context.Context, filename string, reader io.Reader, size int64, mime string) (*FileMetadata, error) {
+// UploadLegacy handles the incoming file, saves it via driver directly, and returns metadata.
+// Serves as a bridge for existing UI clients using multipart/form-data.
+func (s *UploadService) UploadLegacy(ctx context.Context, filename string, reader io.Reader, size int64, mime string) (*FileMetadata, error) {
 	if mime == "" {
 		mime = "application/octet-stream"
 	}
@@ -56,14 +54,10 @@ func (s *UploadService) Upload(ctx context.Context, filename string, reader io.R
 	ext := filepath.Ext(filename)
 	key := fmt.Sprintf("%s%s", id, ext)
 
-	// Wrap the reader so we can determine the actual number of bytes written,
-	// rather than trusting any client-supplied size hints.
-	// If the reader supports seeking (e.g. multipart.File), expose it so the
-	// S3 SDK can type-assert to io.ReadSeeker for retries and content-length.
 	cr := &countingReader{r: reader}
 	var body io.Reader = cr
-	if s, ok := reader.(io.Seeker); ok {
-		body = &countingReadSeeker{countingReader: cr, s: s}
+	if seeker, ok := reader.(io.Seeker); ok {
+		body = &countingReadSeeker{countingReader: cr, s: seeker}
 	}
 
 	err := s.Driver.Save(ctx, key, body, mime)
@@ -72,17 +66,45 @@ func (s *UploadService) Upload(ctx context.Context, filename string, reader io.R
 	}
 
 	metadata := &FileMetadata{
-		ID:   id,
-		Name: filename,
-		Key:  key,
-		// URL is not populated by default; clients should call GetDownloadURL
-		// when they need a time-limited or presigned URL for download.
+		ID:       id,
+		Name:     filename,
+		Key:      key,
 		URL:      "",
 		Size:     cr.n,
 		MimeType: mime,
 	}
 
-	slog.InfoContext(ctx, "File uploaded successfully", "id", id, "key", key)
+	slog.InfoContext(ctx, "File uploaded successfully (legacy)", "id", id, "key", key)
+	return metadata, nil
+}
+
+// Upload handles the preparation of a file upload by generating a unique key
+// and a presigned/upload URL via the storage driver.
+func (s *UploadService) Upload(ctx context.Context, filename string, size int64, mime string) (*FileMetadata, error) {
+	if mime == "" {
+		mime = "application/octet-stream"
+	}
+	id := uuid.NewString()
+	ext := filepath.Ext(filename)
+	key := fmt.Sprintf("%s%s", id, ext)
+
+	// Generate a presigned URL for the upload.
+	// We use a 15-minute TTL by default.
+	uploadURL, err := s.Driver.GetUploadURL(ctx, key, 15*time.Minute, mime, size)
+	if err != nil {
+		return nil, fmt.Errorf("failed to generate upload URL: %w", err)
+	}
+
+	metadata := &FileMetadata{
+		ID:        id,
+		Name:      filename,
+		Key:       key,
+		UploadURL: uploadURL,
+		Size:      size,
+		MimeType:  mime,
+	}
+
+	slog.InfoContext(ctx, "File upload prepared", "id", id, "key", key)
 	return metadata, nil
 }
 

--- a/backend/internal/uploads/service.go
+++ b/backend/internal/uploads/service.go
@@ -6,7 +6,6 @@ import (
 	"io"
 	"log/slog"
 	"path/filepath"
-	"time"
 
 	"github.com/google/uuid"
 )
@@ -88,9 +87,8 @@ func (s *UploadService) Upload(ctx context.Context, filename string, size int64,
 	ext := filepath.Ext(filename)
 	key := fmt.Sprintf("%s%s", id, ext)
 
-	// Generate a presigned URL for the upload.
-	// We use a 15-minute TTL by default.
-	uploadURL, err := s.Driver.GetUploadURL(ctx, key, 15*time.Minute, mime, size)
+	// Generate a presigned URL for the upload
+	uploadURL, err := s.Driver.GetUploadURL(ctx, key, mime, size)
 	if err != nil {
 		return nil, fmt.Errorf("failed to generate upload URL: %w", err)
 	}
@@ -114,8 +112,8 @@ func (s *UploadService) Download(ctx context.Context, key string) (io.ReadCloser
 }
 
 // GetDownloadURL generates a time-limited or presigned URL for the given key
-func (s *UploadService) GetDownloadURL(ctx context.Context, key string, ttl time.Duration) (string, error) {
-	return s.Driver.GetDownloadURL(ctx, key, ttl)
+func (s *UploadService) GetDownloadURL(ctx context.Context, key string) (string, error) {
+	return s.Driver.GetDownloadURL(ctx, key)
 }
 
 // Delete removes a file from storage

--- a/backend/internal/uploads/service_test.go
+++ b/backend/internal/uploads/service_test.go
@@ -47,15 +47,23 @@ func (m *MockDriver) GetDownloadURL(ctx context.Context, key string, ttl time.Du
 	return "/test/download/" + key, nil
 }
 
+func (m *MockDriver) GetUploadURL(ctx context.Context, key string, ttl time.Duration, contentType string, maxSizeBytes int64) (string, error) {
+	m.LastTTL = ttl
+	if m.GenerateURLErr != nil {
+		return "", m.GenerateURLErr
+	}
+	return "/test/upload/" + key, nil
+}
+
 func TestUploadService(t *testing.T) {
 	mock := &MockDriver{}
 	service := NewUploadService(mock)
 
 	ctx := context.Background()
 	filename := "test.jpg"
-	content := []byte("image data")
+	size := int64(1024)
 
-	metadata, err := service.Upload(ctx, filename, bytes.NewReader(content), int64(len(content)), "image/jpeg")
+	metadata, err := service.Upload(ctx, filename, size, "image/jpeg")
 	if err != nil {
 		t.Fatalf("Upload failed: %v", err)
 	}
@@ -64,12 +72,12 @@ func TestUploadService(t *testing.T) {
 		t.Errorf("expected name %s, got %s", filename, metadata.Name)
 	}
 
-	if !bytes.Equal(mock.SavedBody, content) {
-		t.Error("saved body does not match input")
+	if metadata.Size != size {
+		t.Errorf("expected size %d, got %d", size, metadata.Size)
 	}
 
-	if metadata.URL != "" {
-		t.Errorf("expected URL to be empty, got %s", metadata.URL)
+	if metadata.UploadURL != "/test/upload/"+metadata.Key {
+		t.Errorf("unexpected upload URL: %s", metadata.UploadURL)
 	}
 }
 

--- a/backend/internal/uploads/service_test.go
+++ b/backend/internal/uploads/service_test.go
@@ -6,7 +6,6 @@ import (
 	"errors"
 	"io"
 	"testing"
-	"time"
 )
 
 // MockDriver implements StorageDriver for testing
@@ -16,7 +15,6 @@ type MockDriver struct {
 	GenerateURLErr error
 	DeleteCalled   bool
 	DeleteKey      string
-	LastTTL        time.Duration
 }
 
 func (m *MockDriver) Save(ctx context.Context, key string, body io.Reader, contentType string) error {
@@ -39,16 +37,14 @@ func (m *MockDriver) Delete(ctx context.Context, key string) error {
 	return nil
 }
 
-func (m *MockDriver) GetDownloadURL(ctx context.Context, key string, ttl time.Duration) (string, error) {
-	m.LastTTL = ttl
+func (m *MockDriver) GetDownloadURL(ctx context.Context, key string) (string, error) {
 	if m.GenerateURLErr != nil {
 		return "", m.GenerateURLErr
 	}
 	return "/test/download/" + key, nil
 }
 
-func (m *MockDriver) GetUploadURL(ctx context.Context, key string, ttl time.Duration, contentType string, maxSizeBytes int64) (string, error) {
-	m.LastTTL = ttl
+func (m *MockDriver) GetUploadURL(ctx context.Context, key string, contentType string, maxSizeBytes int64) (string, error) {
 	if m.GenerateURLErr != nil {
 		return "", m.GenerateURLErr
 	}
@@ -111,17 +107,13 @@ func TestUploadService_GetDownloadURL_Success(t *testing.T) {
 	ctx := context.Background()
 	const key = "test-key"
 
-	ttl := 10 * time.Minute
-	url, err := service.GetDownloadURL(ctx, key, ttl)
+	url, err := service.GetDownloadURL(ctx, key)
 	if err != nil {
 		t.Fatalf("GetDownloadURL failed: %v", err)
 	}
 
 	if url != "/test/download/"+key {
 		t.Errorf("unexpected URL: %s", url)
-	}
-	if mock.LastTTL != ttl {
-		t.Errorf("expected TTL %v, got %v", ttl, mock.LastTTL)
 	}
 }
 
@@ -130,7 +122,7 @@ func TestUploadService_GetDownloadURL_Error(t *testing.T) {
 	mock := &MockDriver{GenerateURLErr: expectedErr}
 	service := NewUploadService(mock)
 
-	_, err := service.GetDownloadURL(context.Background(), "test-key", 0)
+	_, err := service.GetDownloadURL(context.Background(), "test-key")
 	if err == nil {
 		t.Fatal("expected error from GetDownloadURL, got nil")
 	}

--- a/backend/internal/uploads/storage.go
+++ b/backend/internal/uploads/storage.go
@@ -3,7 +3,6 @@ package uploads
 import (
 	"context"
 	"io"
-	"time"
 )
 
 // StorageDriver defines how we interact with the binary storage
@@ -18,8 +17,8 @@ type StorageDriver interface {
 	Delete(ctx context.Context, key string) error
 
 	// GetDownloadURL returns a presigned or time-limited URL for downloading
-	GetDownloadURL(ctx context.Context, key string, ttl time.Duration) (string, error)
+	GetDownloadURL(ctx context.Context, key string) (string, error)
 
 	// GetUploadURL returns a presigned URL for uploading a file directly to storage
-	GetUploadURL(ctx context.Context, key string, ttl time.Duration, contentType string, maxSizeBytes int64) (string, error)
+	GetUploadURL(ctx context.Context, key string, contentType string, maxSizeBytes int64) (string, error)
 }

--- a/backend/internal/uploads/storage.go
+++ b/backend/internal/uploads/storage.go
@@ -19,4 +19,7 @@ type StorageDriver interface {
 
 	// GetDownloadURL returns a presigned or time-limited URL for downloading
 	GetDownloadURL(ctx context.Context, key string, ttl time.Duration) (string, error)
+
+	// GetUploadURL returns a presigned URL for uploading a file directly to storage
+	GetUploadURL(ctx context.Context, key string, ttl time.Duration, contentType string, maxSizeBytes int64) (string, error)
 }


### PR DESCRIPTION
## Summary
Implement backend changes for migrating the file upload mechanism to use pre-signed URLs. This is Phase 1 of 3 part rollout to transition the platform gracefully. Upload service now securely generates and returns pre-signed upload URLs while retaining full backwards compatibility with the existing legacy `multipart/form-data` upload endpoints for seamless transition

**Note `PUT local-dev` endpoint's exclusive to local development**
-  In prod, will be 1 API call to POST /uploads. Then, frontend uploads to the URL returned by backend (via `upload_url`). File is NOT ever sent to backend.
- in Local Dev environment, frontend _does_ send the file to backend (via the `PUT local-dev` endpoint). But this is a necessary evil if we don't run tools like seaweedfs / MinIO locally! `PUT local-dev` handler mimic S3's behavior so that we can test the exact same frontend logic

## Changes
- New API Endpoint Flow: add handling for JSON-based requests to `/uploads` to generate pre-signed upload URLs with strong time-to-live (TTL) and metadata constraints
- HMAC Signatures: implement HMAC-SHA256 tokens using null byte (`\x00`) separators in `token.go` to sign security constraints (size limit, expiration, content type) and mitigate payload collision risks
- Local Dev Mocking: extend `LocalFSDriver` to reliably mimic S3 pre-signed URL behaviors for local development without actual object storage
- Security Hardening: enforce a `1MB` max request body limit (`http.MaxBytesReader`) on the JSON metadata endpoint to prevent DoS attacks
- Error Handling: improve error checking by using `errors.As` to properly map `http.MaxBytesError` instances to HTTP 413 (Payload Too Large) responses

## Testing
- Verified backwards compatibility with legacy `multipart/form-data` clients
- Uploaded valid and invalid file sizes, ensuring the `1MB` metadata limit blocks large payloads with an HTTP 413 error
