### PR TITLE
feat(task plugin, oga): harden external service integration with typed requests and TaskCode routing

### DIFF
--- a/backend/internal/database/migrations/004_insert_seed_workflow_node_templates.up.sql
+++ b/backend/internal/database/migrations/004_insert_seed_workflow_node_templates.up.sql
@@ -168,11 +168,7 @@ VALUES
             "submission": {
                 "url": ' || to_jsonb((:'NPQS_OGA_SUBMISSION_URL')::text)::text || ',
                 "request": {
-                    "meta": {
-                        "type": "consignment",
-                        "verificationId": "moa:npqs:phytosanitary:001",
-                        "templateKey": "npqs:phytosanitary:v1"
-                    }
+                    "taskCode": "npqs:phytosanitary:v1"
                 }
             }
         }')::jsonb,
@@ -207,11 +203,7 @@ VALUES
             "submission": {
                 "url": ' || to_jsonb((:'FCAU_OGA_SUBMISSION_URL')::text)::text || ',
                 "request": {
-                    "meta": {
-                        "type": "consignment",
-                        "verificationId": "edb:fcau:health-certificate:001",
-                        "templateKey": "fcau:health_certificate:v1"
-                    }
+                    "taskCode": "fcau:health_certificate:v1"
                 }
             }
         }')::jsonb,
