### PR TITLE
Refactor backend config ownership by package

### DIFF
--- a/.env.docker.example
+++ b/.env.docker.example
@@ -60,8 +60,12 @@ OGA_APP_IRD_PORT=5176
 SERVER_DEBUG=true
 SERVER_LOG_LEVEL=info
 STORAGE_TYPE=local
+STORAGE_LOCAL_PUT_SECRET=local-dev-secret
 CORS_ALLOWED_ORIGINS=http://localhost:3000,http://localhost:5173,http://localhost:5174,http://localhost:5175,http://localhost:5176
 SHOW_AUTOFILL_BUTTON=true
+# Optional Configurations
+# STORAGE_LOCAL_PUBLIC_URL=http://localhost:8080
+# STORAGE_PRESIGN_TTL=15m
 
 # ---- OGA backends ----
 OGA_NPQS_DB_DRIVER=postgres

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -26,6 +26,9 @@ CORS_MAX_AGE=3600
 STORAGE_TYPE=local # Options: 'local' or 's3'
 STORAGE_LOCAL_BASE_DIR=./bucket
 STORAGE_LOCAL_PUT_SECRET=local-dev-secret
+# Optional Configurations
+# STORAGE_LOCAL_PUBLIC_URL=http://localhost:8080
+# STORAGE_PRESIGN_TTL=15m
 
 # S3 Configuration (only needed if STORAGE_TYPE=s3)
 # STORAGE_S3_ENDPOINT=

