### PR TITLE
feat(template): add GetWorkflowTemplateByIDV2 for workflow template retrieval

### DIFF
--- a/backend/internal/workflow/router/router_test.go
+++ b/backend/internal/workflow/router/router_test.go
@@ -53,6 +53,14 @@ func (m *MockTemplateProvider) GetWorkflowTemplateByID(ctx context.Context, id s
 	return args.Get(0).(*model.WorkflowTemplate), args.Error(1)
 }
 
+func (m *MockTemplateProvider) GetWorkflowTemplateByIDV2(ctx context.Context, id string) (*model.WorkflowTemplateV2, error) {
+	args := m.Called(ctx, id)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).(*model.WorkflowTemplateV2), args.Error(1)
+}
+
 func (m *MockTemplateProvider) GetWorkflowNodeTemplatesByIDs(ctx context.Context, ids []string) ([]model.WorkflowNodeTemplate, error) {
 	args := m.Called(ctx, ids)
 	return args.Get(0).([]model.WorkflowNodeTemplate), args.Error(1)

--- a/backend/internal/workflow/service/consignment_service_test.go
+++ b/backend/internal/workflow/service/consignment_service_test.go
@@ -44,6 +44,14 @@ func (m *MockTemplateProvider) GetWorkflowTemplateByID(ctx context.Context, id s
 	return args.Get(0).(*model.WorkflowTemplate), args.Error(1)
 }
 
+func (m *MockTemplateProvider) GetWorkflowTemplateByIDV2(ctx context.Context, id string) (*model.WorkflowTemplateV2, error) {
+	args := m.Called(ctx, id)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).(*model.WorkflowTemplateV2), args.Error(1)
+}
+
 func (m *MockTemplateProvider) GetWorkflowNodeTemplatesByIDs(ctx context.Context, ids []string) ([]model.WorkflowNodeTemplate, error) {
 	args := m.Called(ctx, ids)
 	if args.Get(0) == nil {

--- a/backend/internal/workflow/service/interfaces.go
+++ b/backend/internal/workflow/service/interfaces.go
@@ -18,6 +18,9 @@ type TemplateProvider interface {
 	// GetWorkflowTemplateByID retrieves a workflow template by its ID.
 	GetWorkflowTemplateByID(ctx context.Context, id string) (*model.WorkflowTemplate, error)
 
+	// GetWorkflowTemplateByIDV2 retrieves a workflow template by its ID.
+	GetWorkflowTemplateByIDV2(ctx context.Context, id string) (*model.WorkflowTemplateV2, error)
+
 	// GetWorkflowNodeTemplatesByIDs retrieves workflow node templates by their IDs.
 	GetWorkflowNodeTemplatesByIDs(ctx context.Context, ids []string) ([]model.WorkflowNodeTemplate, error)
 

--- a/backend/internal/workflow/service/template_service.go
+++ b/backend/internal/workflow/service/template_service.go
@@ -94,6 +94,16 @@ func (s *TemplateService) GetWorkflowNodeTemplateByID(ctx context.Context, id st
 	return &template, nil
 }
 
+// GetWorkflowTemplateByIDV2 retrieves a workflow template by its ID.
+func (s *TemplateService) GetWorkflowTemplateByIDV2(ctx context.Context, id string) (*model.WorkflowTemplateV2, error) {
+	var template model.WorkflowTemplateV2
+	result := s.db.WithContext(ctx).First(&template, "id = ?", id)
+	if result.Error != nil {
+		return nil, result.Error
+	}
+	return &template, nil
+}
+
 // GetEndNodeTemplate retrieves the special end node template.
 // Assumes there is only one end node template in the system, identified by its type.
 func (s *TemplateService) GetEndNodeTemplate(ctx context.Context) (*model.WorkflowNodeTemplate, error) {

--- a/backend/internal/workflow/service/template_service_test.go
+++ b/backend/internal/workflow/service/template_service_test.go
@@ -72,6 +72,25 @@ func TestTemplateService_GetWorkflowTemplateByID(t *testing.T) {
 	assert.Equal(t, id, result.ID)
 }
 
+func TestTemplateService_GetWorkflowTemplateByIDV2(t *testing.T) {
+	db, sqlMock := setupTestDB(t)
+	service := NewTemplateService(db)
+	ctx := context.Background()
+
+	id := uuid.NewString()
+
+	// Expectation
+	sqlMock.ExpectQuery(`SELECT \* FROM "workflow_template_v2" WHERE id = \$1 ORDER BY "workflow_template_v2"."id" LIMIT \$2`).
+		WithArgs(id, 1).
+		WillReturnRows(sqlmock.NewRows([]string{"id", "name"}).AddRow(id, "Test Template V2"))
+
+	result, err := service.GetWorkflowTemplateByIDV2(ctx, id)
+
+	assert.NoError(t, err)
+	assert.NotNil(t, result)
+	assert.Equal(t, id, result.ID)
+}
+
 func TestTemplateService_GetWorkflowNodeTemplateByID(t *testing.T) {
 	db, sqlMock := setupTestDB(t)
 	service := NewTemplateService(db)


### PR DESCRIPTION
## Summary

Add a new V2 workflow template lookup by ID in the template service. This gives callers a direct way to retrieve workflow_template_v2 records and keeps the V2 API aligned with the existing template lookup path.

## Type of Change

- [x] New feature (non-breaking change which adds functionality)

## Changes Made

- Added GetWorkflowTemplateByIDV2 to the workflow template service.
- Extended the template provider interface to expose the new V2 lookup.
- Added unit coverage for the new service method.
- Updated test mocks so V2 consumers compile and behave correctly.

## Testing

- [x] I have added unit tests for new functionality
- [x] I have tested this change locally
- [x] I have tested edge cases
- [x] All existing tests pass

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have checked that there are no merge conflicts

## Related Issues

Closes #386 

## Additional Notes

This change is focused on adding the V2 ID-based retrieval path and keeping the service interface consistent for existing callers and tests.

This function will be need to be refactored as `GetWorkflowTemplateByID` during the implementation process of #372 