@@ -240,9 +232,7 @@ VALUES
             "submission": {
                 "url": ' || to_jsonb((:'NPQS_OGA_SUBMISSION_URL')::text)::text || ',
                 "request": {
-                    "meta": {
-                        "templateKey": "npqs:manual_inspection:v1"
-                    },
+                    "taskCode": "npqs:manual_inspection:v1",
                     "template": {
                         "consignee_name": "consignee:consignee_name",
                         "consigneeAddress": "consignee:address"
@@ -292,21 +282,19 @@ VALUES
             "submission": {
                 "url": "http://localhost:8081/api/oga/inject",
                 "request": {
-                    "meta": {
-                    "templateKey": "ship_departure_v1"
+                    "taskCode": "ship_departure_v1",
+                    "template": {
+                        "port_code": "departure_port",
+                        "vessel_id": "ship_identifier"
+                    }
                 },
-                "template": {
-                    "port_code": "departure_port",
-                    "vessel_id": "ship_identifier"
-                }
-            },
-            "response": {
-                "display": {
-                    "formId": "95d7e7fe-5be0-43cb-ac71-94bc70d3a01d"
+                "response": {
+                    "display": {
+                        "formId": "95d7e7fe-5be0-43cb-ac71-94bc70d3a01d"
+                    }
                 }
             }
-        }
-}',
+        }',
         '[
             "c0000003-0003-0003-0003-000000000003",
             "c0000003-0003-0003-0003-000000000004",

--- a/backend/internal/task/plugin/simple_form.go
+++ b/backend/internal/task/plugin/simple_form.go
@@ -96,7 +96,7 @@ type SubmissionConfig struct {
 
 // SimpleFormExternalServiceRequest represents the payload sent to the external service.
 type SimpleFormExternalServiceRequest struct {
-	TaskCode           string             `json:"taskCode,omitempty"` // Code to identify task config on external service side
+	TaskCode           string             `json:"taskCode"` // Code to identify task config on external service side
 	TaskID             string             `json:"taskId"`
 	WorkflowID         string             `json:"workflowId"`
 	ServiceURL         string             `json:"serviceUrl"`
@@ -458,7 +458,7 @@ func (s *SimpleForm) submitHandler(ctx context.Context, content any) (*Execution
 				Success: false,
 				Error: &ApiError{
 					Code:    "MISSING_TASK_CODE",
-					Message: "TaskCode is required for external service submission. Please configure either submission.request.taskCode or ensure formId is set.",
+					Message: "TaskCode is required for external service submission. Please configure submission.request.taskCode in the plugin config.",
 				},
 			},
 		}, nil

--- a/backend/internal/task/plugin/simple_form.go
+++ b/backend/internal/task/plugin/simple_form.go
@@ -453,15 +453,7 @@ func (s *SimpleForm) submitHandler(ctx context.Context, content any) (*Execution
 
 	// Validate that TaskCode is non-empty (required by OGA service)
 	if requestPayload.TaskCode == "" {
-		return &ExecutionResponse{
-			ApiResponse: &ApiResponse{
-				Success: false,
-				Error: &ApiError{
-					Code:    "MISSING_TASK_CODE",
-					Message: "TaskCode is required for external service submission. Please configure submission.request.taskCode in the plugin config.",
-				},
-			},
-		}, nil
+		return nil, fmt.Errorf("taskCode is required in submission request configuration")
 	}
 
 	if history, err := s.readOGAFeedbackHistory(); err == nil && len(history) > 0 {

--- a/backend/internal/task/plugin/simple_form.go
+++ b/backend/internal/task/plugin/simple_form.go
@@ -451,6 +451,19 @@ func (s *SimpleForm) submitHandler(ctx context.Context, content any) (*Execution
 		requestPayload.TaskCode = s.config.Submission.Request.TaskCode
 	}
 
+	// Validate that TaskCode is non-empty (required by OGA service)
+	if requestPayload.TaskCode == "" {
+		return &ExecutionResponse{
+			ApiResponse: &ApiResponse{
+				Success: false,
+				Error: &ApiError{
+					Code:    "MISSING_TASK_CODE",
+					Message: "TaskCode is required for external service submission. Please configure either submission.request.taskCode or ensure formId is set.",
+				},
+			},
+		}, nil
+	}
+
 	if history, err := s.readOGAFeedbackHistory(); err == nil && len(history) > 0 {
 		requestPayload.OGAFeedbackHistory = history
 	}

--- a/backend/internal/task/plugin/simple_form.go
+++ b/backend/internal/task/plugin/simple_form.go
@@ -94,6 +94,16 @@ type SubmissionConfig struct {
 	Response  *Response `json:"response,omitempty"` // Expected response mapping after submission
 }
 
+// SimpleFormExternalServiceRequest represents the payload sent to the external service.
+type SimpleFormExternalServiceRequest struct {
+	TaskCode           string             `json:"taskCode,omitempty"` // Code to identify task config on external service side
+	TaskID             string             `json:"taskId"`
+	WorkflowID         string             `json:"workflowId"`
+	ServiceURL         string             `json:"serviceUrl"`
+	Data               map[string]any     `json:"data"` // Submitted trader form data
+	OGAFeedbackHistory []OGAFeedbackEntry `json:"ogaFeedbackHistory,omitempty"`
+}
+
 type CallbackConfig struct {
 	Transition *TransitionConfig `json:"transition,omitempty"`
 	Response   *Response         `json:"response,omitempty"`
@@ -431,18 +441,18 @@ func (s *SimpleForm) submitHandler(ctx context.Context, content any) (*Execution
 		}, nil
 	}
 
-	requestPayload := map[string]any{
-		"data":       formData,
-		"taskId":     s.api.GetTaskID(),
-		"workflowId": s.api.GetWorkflowID(),
-		"serviceUrl": strings.TrimRight(s.cfg.Server.ServiceURL, "/") + TasksAPIPath,
+	requestPayload := SimpleFormExternalServiceRequest{
+		TaskID:     s.api.GetTaskID(),
+		WorkflowID: s.api.GetWorkflowID(),
+		ServiceURL: strings.TrimRight(s.cfg.Server.ServiceURL, "/") + TasksAPIPath,
+		Data:       formData,
 	}
 	if s.config.Submission != nil && s.config.Submission.Request != nil {
-		requestPayload["taskCode"] = s.config.Submission.Request.TaskCode
+		requestPayload.TaskCode = s.config.Submission.Request.TaskCode
 	}
 
 	if history, err := s.readOGAFeedbackHistory(); err == nil && len(history) > 0 {
-		requestPayload["ogaFeedbackHistory"] = history
+		requestPayload.OGAFeedbackHistory = history
 	}
 
 	var serviceID string
@@ -888,11 +898,11 @@ func (s *SimpleForm) mergeFormData(prepopulated, existing map[string]interface{}
 
 // sendFormSubmission sends the form data to the specified service or URL.
 // It uses the remote Manager to identify the service (by ID or URL) and apply its configuration.
-func (s *SimpleForm) sendFormSubmission(ctx context.Context, serviceID, path string, formData map[string]interface{}) (map[string]interface{}, error) {
+func (s *SimpleForm) sendFormSubmission(ctx context.Context, serviceID, path string, payload any) (map[string]interface{}, error) {
 	req := remote.Request{
 		Method: "POST",
 		Path:   path,
-		Body:   formData,
+		Body:   payload,
 		Retry:  &remote.DefaultRetryConfig,
 	}
 

--- a/backend/internal/task/plugin/simple_form.go
+++ b/backend/internal/task/plugin/simple_form.go
@@ -73,16 +73,11 @@ type Config struct {
 	RequiresOgaVerification bool              `json:"requiresOgaVerification,omitempty"` // If true, waits for OGA_VERIFICATION action; if false, completes after submission response
 }
 
-type Meta struct {
-	// TODO: After adapting to TemplateKey, VerificationType and VerificationId should be removed.
-	VerificationType string `json:"type,omitempty"`
-	VerificationId   string `json:"verificationId,omitempty"`
-	TemplateKey      string `json:"templateKey,omitempty"`
-}
 type Request struct {
-	Meta     *Meta           `json:"meta,omitempty"`
+	TaskCode string          `json:"taskCode"` // Code to identify task config on External service side
 	Template json.RawMessage `json:"template,omitempty"`
 }
+
 type Response struct {
 	Mapping map[string]string `json:"mapping,omitempty"` // Data to be mapped to global context after submission
 	Display *Display          `json:"display,omitempty"`
@@ -443,7 +438,7 @@ func (s *SimpleForm) submitHandler(ctx context.Context, content any) (*Execution
 		"serviceUrl": strings.TrimRight(s.cfg.Server.ServiceURL, "/") + TasksAPIPath,
 	}
 	if s.config.Submission != nil && s.config.Submission.Request != nil {
-		requestPayload["meta"] = s.config.Submission.Request.Meta
+		requestPayload["taskCode"] = s.config.Submission.Request.TaskCode
 	}
 
 	if history, err := s.readOGAFeedbackHistory(); err == nil && len(history) > 0 {

--- a/backend/internal/task/plugin/wait_for_event.go
+++ b/backend/internal/task/plugin/wait_for_event.go
@@ -239,6 +239,9 @@ func (t *WaitForEventTask) notifyExternalService(ctx context.Context, taskID str
 	if t.config.Submission.Request != nil {
 		extReq.TaskCode = t.config.Submission.Request.TaskCode
 	}
+	if extReq.TaskCode == "" {
+		return fmt.Errorf("taskCode is required for external service submission. Please configure submission.request.taskCode in the plugin config")
+	}
 
 	req := remote.Request{
 		Method: "POST",

--- a/backend/internal/task/plugin/wait_for_event.go
+++ b/backend/internal/task/plugin/wait_for_event.go
@@ -80,8 +80,8 @@ func (t *WaitForEventTask) Init(api API) {
 	t.api = api
 }
 
-// ExternalServiceRequest represents the payload sent to the external service
-type ExternalServiceRequest struct {
+// WaitForEventExternalServiceRequest represents the payload sent to the external service
+type WaitForEventExternalServiceRequest struct {
 	TaskCode   string `json:"taskCode"` // Code to identify task config on External service side
 	TaskID     string `json:"taskId"`
 	WorkflowID string `json:"workflowId"`
@@ -229,7 +229,7 @@ func (t *WaitForEventTask) notifyExternalService(ctx context.Context, taskID str
 	target := t.config.Submission.Url
 	serviceID := t.config.Submission.ServiceID
 
-	extReq := ExternalServiceRequest{
+	extReq := WaitForEventExternalServiceRequest{
 		WorkflowID: workflowID,
 		TaskID:     taskID,
 		ServiceURL: strings.TrimRight(t.serviceBaseURL, "/") + TasksAPIPath,

--- a/backend/internal/task/plugin/wait_for_event.go
+++ b/backend/internal/task/plugin/wait_for_event.go
@@ -82,11 +82,11 @@ func (t *WaitForEventTask) Init(api API) {
 
 // ExternalServiceRequest represents the payload sent to the external service
 type ExternalServiceRequest struct {
-	Data       any    `json:"data"` // Resolved data from global context
-	WorkflowID string `json:"workflowId"`
+	TaskCode   string `json:"taskCode"` // Code to identify task config on External service side
 	TaskID     string `json:"taskId"`
+	WorkflowID string `json:"workflowId"`
 	ServiceURL string `json:"serviceUrl"`
-	Meta       *Meta  `json:"meta,omitempty"`
+	Data       any    `json:"data"` // Resolved data from global context
 }
 
 // NewWaitForEventFSM returns the state graph for WaitForEventTask.
@@ -237,7 +237,7 @@ func (t *WaitForEventTask) notifyExternalService(ctx context.Context, taskID str
 	}
 
 	if t.config.Submission.Request != nil {
-		extReq.Meta = t.config.Submission.Request.Meta
+		extReq.TaskCode = t.config.Submission.Request.TaskCode
 	}
 
 	req := remote.Request{

--- a/backend/internal/task/plugin/wait_for_event_test.go
+++ b/backend/internal/task/plugin/wait_for_event_test.go
@@ -95,6 +95,9 @@ func newWFETask(t *testing.T, serverURL string) (*WaitForEventTask, *wfeAPI) {
 	raw, err := json.Marshal(WaitForEventConfig{
 		Submission: &SubmissionConfig{
 			Url: serverURL,
+			Request: &Request{
+				TaskCode: "test-task-code",
+			},
 		},
 	})
 	if err != nil {

--- a/oga/internal/form.go
+++ b/oga/internal/form.go
@@ -71,10 +71,9 @@ func (fs *FormStore) GetDefaultForm() (json.RawMessage, error) {
 	return fs.GetForm(fs.defaultFormID)
 }
 
-// FormIDFromMeta constructs a form ID from Meta fields: "type:verificationId".
-func FormIDFromMeta(m *Meta) string {
-	if m == nil {
-		return ""
-	}
-	return m.VerificationType + ":" + m.VerificationId
+// FormIDFromTaskCode constructs a form ID from Meta fields: "type:verificationId".
+func FormIDFromTaskCode(taskCode string) string {
+	// TODO: this is a temporary implementation. The form ID construction logic may evolve as we support more complex scenarios.
+	// For example, we might want to include the task code, or have a mapping of task codes to form IDs in the config.
+	return taskCode
 }

--- a/oga/internal/form.go
+++ b/oga/internal/form.go
@@ -71,7 +71,7 @@ func (fs *FormStore) GetDefaultForm() (json.RawMessage, error) {
 	return fs.GetForm(fs.defaultFormID)
 }
 
-// FormIDFromTaskCode constructs a form ID from Meta fields: "type:verificationId".
+// FormIDFromTaskCode returns the form ID associated with the given task code.
 func FormIDFromTaskCode(taskCode string) string {
 	// TODO: this is a temporary implementation. The form ID construction logic may evolve as we support more complex scenarios.
 	// For example, we might want to include the task code, or have a mapping of task codes to form IDs in the config.

--- a/oga/internal/service.go
+++ b/oga/internal/service.go
@@ -57,16 +57,17 @@ type Meta struct {
 // InjectRequest represents the incoming data from services
 type InjectRequest struct {
 	TaskID             string           `json:"taskId"`
+	TaskCode           string           `json:"taskCode"`
 	WorkflowID         string           `json:"workflowId"`
 	Data               map[string]any   `json:"data"`
 	ServiceURL         string           `json:"serviceUrl"` // URL to send response back to
-	Meta               *Meta            `json:"meta,omitempty"`
 	OGAFeedbackHistory []map[string]any `json:"ogafeedbackhistory,omitempty"`
 }
 
 // Application represents an application for display in the UI
 type Application struct {
 	TaskID          string           `json:"taskId"`
+	TaskCode        string           `json:"taskCode"`
 	WorkflowID      string           `json:"workflowId"`
 	ServiceURL      string           `json:"serviceUrl"`
 	Data            map[string]any   `json:"data"`                    // Data from NSW service to be rendered in the UI
@@ -96,38 +97,6 @@ type TaskResponse struct {
 	Payload    any    `json:"payload"`
 }
 
-// metaToJSONB converts a *Meta struct to JSONB via JSON round-trip.
-func metaToJSONB(m *Meta) (JSONB, error) {
-	if m == nil {
-		return nil, nil
-	}
-	data, err := json.Marshal(m)
-	if err != nil {
-		return nil, fmt.Errorf("failed to marshal Meta: %w", err)
-	}
-	var j JSONB
-	if err := json.Unmarshal(data, &j); err != nil {
-		return nil, fmt.Errorf("failed to unmarshal Meta to JSONB: %w", err)
-	}
-	return j, nil
-}
-
-// metaFromJSONB converts a JSONB map back to a *Meta struct via JSON round-trip.
-func metaFromJSONB(j JSONB) *Meta {
-	if j == nil {
-		return nil
-	}
-	data, err := json.Marshal(j)
-	if err != nil {
-		return nil
-	}
-	var m Meta
-	if err := json.Unmarshal(data, &m); err != nil {
-		return nil
-	}
-	return &m
-}
-
 type ogaService struct {
 	store      *ApplicationStore
 	formStore  *FormStore
@@ -151,6 +120,9 @@ func (s *ogaService) CreateApplication(ctx context.Context, req *InjectRequest) 
 	if req.TaskID == "" {
 		return fmt.Errorf("taskId is required")
 	}
+	if req.TaskCode == "" {
+		return fmt.Errorf("taskCode is required")
+	}
 	if req.WorkflowID == "" {
 		return fmt.Errorf("workflowId is required")
 	}
@@ -166,17 +138,12 @@ func (s *ogaService) CreateApplication(ctx context.Context, req *InjectRequest) 
 		return s.store.UpdateDataAndResetStatus(req.TaskID, req.Data)
 	}
 
-	metaJSON, err := metaToJSONB(req.Meta)
-	if err != nil {
-		return fmt.Errorf("failed to convert meta: %w", err)
-	}
-
 	appRecord := &ApplicationRecord{
 		TaskID:     req.TaskID,
+		TaskCode:   req.TaskCode,
 		WorkflowID: req.WorkflowID,
 		ServiceURL: req.ServiceURL,
 		Data:       req.Data,
-		Meta:       metaJSON,
 		Status:     "PENDING",
 	}
 
@@ -208,13 +175,12 @@ func (s *ogaService) GetApplications(ctx context.Context, status string, workflo
 
 	applications := make([]Application, len(records))
 	for i, record := range records {
-		meta := metaFromJSONB(record.Meta)
 		applications[i] = Application{
 			TaskID:     record.TaskID,
+			TaskCode:   record.TaskCode,
 			WorkflowID: record.WorkflowID,
 			ServiceURL: record.ServiceURL,
 			Data:       record.Data,
-			Meta:       meta,
 			Status:     record.Status,
 			ReviewedAt: record.ReviewedAt,
 			CreatedAt:  record.CreatedAt,
@@ -263,14 +229,13 @@ func (s *ogaService) GetApplication(ctx context.Context, taskID string) (*Applic
 		return nil, fmt.Errorf("failed to get application: %w", err)
 	}
 
-	meta := metaFromJSONB(record.Meta)
 	app := &Application{
 		TaskID:          record.TaskID,
+		TaskCode:        record.TaskCode,
 		WorkflowID:      record.WorkflowID,
 		ServiceURL:      record.ServiceURL,
 		Data:            record.Data,
 		OgaActionData:   record.ReviewerResponse,
-		Meta:            meta,
 		Status:          record.Status,
 		FeedbackHistory: feedbackHistoryFromRaw(record.OGAFeedbackHistory),
 		ReviewedAt:      record.ReviewedAt,
@@ -279,7 +244,7 @@ func (s *ogaService) GetApplication(ctx context.Context, taskID string) (*Applic
 	}
 
 	// Attach oga form: look up by meta, fall back to default
-	formID := FormIDFromMeta(meta)
+	formID := FormIDFromTaskCode(record.TaskCode)
 	if formID != "" {
 		if ogaForm, err := s.formStore.GetForm(formID); err == nil {
 			app.OgaForm = ogaForm

--- a/oga/internal/service.go
+++ b/oga/internal/service.go
@@ -61,7 +61,7 @@ type InjectRequest struct {
 	WorkflowID         string           `json:"workflowId"`
 	Data               map[string]any   `json:"data"`
 	ServiceURL         string           `json:"serviceUrl"` // URL to send response back to
-	OGAFeedbackHistory []map[string]any `json:"ogafeedbackhistory,omitempty"`
+	OGAFeedbackHistory []map[string]any `json:"ogaFeedbackHistory,omitempty"`
 }
 
 // Application represents an application for display in the UI

--- a/oga/internal/service.go
+++ b/oga/internal/service.go
@@ -245,26 +245,21 @@ func (s *ogaService) GetApplication(ctx context.Context, taskID string) (*Applic
 
 	// Attach oga form: look up by meta, fall back to default
 	formID := FormIDFromTaskCode(record.TaskCode)
-	if formID != "" {
-		if ogaForm, err := s.formStore.GetForm(formID); err == nil {
-			app.OgaForm = ogaForm
-		} else {
-			slog.WarnContext(ctx, "form not found for application, using default", "taskID", taskID, "formID", formID)
-			if ogaForm, err := s.formStore.GetDefaultForm(); err == nil {
-				app.OgaForm = ogaForm
-			}
-		}
-		// Try to load a separate "view" form for rendering the data in read-only mode in the UI, using a naming convention "{formID}.view"
-		dataViewFormID := formID + ".view"
-		if dataForm, err := s.formStore.GetForm(dataViewFormID); err == nil {
-			app.DataForm = dataForm
-		}
+	if ogaForm, err := s.formStore.GetForm(formID); err == nil {
+		app.OgaForm = ogaForm
 	} else {
+		slog.WarnContext(ctx, "form not found for application, using default", "taskID", taskID, "formID", formID)
 		if ogaForm, err := s.formStore.GetDefaultForm(); err == nil {
 			app.OgaForm = ogaForm
 		}
 	}
 
+	// TODO: This is a temporary implementation to get the Read Only form UI schema. The OGA form and dataView form will be stored in same template definition in the future, and we can get rid of this special handling to look for a separate form for data view.
+	// Try to load a separate "view" form for rendering the data in read-only mode in the UI, using a naming convention "{formID}.view"
+	dataViewFormID := formID + ".view"
+	if dataForm, err := s.formStore.GetForm(dataViewFormID); err == nil {
+		app.DataForm = dataForm
+	}
 	return app, nil
 }
 

--- a/oga/internal/service.go
+++ b/oga/internal/service.go
@@ -276,12 +276,6 @@ func (s *ogaService) ReviewApplication(ctx context.Context, taskID string, revie
 		return err
 	}
 
-	decision, ok := reviewerResponse["decision"].(string)
-	if !ok || decision == "" {
-		return fmt.Errorf("reviewerResponse must contain a non-empty 'decision' string")
-	}
-	status := decision
-
 	// Prepare response payload for the service
 	response := TaskResponse{
 		TaskID:     app.TaskID,
@@ -300,6 +294,10 @@ func (s *ogaService) ReviewApplication(ctx context.Context, taskID string, revie
 			"error", err)
 		return fmt.Errorf("failed to send response to service: %w", err)
 	}
+
+	// TODO: Should remove this hardcoded status and determine it based on reviewerResponse content in the future, once we define a standard config to determine it from reviewerResponse.
+	// For now assume any review action results in "DONE" status.
+	status := "DONE"
 
 	if err := s.store.UpdateStatus(taskID, status, reviewerResponse); err != nil {
 		// TODO: If this fails, we have already sent the response to the service but failed to update our record of it. We should consider how to handle this edge case - for now we just log an error.

--- a/oga/internal/store.go
+++ b/oga/internal/store.go
@@ -45,10 +45,10 @@ func (j *JSONB) Scan(value any) error {
 // ApplicationRecord represents an application in the OGA database
 type ApplicationRecord struct {
 	TaskID             string           `gorm:"type:text;primaryKey"`
+	TaskCode           string           `gorm:"type:varchar(100);not null"`
 	WorkflowID         string           `gorm:"type:text;index;not null"`
 	ServiceURL         string           `gorm:"type:varchar(512);not null"`                  // URL to send response back to
 	Data               JSONB            `gorm:"type:text"`                                   // Injected data from service
-	Meta               JSONB            `gorm:"type:text"`                                   // Meta Information on Rendering the form
 	ReviewerResponse   JSONB            `gorm:"type:text"`                                   // Response from reviewer
 	Status             string           `gorm:"type:varchar(50);not null;default:'PENDING'"` // PENDING, APPROVED, REJECTED
 	OGAFeedbackHistory []map[string]any `gorm:"type:text;serializer:json"`

--- a/oga/internal/store.go
+++ b/oga/internal/store.go
@@ -50,7 +50,7 @@ type ApplicationRecord struct {
 	ServiceURL         string           `gorm:"type:varchar(512);not null"`                  // URL to send response back to
 	Data               JSONB            `gorm:"type:text"`                                   // Injected data from service
 	ReviewerResponse   JSONB            `gorm:"type:text"`                                   // Response from reviewer
-	Status             string           `gorm:"type:varchar(50);not null;default:'PENDING'"` // PENDING, APPROVED, REJECTED
+	Status             string           `gorm:"type:varchar(50);not null;default:'PENDING'"` // PENDING, FEEDBACK_REQUESTED, DONE
 	OGAFeedbackHistory []map[string]any `gorm:"type:text;serializer:json"`
 	ReviewedAt         *time.Time       // When it was reviewed
 	CreatedAt          time.Time        `gorm:"autoCreateTime"`

--- a/oga/internal/store_test.go
+++ b/oga/internal/store_test.go
@@ -51,10 +51,10 @@ func seedRecord(t *testing.T, store *ApplicationStore, taskID string, data JSONB
 	}
 	err := store.CreateOrUpdate(&ApplicationRecord{
 		TaskID:     taskID,
+		TaskCode:   "verification:123",
 		WorkflowID: "wf-seed",
 		ServiceURL: "http://test",
 		Data:       data,
-		Meta:       JSONB{"type": "test"},
 		Status:     "PENDING",
 	})
 	if err != nil {
@@ -213,10 +213,10 @@ func TestApplicationStore_JSONB_NilData(t *testing.T) {
 
 	err := store.CreateOrUpdate(&ApplicationRecord{
 		TaskID:     "task-nil-data",
+		TaskCode:   "verification:123",
 		WorkflowID: "wf-1",
 		ServiceURL: "http://test",
 		Data:       nil,
-		Meta:       nil,
 	})
 	if err != nil {
 		t.Fatalf("CreateOrUpdate with nil JSONB failed: %v", err)

--- a/portals/apps/oga-app/src/api.ts
+++ b/portals/apps/oga-app/src/api.ts
@@ -112,10 +112,6 @@ export interface OGAApplication {
   serviceUrl: string;
   data: Record<string, unknown>;
   ogaActionData?: Record<string, unknown>;
-  meta?: {
-    type: string;
-    verificationId: string;
-  };
   dataForm?: {
     schema: JsonSchema;
     uiSchema: UISchemaElement;

--- a/portals/apps/oga-app/src/screens/WorkflowTasksScreen.tsx
+++ b/portals/apps/oga-app/src/screens/WorkflowTasksScreen.tsx
@@ -123,7 +123,8 @@ export function WorkflowTasksScreen() {
                       {app.taskId}
                     </td>
                     <td className="px-6 py-4 whitespace-nowrap text-gray-700 capitalize">
-                      {app.meta?.type || 'Standard'}
+                      {/* TODO: For now we only have one verification type, but this should be dynamic in the future */}
+                      Standard
                     </td>
                     <td className="px-6 py-4 whitespace-nowrap">
                       <Badge


### PR DESCRIPTION
## Summary
This PR improves external service integration robustness across task plugins to OGAs by replacing loosely shaped payload contracts with explicit request structures and introducing TaskCode driven config resolution in the OGA side.

The main goals are:
- Make external request payloads explicit and safer to evolve.
- Remove hardcoded decision/status behavior in OGA review handling.
- Standardize submission contracts so OGAs can resolve their own config using TaskCode.

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Refactoring (no functional changes)

## Changes Made
- feat(application): add TaskCode field and refactor form ID construction logic.
- fix(service): update ReviewApplication to set status to DONE and remove hardcoded decision logic.
- refactor(task): replace Meta structure with TaskCode in submission requests.
- feat(service): introduce explicit external service request structures for SimpleForm and WaitForEvent.

Implementation highlights:
- Replaced ad-hoc or ambiguous request payload composition with typed request structs for outbound external-service calls.
- Added TaskCode to submission/injected request data so OGA can map incoming requests to the correct per-task configuration.
- Kept behavior backward-compatible where possible while making request contracts clearer and easier to validate.

## Testing
- [x] I have tested this change locally
- [x] All existing tests pass

Validation performed:
- Plugin package tests pass for task plugins after request-struct refactor.
- Verified request contract updates across affected task/service code paths.

## Related Issues
No issues created

## Additional Notes
This change is intentionally focused on contract clarity and maintainability:
- Safer extension path for future external integration fields.
- Reduced hidden coupling caused by hardcoded metadata/decision handling.
- Improved traceability for downstream OGA processing via TaskCode.