--- a/backend/internal/app/bootstrap/app.go
+++ b/backend/internal/app/bootstrap/app.go
@@ -127,7 +127,7 @@ func setupWorkflowManager(
 
 // Build initializes dependencies and returns a fully wired application server.
 func Build(ctx context.Context, cfg *config.Config) (*App, error) {
-	db, err := database.New(&cfg.Database)
+	db, err := database.New(cfg.Database)
 	if err != nil {
 		return nil, fmt.Errorf("failed to connect to database: %w", err)
 	}

--- a/backend/internal/auth/config.go
+++ b/backend/internal/auth/config.go
@@ -1,6 +1,10 @@
 package auth
 
-import "fmt"
+import (
+	"fmt"
+
+	"github.com/OpenNSW/nsw/internal/validation"
+)
 
 type Config struct {
 	JWKSURL               string
@@ -14,8 +18,14 @@ func (c *Config) Validate() error {
 	if c.JWKSURL == "" {
 		return fmt.Errorf("AUTH_JWKS_URL is required")
 	}
+	if err := validation.HTTPURL("AUTH_JWKS_URL", c.JWKSURL); err != nil {
+		return err
+	}
 	if c.Issuer == "" {
 		return fmt.Errorf("AUTH_ISSUER is required")
+	}
+	if err := validation.HTTPURL("AUTH_ISSUER", c.Issuer); err != nil {
+		return err
 	}
 	if c.Audience == "" {
 		return fmt.Errorf("AUTH_AUDIENCE is required")

--- a/backend/internal/auth/config.go
+++ b/backend/internal/auth/config.go
@@ -1,0 +1,27 @@
+package auth
+
+import "fmt"
+
+type Config struct {
+	JWKSURL               string
+	Issuer                string
+	Audience              string
+	ClientID              string
+	InsecureSkipTLSVerify bool
+}
+
+func (c *Config) Validate() error {
+	if c.JWKSURL == "" {
+		return fmt.Errorf("AUTH_JWKS_URL is required")
+	}
+	if c.Issuer == "" {
+		return fmt.Errorf("AUTH_ISSUER is required")
+	}
+	if c.Audience == "" {
+		return fmt.Errorf("AUTH_AUDIENCE is required")
+	}
+	if c.ClientID == "" {
+		return fmt.Errorf("AUTH_CLIENT_ID is required")
+	}
+	return nil
+}

--- a/backend/internal/auth/config.go
+++ b/backend/internal/auth/config.go
@@ -10,7 +10,7 @@ type Config struct {
 	JWKSURL               string
 	Issuer                string
 	Audience              string
-	ClientID              string
+	ClientIDs             []string
 	InsecureSkipTLSVerify bool
 }
 
@@ -30,8 +30,9 @@ func (c *Config) Validate() error {
 	if c.Audience == "" {
 		return fmt.Errorf("AUTH_AUDIENCE is required")
 	}
-	if c.ClientID == "" {
-		return fmt.Errorf("AUTH_CLIENT_ID is required")
+
+	if len(c.ClientIDs) == 0 {
+		return fmt.Errorf("AUTH_CLIENT_IDS is required")
 	}
 	return nil
 }

--- a/backend/internal/auth/manager.go
+++ b/backend/internal/auth/manager.go
@@ -9,8 +9,6 @@ import (
 	"time"
 
 	"gorm.io/gorm"
-
-	"github.com/OpenNSW/nsw/internal/config"
 )
 
 // Manager handles all authentication-related operations and middleware setup.
@@ -33,7 +31,7 @@ type Manager struct {
 //	handler := middleware.CORS(&cfg.CORS)(authManager.Middleware()(mux))
 //
 // This centralizes auth setup for token extraction, middleware, and user-context access.
-func NewManager(db *gorm.DB, authConfig config.AuthConfig) (*Manager, error) {
+func NewManager(db *gorm.DB, authConfig Config) (*Manager, error) {
 	slog.Info("initializing auth manager")
 
 	service := NewAuthService(db)

--- a/backend/internal/config/config.go
+++ b/backend/internal/config/config.go
@@ -11,6 +11,7 @@ import (
 	"github.com/OpenNSW/nsw/internal/auth"
 	"github.com/OpenNSW/nsw/internal/database"
 	"github.com/OpenNSW/nsw/internal/uploads"
+	"github.com/OpenNSW/nsw/internal/validation"
 )
 
 // Config holds all configuration for the application
@@ -130,6 +131,12 @@ func Load() (*Config, error) {
 
 // Validate checks that all required configuration is present
 func (c *Config) Validate() error {
+	if strings.TrimSpace(c.Server.ServiceURL) == "" {
+		return fmt.Errorf("SERVICE_URL is required")
+	}
+	if err := validation.HTTPURL("SERVICE_URL", c.Server.ServiceURL); err != nil {
+		return err
+	}
 	if err := c.Database.Validate(); err != nil {
 		return fmt.Errorf("invalid database configuration: %w", err)
 	}
@@ -139,14 +146,18 @@ func (c *Config) Validate() error {
 	if err := c.Auth.Validate(); err != nil {
 		return fmt.Errorf("invalid auth configuration: %w", err)
 	}
-	if !c.Server.Debug {
-		if len(c.CORS.AllowedOrigins) == 0 {
-			return fmt.Errorf("CORS_ALLOWED_ORIGINS must be explicitly configured in production")
-		}
-		for _, origin := range c.CORS.AllowedOrigins {
-			if origin == "*" {
+	if len(c.CORS.AllowedOrigins) == 0 {
+		return fmt.Errorf("CORS_ALLOWED_ORIGINS is required")
+	}
+	for _, origin := range c.CORS.AllowedOrigins {
+		if origin == "*" {
+			if !c.Server.Debug {
 				return fmt.Errorf("CORS_ALLOWED_ORIGINS cannot contain '*' in production (SERVER_DEBUG=false)")
 			}
+			continue
+		}
+		if err := validation.HTTPURL("CORS_ALLOWED_ORIGINS", origin); err != nil {
+			return err
 		}
 	}
 	return nil

--- a/backend/internal/config/config.go
+++ b/backend/internal/config/config.go
@@ -3,34 +3,25 @@ package config
 import (
 	"fmt"
 	"log/slog"
-	"net/url"
 	"os"
 	"strconv"
 	"strings"
 	"time"
+
+	"github.com/OpenNSW/nsw/internal/auth"
+	"github.com/OpenNSW/nsw/internal/database"
+	"github.com/OpenNSW/nsw/internal/uploads"
 )
 
 // Config holds all configuration for the application
 type Config struct {
-	Database     DatabaseConfig
-	Server       ServerConfig
-	CORS         CORSConfig
-	Storage      StorageConfig
-	Auth         AuthConfig
-	Notification NotificationConfig
-}
-
-// DatabaseConfig holds database connection configuration
-type DatabaseConfig struct {
-	Host                   string
-	Port                   int
-	Username               string
-	Password               string
-	Name                   string
-	SSLMode                string
-	MaxIdleConns           int
-	MaxOpenConns           int
-	MaxConnLifetimeSeconds int
+	Database             database.Config
+	Server               ServerConfig
+	CORS                 CORSConfig
+	Storage              uploads.Config
+	Auth                 auth.Config
+	Notification         NotificationConfig
+	UseWorkflowManagerV2 bool
 }
 
 // ServerConfig holds server configuration
@@ -49,29 +40,6 @@ type CORSConfig struct {
 	AllowedHeaders   []string
 	AllowCredentials bool
 	MaxAge           int
-}
-
-type StorageConfig struct {
-	Type           string // "local" or "s3"
-	LocalBaseDir   string
-	LocalPublicURL string
-	S3Endpoint     string
-	S3Bucket       string
-	S3Region       string
-	S3AccessKey    string
-	S3SecretKey    string
-	S3UseSSL       bool
-	S3PublicURL    string
-	LocalPutSecret string
-	PresignTTL     time.Duration
-}
-
-type AuthConfig struct {
-	JWKSURL               string
-	Issuer                string
-	Audience              string
-	ClientIDs             []string
-	InsecureSkipTLSVerify bool
 }
 
 type NotificationConfig struct {
@@ -95,11 +63,8 @@ func Load() (*Config, error) {
 		return nil, fmt.Errorf("invalid SERVER_PORT: %w", err)
 	}
 
-	authJWKSURL := getEnvOrDefault("AUTH_JWKS_URL", "https://localhost:8090/oauth2/jwks")
-	defaultInsecureJWKS := getDefaultInsecureJWKS(authJWKSURL)
-
 	cfg := &Config{
-		Database: DatabaseConfig{
+		Database: database.Config{
 			Host:                   getEnvOrDefault("DB_HOST", "localhost"),
 			Port:                   dbPort,
 			Username:               getEnvOrDefault("DB_USERNAME", "postgres"),
@@ -124,10 +89,10 @@ func Load() (*Config, error) {
 			AllowCredentials: getBoolOrDefault("CORS_ALLOW_CREDENTIALS", true),
 			MaxAge:           getIntOrDefault("CORS_MAX_AGE", 3600),
 		},
-		Storage: StorageConfig{
+		Storage: uploads.Config{
 			Type:           strings.TrimSpace(getEnvOrDefault("STORAGE_TYPE", "local")),
 			LocalBaseDir:   getEnvOrDefault("STORAGE_LOCAL_BASE_DIR", "./bucket"),
-			LocalPublicURL: getEnvOrDefault("SERVICE_URL", fmt.Sprintf("http://localhost:%d", serverPort)),
+			LocalPublicURL: getEnvOrDefault("STORAGE_LOCAL_PUBLIC_URL", getEnvOrDefault("SERVICE_URL", fmt.Sprintf("http://localhost:%d", serverPort))),
 			S3Endpoint:     os.Getenv("STORAGE_S3_ENDPOINT"),
 			S3Bucket:       getEnvOrDefault("STORAGE_S3_BUCKET", "nsw-uploads"),
 			S3Region:       getEnvOrDefault("STORAGE_S3_REGION", "us-east-1"),
@@ -138,12 +103,12 @@ func Load() (*Config, error) {
 			LocalPutSecret: getEnvOrDefault("STORAGE_LOCAL_PUT_SECRET", "local-dev-secret"),
 			PresignTTL:     parseDurationOrDefault(getEnvOrDefault("STORAGE_PRESIGN_TTL", "15m"), 15*time.Minute),
 		},
-		Auth: AuthConfig{
+		Auth: auth.Config{
 			JWKSURL:               getEnvOrDefault("AUTH_JWKS_URL", "https://localhost:8090/oauth2/jwks"),
 			Issuer:                getEnvOrDefault("AUTH_ISSUER", "https://localhost:8090"),
-			Audience:              getEnvOrDefault("AUTH_AUDIENCE", "NSW_API"),
-			ClientIDs:             parseCommaSeparated(getEnvOrDefault("AUTH_CLIENT_IDS", "TRADER_PORTAL_APP,FCAU_TO_NSW,NPQS_TO_NSW,IRD_TO_NSW")),
-			InsecureSkipTLSVerify: getBoolOrDefault("AUTH_JWKS_INSECURE_SKIP_VERIFY", defaultInsecureJWKS),
+			Audience:              getEnvOrDefault("AUTH_AUDIENCE", "TRADER_PORTAL_APP"),
+			ClientID:              getEnvOrDefault("AUTH_CLIENT_ID", "TRADER_PORTAL_APP"),
+			InsecureSkipTLSVerify: getBoolOrDefault("AUTH_JWKS_INSECURE_SKIP_VERIFY", false),
 		},
 		Notification: NotificationConfig{
 			SMTPHost:     getEnvOrDefault("EMAIL_SMTP_HOST", "localhost"),
@@ -165,29 +130,14 @@ func Load() (*Config, error) {
 
 // Validate checks that all required configuration is present
 func (c *Config) Validate() error {
-	if c.Database.Host == "" {
-		return fmt.Errorf("DB_HOST is required")
+	if err := c.Database.Validate(); err != nil {
+		return fmt.Errorf("invalid database configuration: %w", err)
 	}
-	if c.Database.Username == "" {
-		return fmt.Errorf("DB_USERNAME is required")
+	if err := c.Storage.Validate(); err != nil {
+		return fmt.Errorf("invalid storage configuration: %w", err)
 	}
-	if c.Database.Password == "" {
-		return fmt.Errorf("DB_PASSWORD is required")
-	}
-	if c.Database.Name == "" {
-		return fmt.Errorf("DB_NAME is required")
-	}
-	if c.Auth.JWKSURL == "" {
-		return fmt.Errorf("AUTH_JWKS_URL is required")
-	}
-	if c.Auth.Issuer == "" {
-		return fmt.Errorf("AUTH_ISSUER is required")
-	}
-	if c.Auth.Audience == "" {
-		return fmt.Errorf("AUTH_AUDIENCE is required")
-	}
-	if len(c.Auth.ClientIDs) == 0 {
-		return fmt.Errorf("AUTH_CLIENT_IDS is required")
+	if err := c.Auth.Validate(); err != nil {
+		return fmt.Errorf("invalid auth configuration: %w", err)
 	}
 	if !c.Server.Debug {
 		if len(c.CORS.AllowedOrigins) == 0 {
@@ -200,22 +150,6 @@ func (c *Config) Validate() error {
 		}
 	}
 	return nil
-}
-
-// DSN returns the database connection string
-func (c *DatabaseConfig) DSN() string {
-	// Using the URL format is more robust for handling special characters in passwords.
-	// format: postgres://user:password@host:port/dbname?sslmode=disable
-	dsn := url.URL{
-		Scheme: "postgres",
-		User:   url.UserPassword(c.Username, c.Password),
-		Host:   fmt.Sprintf("%s:%d", c.Host, c.Port),
-		Path:   c.Name,
-	}
-	query := dsn.Query()
-	query.Add("sslmode", c.SSLMode)
-	dsn.RawQuery = query.Encode()
-	return dsn.String()
 }
 
 // getEnvOrDefault returns the value of an environment variable or a default value
@@ -244,11 +178,6 @@ func getBoolOrDefault(key string, defaultValue bool) bool {
 		}
 	}
 	return defaultValue
-}
-
-// getDefaultInsecureJWKS returns true if the JWKS URL is a localhost URL, indicating that TLS verification can be skipped in development
-func getDefaultInsecureJWKS(jwksURL string) bool {
-	return strings.HasPrefix(jwksURL, "https://localhost") || strings.HasPrefix(jwksURL, "https://127.0.0.1")
 }
 
 // parseDurationOrDefault returns the time.Duration value of a string or a default value

--- a/backend/internal/config/config.go
+++ b/backend/internal/config/config.go
@@ -16,13 +16,12 @@ import (
 
 // Config holds all configuration for the application
 type Config struct {
-	Database             database.Config
-	Server               ServerConfig
-	CORS                 CORSConfig
-	Storage              uploads.Config
-	Auth                 auth.Config
-	Notification         NotificationConfig
-	UseWorkflowManagerV2 bool
+	Database     database.Config
+	Server       ServerConfig
+	CORS         CORSConfig
+	Storage      uploads.Config
+	Auth         auth.Config
+	Notification NotificationConfig
 }
 
 // ServerConfig holds server configuration
@@ -107,8 +106,8 @@ func Load() (*Config, error) {
 		Auth: auth.Config{
 			JWKSURL:               getEnvOrDefault("AUTH_JWKS_URL", "https://localhost:8090/oauth2/jwks"),
 			Issuer:                getEnvOrDefault("AUTH_ISSUER", "https://localhost:8090"),
-			Audience:              getEnvOrDefault("AUTH_AUDIENCE", "TRADER_PORTAL_APP"),
-			ClientID:              getEnvOrDefault("AUTH_CLIENT_ID", "TRADER_PORTAL_APP"),
+			Audience:              getEnvOrDefault("AUTH_AUDIENCE", "NSW_API"),
+			ClientIDs:             parseCommaSeparated(getEnvOrDefault("AUTH_CLIENT_IDS", "TRADER_PORTAL_APP,FCAU_TO_NSW,NPQS_TO_NSW,IRD_TO_NSW")),
 			InsecureSkipTLSVerify: getBoolOrDefault("AUTH_JWKS_INSECURE_SKIP_VERIFY", false),
 		},
 		Notification: NotificationConfig{

--- a/backend/internal/database/config.go
+++ b/backend/internal/database/config.go
@@ -1,0 +1,51 @@
+package database
+
+import (
+	"fmt"
+	"net/url"
+)
+
+// Config holds database connection configuration.
+type Config struct {
+	Host                   string
+	Port                   int
+	Username               string
+	Password               string
+	Name                   string
+	SSLMode                string
+	MaxIdleConns           int
+	MaxOpenConns           int
+	MaxConnLifetimeSeconds int
+}
+
+func (c *Config) Validate() error {
+	if c.Host == "" {
+		return fmt.Errorf("DB_HOST is required")
+	}
+	if c.Username == "" {
+		return fmt.Errorf("DB_USERNAME is required")
+	}
+	if c.Password == "" {
+		return fmt.Errorf("DB_PASSWORD is required")
+	}
+	if c.Name == "" {
+		return fmt.Errorf("DB_NAME is required")
+	}
+	return nil
+}
+
+// DSN returns the database connection string.
+func (c *Config) DSN() string {
+	// Using the URL format is more robust for handling special characters in passwords.
+	// format: postgres://user:password@host:port/dbname?sslmode=disable
+	dsn := url.URL{
+		Scheme: "postgres",
+		User:   url.UserPassword(c.Username, c.Password),
+		Host:   fmt.Sprintf("%s:%d", c.Host, c.Port),
+		Path:   c.Name,
+	}
+	query := dsn.Query()
+	query.Add("sslmode", c.SSLMode)
+	dsn.RawQuery = query.Encode()
+	return dsn.String()
+}

--- a/backend/internal/database/database.go
+++ b/backend/internal/database/database.go
@@ -8,16 +8,10 @@ import (
 	"gorm.io/driver/postgres"
 	"gorm.io/gorm"
 	"gorm.io/gorm/logger"
-
-	"github.com/OpenNSW/nsw/internal/config"
 )
 
 // New creates a new database connection using the provided configuration
-func New(cfg *config.DatabaseConfig) (*gorm.DB, error) {
-	if cfg == nil {
-		return nil, fmt.Errorf("database config cannot be nil")
-	}
-
+func New(cfg Config) (*gorm.DB, error) {
 	// Configure GORM logger
 	gormLogger := logger.Default.LogMode(logger.Info)
 

--- a/backend/internal/uploads/config.go
+++ b/backend/internal/uploads/config.go
@@ -1,0 +1,58 @@
+package uploads
+
+import (
+	"fmt"
+	"strings"
+	"time"
+)
+
+type Config struct {
+	Type           string // "local" or "s3"
+	LocalBaseDir   string
+	LocalPublicURL string
+	S3Endpoint     string
+	S3Bucket       string
+	S3Region       string
+	S3AccessKey    string
+	S3SecretKey    string
+	S3UseSSL       bool
+	S3PublicURL    string
+	LocalPutSecret string
+	PresignTTL     time.Duration
+}
+
+func (c *Config) Validate() error {
+	switch strings.TrimSpace(c.Type) {
+	case "local":
+		if strings.TrimSpace(c.LocalBaseDir) == "" {
+			return fmt.Errorf("STORAGE_LOCAL_BASE_DIR is required when STORAGE_TYPE=local")
+		}
+		if strings.TrimSpace(c.LocalPublicURL) == "" {
+			return fmt.Errorf("STORAGE_LOCAL_PUBLIC_URL is required when STORAGE_TYPE=local")
+		}
+		if strings.TrimSpace(c.LocalPutSecret) == "" {
+			return fmt.Errorf("STORAGE_LOCAL_PUT_SECRET is required when STORAGE_TYPE=local")
+		}
+	case "s3":
+		if strings.TrimSpace(c.S3Endpoint) == "" {
+			return fmt.Errorf("STORAGE_S3_ENDPOINT is required when STORAGE_TYPE=s3")
+		}
+		if strings.TrimSpace(c.S3Bucket) == "" {
+			return fmt.Errorf("STORAGE_S3_BUCKET is required when STORAGE_TYPE=s3")
+		}
+		if strings.TrimSpace(c.S3Region) == "" {
+			return fmt.Errorf("STORAGE_S3_REGION is required when STORAGE_TYPE=s3")
+		}
+		if (strings.TrimSpace(c.S3AccessKey) == "") != (strings.TrimSpace(c.S3SecretKey) == "") {
+			return fmt.Errorf("STORAGE_S3_ACCESS_KEY and STORAGE_S3_SECRET_KEY must be configured together")
+		}
+	default:
+		return fmt.Errorf("unsupported STORAGE_TYPE: %s", c.Type)
+	}
+
+	if c.PresignTTL <= 0 {
+		return fmt.Errorf("STORAGE_PRESIGN_TTL must be greater than zero")
+	}
+
+	return nil
+}

--- a/backend/internal/uploads/config.go
+++ b/backend/internal/uploads/config.go
@@ -4,6 +4,8 @@ import (
 	"fmt"
 	"strings"
 	"time"
+
+	"github.com/OpenNSW/nsw/internal/validation"
 )
 
 type Config struct {
@@ -30,12 +32,18 @@ func (c *Config) Validate() error {
 		if strings.TrimSpace(c.LocalPublicURL) == "" {
 			return fmt.Errorf("STORAGE_LOCAL_PUBLIC_URL is required when STORAGE_TYPE=local")
 		}
+		if err := validation.HTTPURL("STORAGE_LOCAL_PUBLIC_URL", c.LocalPublicURL); err != nil {
+			return err
+		}
 		if strings.TrimSpace(c.LocalPutSecret) == "" {
 			return fmt.Errorf("STORAGE_LOCAL_PUT_SECRET is required when STORAGE_TYPE=local")
 		}
 	case "s3":
 		if strings.TrimSpace(c.S3Endpoint) == "" {
 			return fmt.Errorf("STORAGE_S3_ENDPOINT is required when STORAGE_TYPE=s3")
+		}
+		if err := validation.HTTPURL("STORAGE_S3_ENDPOINT", c.S3Endpoint); err != nil {
+			return err
 		}
 		if strings.TrimSpace(c.S3Bucket) == "" {
 			return fmt.Errorf("STORAGE_S3_BUCKET is required when STORAGE_TYPE=s3")
@@ -45,6 +53,11 @@ func (c *Config) Validate() error {
 		}
 		if (strings.TrimSpace(c.S3AccessKey) == "") != (strings.TrimSpace(c.S3SecretKey) == "") {
 			return fmt.Errorf("STORAGE_S3_ACCESS_KEY and STORAGE_S3_SECRET_KEY must be configured together")
+		}
+		if strings.TrimSpace(c.S3PublicURL) != "" {
+			if err := validation.HTTPURL("STORAGE_S3_PUBLIC_URL", c.S3PublicURL); err != nil {
+				return err
+			}
 		}
 	default:
 		return fmt.Errorf("unsupported STORAGE_TYPE: %s", c.Type)

--- a/backend/internal/uploads/factory.go
+++ b/backend/internal/uploads/factory.go
@@ -11,12 +11,11 @@ import (
 	"github.com/aws/aws-sdk-go-v2/credentials"
 	"github.com/aws/aws-sdk-go-v2/service/s3"
 
-	"github.com/OpenNSW/nsw/internal/config"
 	"github.com/OpenNSW/nsw/internal/uploads/drivers"
 )
 
 // NewStorageFromConfig creates a storage instance based on the provided configuration.
-func NewStorageFromConfig(ctx context.Context, cfg config.StorageConfig) (StorageDriver, error) {
+func NewStorageFromConfig(ctx context.Context, cfg Config) (StorageDriver, error) {
 	switch strings.TrimSpace(cfg.Type) {
 	case "local":
 		slog.Info("Initializing local storage", "dir", cfg.LocalBaseDir)

--- a/backend/internal/validation/url.go
+++ b/backend/internal/validation/url.go
@@ -1,0 +1,18 @@
+package validation
+
+import (
+	"fmt"
+	"net/url"
+	"strings"
+)
+
+func HTTPURL(name, value string) error {
+	parsed, err := url.ParseRequestURI(strings.TrimSpace(value))
+	if err != nil || parsed.Scheme == "" || parsed.Host == "" {
+		return fmt.Errorf("%s must be a valid absolute URL", name)
+	}
+	if parsed.Scheme != "http" && parsed.Scheme != "https" {
+		return fmt.Errorf("%s must use http or https", name)
+	}
+	return nil
+}


### PR DESCRIPTION
## Summary

Refactors backend configuration ownership so database, auth, and uploads/storage config types live with the packages that consume them, while `backend/internal/config` remains responsible for environment-variable loading and top-level composition. This keeps env mappings visible but moves validation and package-specific config behavior closer to the relevant implementation.

Closes #379

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [x] Refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Other (please describe):

## Changes Made

- Moved auth configuration and validation into `backend/internal/auth`.
- Moved database configuration, validation, and DSN construction into `backend/internal/database`.
- Moved uploads/storage configuration and validation into `backend/internal/uploads`.
- Kept explicit environment variable mapping in `backend/internal/config/config.go` so configuration remains easy to audit.
- Added storage validation based on `STORAGE_TYPE`:
  - `local` requires local base directory, local public URL, local put secret, and a positive presign TTL.
  - `s3` requires endpoint, bucket, region, positive presign TTL, and validates that static access/secret keys are configured together when provided.
- Added explicit `STORAGE_LOCAL_PUBLIC_URL` examples while retaining `SERVICE_URL` fallback behavior.
- Removed localhost-based default derivation for `AUTH_JWKS_INSECURE_SKIP_VERIFY`; it now defaults to `false` unless explicitly configured.

## Testing

- [x] I have tested this change locally
- [ ] I have added unit tests for new functionality
- [x] I have tested edge cases
- [x] All existing tests pass

Validated with:

```bash
GOCACHE=/tmp/nsw-go-build-cache go test ./internal/config ./internal/database ./internal/uploads ./internal/app/bootstrap
GOCACHE=/tmp/nsw-go-build-cache go test ./internal/auth
```

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have checked that there are no merge conflicts

## Related Issues

Closes #379

## Screenshots/Demo

Not applicable.

## Additional Notes

`AUTH_JWKS_INSECURE_SKIP_VERIFY` no longer derives its default from whether the JWKS URL points to localhost. That derivation is surprising because TLS verification policy should be an explicit deployment/security decision, not inferred from a hostname string. A localhost URL can still be served with a trusted certificate, and a non-local URL can still be a development or test endpoint with a self-signed certificate. Inferring security behavior from URL shape also makes local and production behavior less predictable when URLs change. The safer default is to keep TLS verification enabled unless the developer explicitly opts out via configuration.

Notification configuration remains in the top-level config for now because notifications are not feature complete yet. Once that area stabilizes, the developer completing notifications should move notification-specific config and validation into the notification package using the same ownership pattern.

## Deployment Notes

Deployments that rely on self-signed JWKS certificates must explicitly set:

```env
AUTH_JWKS_INSECURE_SKIP_VERIFY=true
```

Local storage deployments should set:

```env
STORAGE_LOCAL_PUBLIC_URL=<backend public URL>
STORAGE_LOCAL_PUT_SECRET=<local upload signing secret>
STORAGE_PRESIGN_TTL=15m
```