### PR TITLE
[Trader App][Wait For Event] Fix non-clickable download button in ReviewResponseForm

### DIFF
--- a/portals/apps/trader-app/src/plugins/WaitForEvent.tsx
+++ b/portals/apps/trader-app/src/plugins/WaitForEvent.tsx
@@ -135,7 +135,7 @@ function ReviewResponseForm({ formInfo }: { formInfo: TaskFormData }) {
       <div className="bg-gray-50 border-b border-gray-100 px-6 py-4">
         <h3 className="text-sm font-bold text-gray-700 uppercase tracking-wider">{formInfo.title}</h3>
       </div>
-      <div className="p-6 pointer-events-none opacity-80 bg-gray-50/30">
+      <div className="p-6 bg-gray-50/30">
         <JsonForms
           schema={formInfo.schema}
           uischema={formInfo.uiSchema}


### PR DESCRIPTION
## Summary
This PR fixes an issue where the download ("View") button in the `ReviewResponseForm` (part of the `WaitForEvent` plugin) was non-interactive due to the `pointer-events-none` class on its container.

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)

## Changes Made
- Removed `pointer-events-none` from the `div` container wrapping the `JsonForms` component in `portals/apps/trader-app/src/plugins/WaitForEvent.tsx`.

## Testing
- [x] I have tested this change locally

## Checklist
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings

## Related Issues
Closes #383