### PR TITLE
Updates for presigned URL flow in the OGA and Trader portals

### DIFF
--- a/backend/internal/uploads/factory.go
+++ b/backend/internal/uploads/factory.go
@@ -43,8 +43,8 @@ func NewStorageFromConfig(ctx context.Context, cfg Config) (StorageDriver, error
 			}
 			o.UsePathStyle = true
 			// Allow uploads over HTTP (e.g. local MinIO) where TLS is unavailable.
-			// Without this, the SDK requires a seekable stream to compute checksums
-			// upfront, which fails when the reader has been wrapped (e.g. countingReader).
+			// Without this, the SDK may require a seekable stream to compute checksums
+			// upfront if the reader is wrapped.
 			o.RequestChecksumCalculation = aws.RequestChecksumCalculationWhenSupported
 		})
 

--- a/backend/internal/uploads/http_handler.go
+++ b/backend/internal/uploads/http_handler.go
@@ -9,7 +9,6 @@ import (
 	"os"
 	"regexp"
 	"strconv"
-	"strings"
 	"time"
 
 	"github.com/OpenNSW/nsw/internal/auth"
@@ -55,52 +54,6 @@ func (h *HTTPHandler) Upload(w http.ResponseWriter, r *http.Request) {
 	if auth.GetAuthContext(r.Context()) == nil {
 		slog.WarnContext(r.Context(), "authentication required but not provided for upload")
 		writeJSONError(w, http.StatusUnauthorized, "Unauthorized")
-		return
-	}
-
-	contentType := r.Header.Get("Content-Type")
-
-	// Legacy backward compatibility for existing UI
-	if strings.Contains(contentType, "multipart/form-data") {
-		// Parse multipart form
-		// Enforce 32MB limit as per requirements
-		r.Body = http.MaxBytesReader(w, r.Body, 32<<20)
-		if err := r.ParseMultipartForm(32 << 20); err != nil {
-			slog.ErrorContext(r.Context(), "Failed to parse multipart form", "error", err)
-			writeJSONError(w, http.StatusBadRequest, "file size exceeds 32MB limit or invalid form")
-			return
-		}
-
-		file, header, err := r.FormFile("file")
-		if err != nil {
-			writeJSONError(w, http.StatusBadRequest, "file is required")
-			return
-		}
-		defer func() { _ = file.Close() }()
-
-		mimeType := header.Header.Get("Content-Type")
-		if mimeType == "" {
-			mimeType = drivers.DefaultMime
-		}
-
-		if !isAllowedContentType(mimeType) {
-			writeJSONError(w, http.StatusUnsupportedMediaType, "invalid or prohibited file type")
-			return
-		}
-
-		// TODO: Remove legacy multipart upload support once all clients migrate to presigned URLs
-		metadata, err := h.Service.UploadLegacy(r.Context(), header.Filename, file, header.Size, mimeType)
-		if err != nil {
-			slog.ErrorContext(r.Context(), "Legacy upload failed", "error", err)
-			writeJSONError(w, http.StatusInternalServerError, "failed to process legacy upload")
-			return
-		}
-
-		w.Header().Set("Content-Type", "application/json")
-		w.WriteHeader(http.StatusCreated)
-		if err := json.NewEncoder(w).Encode(metadata); err != nil {
-			slog.ErrorContext(r.Context(), "Failed to encode legacy response", "error", err)
-		}
 		return
 	}
 

--- a/backend/internal/uploads/service.go
+++ b/backend/internal/uploads/service.go
@@ -20,64 +20,6 @@ func NewUploadService(driver StorageDriver) *UploadService {
 	return &UploadService{Driver: driver}
 }
 
-type countingReader struct {
-	r io.Reader
-	n int64
-}
-
-func (c *countingReader) Read(p []byte) (int, error) {
-	n, err := c.r.Read(p)
-	c.n += int64(n)
-	return n, err
-}
-
-type countingReadSeeker struct {
-	*countingReader
-	s io.Seeker
-}
-
-func (c *countingReadSeeker) Seek(offset int64, whence int) (int64, error) {
-	pos, err := c.s.Seek(offset, whence)
-	if err == nil && pos == 0 {
-		c.n = 0
-	}
-	return pos, err
-}
-
-// UploadLegacy handles the incoming file, saves it via driver directly, and returns metadata.
-// Serves as a bridge for existing UI clients using multipart/form-data.
-func (s *UploadService) UploadLegacy(ctx context.Context, filename string, reader io.Reader, size int64, mime string) (*FileMetadata, error) {
-	if mime == "" {
-		mime = drivers.DefaultMime
-	}
-	id := uuid.NewString()
-	ext := filepath.Ext(filename)
-	key := fmt.Sprintf("%s%s", id, ext)
-
-	cr := &countingReader{r: reader}
-	var body io.Reader = cr
-	if seeker, ok := reader.(io.Seeker); ok {
-		body = &countingReadSeeker{countingReader: cr, s: seeker}
-	}
-
-	err := s.Driver.Save(ctx, key, body, mime)
-	if err != nil {
-		return nil, fmt.Errorf("storage driver failed: %w", err)
-	}
-
-	metadata := &FileMetadata{
-		ID:       id,
-		Name:     filename,
-		Key:      key,
-		URL:      "",
-		Size:     cr.n,
-		MimeType: mime,
-	}
-
-	slog.InfoContext(ctx, "File uploaded successfully (legacy)", "id", id, "key", key)
-	return metadata, nil
-}
-
 // Upload handles the preparation of a file upload by generating a unique key
 // and a presigned/upload URL via the storage driver.
 func (s *UploadService) Upload(ctx context.Context, filename string, size int64, mime string) (*FileMetadata, error) {

--- a/portals/apps/oga-app/src/api.ts
+++ b/portals/apps/oga-app/src/api.ts
@@ -1,8 +1,6 @@
 // API service for OGA Portal
 import type { JsonSchema, UISchemaElement } from '@jsonforms/core';
-import { getRequiredEnv } from './runtimeConfig';
-
-const API_BASE_URL = getRequiredEnv('VITE_API_BASE_URL');
+import { API_BASE_URL } from './constants';
 
 export type AccessTokenProvider = () => Promise<string | null | undefined>
 

--- a/portals/apps/oga-app/src/api.ts
+++ b/portals/apps/oga-app/src/api.ts
@@ -1,8 +1,8 @@
 // API service for OGA Portal
 import type { JsonSchema, UISchemaElement } from '@jsonforms/core';
-import { getEnv } from './runtimeConfig';
+import { getRequiredEnv } from './runtimeConfig';
 
-const API_BASE_URL = getEnv('VITE_API_BASE_URL', 'http://localhost:8081')!;
+const API_BASE_URL = getRequiredEnv('VITE_API_BASE_URL');
 
 export type AccessTokenProvider = () => Promise<string | null | undefined>
 

--- a/portals/apps/oga-app/src/constants/index.ts
+++ b/portals/apps/oga-app/src/constants/index.ts
@@ -1,0 +1,3 @@
+import { getRequiredEnv } from '../runtimeConfig'
+
+export const API_BASE_URL = getRequiredEnv('VITE_API_BASE_URL')

--- a/portals/apps/oga-app/src/screens/WorkflowDetailScreen.tsx
+++ b/portals/apps/oga-app/src/screens/WorkflowDetailScreen.tsx
@@ -4,43 +4,9 @@ import { Button, Badge, Spinner, Text, Card, Flex, Box, Callout, Tabs } from '@r
 import { ArrowLeftIcon, CheckCircledIcon, ExclamationTriangleIcon, InfoCircledIcon, ChatBubbleIcon } from '@radix-ui/react-icons'
 import { fetchApplicationDetail, submitReview, submitFeedback, type OGAApplication } from '../api'
 import { JsonForms } from '@jsonforms/react';
-import { radixRenderers, useUpload } from '@opennsw/jsonforms-renderers';
+import { radixRenderers } from '@opennsw/jsonforms-renderers';
 import type { JsonSchema, UISchemaElement } from '@jsonforms/core';
 import { useApi } from '../services/useApi'
-
-function DataValue({ value }: { value: any }) {
-  const uploadContext = useUpload();
-  
-  if (typeof value !== 'string') {
-    return <Text size="2" weight="medium">{JSON.stringify(value)}</Text>;
-  }
-
-  // Detect file key (ENDS with extension OR matches UUID)
-  const isFileKey = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}/i.test(value) || 
-                   /\.(pdf|png|jpg|jpeg|doc|docx|xls|xlsx)$/i.test(value);
-
-  if (isFileKey) {
-    const handleView = async () => {
-      const result = await uploadContext?.getDownloadUrl?.(value);
-      if (result?.url) {
-        window.open(result.url, '_blank', 'noopener,noreferrer');
-      }
-    };
-
-    return (
-      <Flex align="center" gap="2" justify="between" width="100%">
-        <Text size="2" weight="medium" className="truncate" style={{ flex: 1, marginRight: '8px' }}>
-          {value}
-        </Text>
-        <Button variant="soft" color="blue" size="1" onClick={handleView} style={{ flexShrink: 0 }}>
-          View
-        </Button>
-      </Flex>
-    );
-  }
-
-  return <Text size="2" weight="medium">{value}</Text>;
-}
 
 export function WorkflowDetailScreen() {
   const navigate = useNavigate()
@@ -295,7 +261,9 @@ export function WorkflowDetailScreen() {
                           <Text size="1" color="gray" as="div" className="capitalize mb-1">
                             {key.replace(/([A-Z])/g, ' $1').replace(/_/g, ' ')}
                           </Text>
-                          <DataValue value={value} />
+                          <Text size="2" weight="medium">
+                            {typeof value === 'object' && value !== null ? JSON.stringify(value) : String(value)}
+                          </Text>
                         </Box>
                       ))}
                     </div>

--- a/portals/apps/oga-app/src/screens/WorkflowDetailScreen.tsx
+++ b/portals/apps/oga-app/src/screens/WorkflowDetailScreen.tsx
@@ -4,9 +4,43 @@ import { Button, Badge, Spinner, Text, Card, Flex, Box, Callout, Tabs } from '@r
 import { ArrowLeftIcon, CheckCircledIcon, ExclamationTriangleIcon, InfoCircledIcon, ChatBubbleIcon } from '@radix-ui/react-icons'
 import { fetchApplicationDetail, submitReview, submitFeedback, type OGAApplication } from '../api'
 import { JsonForms } from '@jsonforms/react';
-import { radixRenderers } from '@opennsw/jsonforms-renderers';
+import { radixRenderers, useUpload } from '@opennsw/jsonforms-renderers';
 import type { JsonSchema, UISchemaElement } from '@jsonforms/core';
 import { useApi } from '../services/useApi'
+
+function DataValue({ value }: { value: any }) {
+  const uploadContext = useUpload();
+  
+  if (typeof value !== 'string') {
+    return <Text size="2" weight="medium">{JSON.stringify(value)}</Text>;
+  }
+
+  // Detect file key (ENDS with extension OR matches UUID)
+  const isFileKey = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}/i.test(value) || 
+                   /\.(pdf|png|jpg|jpeg|doc|docx|xls|xlsx)$/i.test(value);
+
+  if (isFileKey) {
+    const handleView = async () => {
+      const result = await uploadContext?.getDownloadUrl?.(value);
+      if (result?.url) {
+        window.open(result.url, '_blank', 'noopener,noreferrer');
+      }
+    };
+
+    return (
+      <Flex align="center" gap="2" justify="between" width="100%">
+        <Text size="2" weight="medium" className="truncate" style={{ flex: 1, marginRight: '8px' }}>
+          {value}
+        </Text>
+        <Button variant="soft" color="blue" size="1" onClick={handleView} style={{ flexShrink: 0 }}>
+          View
+        </Button>
+      </Flex>
+    );
+  }
+
+  return <Text size="2" weight="medium">{value}</Text>;
+}
 
 export function WorkflowDetailScreen() {
   const navigate = useNavigate()
@@ -261,9 +295,7 @@ export function WorkflowDetailScreen() {
                           <Text size="1" color="gray" as="div" className="capitalize mb-1">
                             {key.replace(/([A-Z])/g, ' $1').replace(/_/g, ' ')}
                           </Text>
-                          <Text size="2" weight="medium">
-                            {typeof value === 'object' && value !== null ? JSON.stringify(value) : String(value)}
-                          </Text>
+                          <DataValue value={value} />
                         </Box>
                       ))}
                     </div>

--- a/portals/apps/oga-app/src/services/upload.ts
+++ b/portals/apps/oga-app/src/services/upload.ts
@@ -2,9 +2,10 @@
  * OGA-app–specific upload implementation. Points to this app's backend;
  * when OGA moves to a separate repo, this file can target OGA-specific endpoints/S3 without touching shared UI.
  */
+import { getEnv } from '../runtimeConfig'
 import type { ApiClient } from '../api'
 
-const API_BASE_URL = (import.meta.env.VITE_OGA_API_BASE_URL as string | undefined) ?? 'http://localhost:8080/api/v1'
+const API_BASE_URL = getEnv('VITE_API_BASE_URL', 'http://localhost:8081')!
 
 export interface UploadResponse {
   key: string
@@ -12,8 +13,8 @@ export interface UploadResponse {
 }
 
 export async function uploadFile(apiClient: ApiClient, file: File): Promise<UploadResponse> {
-  // Request presigned URL and metadata from backend
-  const metadataResponse = await fetch(`${API_BASE_URL}/uploads`, {
+  // Request presigned URL and metadata from OGA backend proxy
+  const metadataResponse = await fetch(`${API_BASE_URL}/api/oga/uploads`, {
     method: 'POST',
     headers: {
       ...(await apiClient.getAuthHeaders(false)),
@@ -53,8 +54,15 @@ export async function uploadFile(apiClient: ApiClient, file: File): Promise<Uplo
 }
 
 export async function getDownloadUrl(apiClient: ApiClient, key: string): Promise<{ url: string; expiresAt: number }> {
+  // Use the API client to fetch download metadata via the OGA backend proxy
   const response = await apiClient.get<{ download_url: string; expires_at: number }>(
     `/api/oga/uploads/${key}`
   )
-  return { url: response.download_url, expiresAt: response.expires_at }
+
+  // Normalize the URL if it's a relative path (common in local dev)
+  const url = response.download_url.startsWith('/')
+    ? new URL(API_BASE_URL).origin + response.download_url
+    : response.download_url
+
+  return { url, expiresAt: response.expires_at }
 }

--- a/portals/apps/oga-app/src/services/upload.ts
+++ b/portals/apps/oga-app/src/services/upload.ts
@@ -5,7 +5,30 @@
 import { getEnv } from '../runtimeConfig'
 import type { ApiClient } from '../api'
 
-const API_BASE_URL = getEnv('VITE_API_BASE_URL', 'http://localhost:8081')!
+const API_BASE_URL = (() => {
+  const value = getEnv('VITE_API_BASE_URL')
+  if (!value) {
+    throw new Error('Missing required environment variable: VITE_API_BASE_URL')
+  }
+  return value
+})()
+
+interface UploadMetadataRequest {
+  filename: string
+  mime_type: string
+  size: number
+}
+
+interface UploadMetadataResponse {
+  key: string
+  name: string
+  upload_url: string
+}
+
+interface DownloadMetadataResponse {
+  download_url: string
+  expires_at: number
+}
 
 export interface UploadResponse {
   key: string
@@ -13,30 +36,17 @@ export interface UploadResponse {
 }
 
 export async function uploadFile(apiClient: ApiClient, file: File): Promise<UploadResponse> {
-  // Request presigned URL and metadata from OGA backend proxy
-  const metadataResponse = await fetch(`${API_BASE_URL}/api/oga/uploads`, {
-    method: 'POST',
-    headers: {
-      ...(await apiClient.getAuthHeaders(false)),
-      'Content-Type': 'application/json',
-    },
-    body: JSON.stringify({
+  const metadata = await apiClient.post<UploadMetadataRequest, UploadMetadataResponse>(
+    '/api/oga/uploads',
+    {
       filename: file.name,
       mime_type: file.type || 'application/octet-stream',
       size: file.size,
-    }),
-  })
-
-  if (!metadataResponse.ok) {
-    const errorText = await metadataResponse.text()
-    console.error(`Metadata request error ${metadataResponse.status}: ${errorText}`)
-    throw new Error(`Failed to initialize upload: ${metadataResponse.status} ${metadataResponse.statusText}`)
-  }
-
-  const meta = (await metadataResponse.json()) as { key: string; name: string; upload_url: string }
+    }
+  )
 
   // Upload file bytes directly to the storage destination (presigned URL)
-  const uploadResponse = await fetch(meta.upload_url, {
+  const uploadResponse = await fetch(metadata.upload_url, {
     method: 'PUT',
     headers: {
       'Content-Type': file.type || 'application/octet-stream',
@@ -50,14 +60,11 @@ export async function uploadFile(apiClient: ApiClient, file: File): Promise<Uplo
     throw new Error(`Failed to upload file to storage: ${uploadResponse.status} ${uploadResponse.statusText}`)
   }
 
-  return { key: meta.key, name: meta.name }
+  return { key: metadata.key, name: metadata.name }
 }
 
 export async function getDownloadUrl(apiClient: ApiClient, key: string): Promise<{ url: string; expiresAt: number }> {
-  // Use the API client to fetch download metadata via the OGA backend proxy
-  const response = await apiClient.get<{ download_url: string; expires_at: number }>(
-    `/api/oga/uploads/${key}`
-  )
+  const response = await apiClient.get<DownloadMetadataResponse>(`/api/oga/uploads/${key}`)
 
   // Normalize the URL if it's a relative path (common in local dev)
   const url = response.download_url.startsWith('/')

--- a/portals/apps/oga-app/src/services/upload.ts
+++ b/portals/apps/oga-app/src/services/upload.ts
@@ -12,22 +12,43 @@ export interface UploadResponse {
 }
 
 export async function uploadFile(apiClient: ApiClient, file: File): Promise<UploadResponse> {
-  const formData = new FormData()
-  formData.append('file', file)
-
-  const response = await fetch(`${API_BASE_URL}/uploads`, {
+  // Request presigned URL and metadata from backend
+  const metadataResponse = await fetch(`${API_BASE_URL}/uploads`, {
     method: 'POST',
-    headers: await apiClient.getAuthHeaders(false),
-    body: formData,
+    headers: {
+      ...(await apiClient.getAuthHeaders(false)),
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify({
+      filename: file.name,
+      mime_type: file.type || 'application/octet-stream',
+      size: file.size,
+    }),
   })
 
-  if (!response.ok) {
-    const errorText = await response.text()
-    console.error(`Upload error ${response.status}: ${errorText}`)
-    throw new Error(`Failed to upload file: ${response.status} ${response.statusText}`)
+  if (!metadataResponse.ok) {
+    const errorText = await metadataResponse.text()
+    console.error(`Metadata request error ${metadataResponse.status}: ${errorText}`)
+    throw new Error(`Failed to initialize upload: ${metadataResponse.status} ${metadataResponse.statusText}`)
   }
 
-  const meta = (await response.json()) as { key: string; name: string }
+  const meta = (await metadataResponse.json()) as { key: string; name: string; upload_url: string }
+
+  // Upload file bytes directly to the storage destination (presigned URL)
+  const uploadResponse = await fetch(meta.upload_url, {
+    method: 'PUT',
+    headers: {
+      'Content-Type': file.type || 'application/octet-stream',
+    },
+    body: file,
+  })
+
+  if (!uploadResponse.ok) {
+    const errorText = await uploadResponse.text()
+    console.error(`Direct storage upload error ${uploadResponse.status}: ${errorText}`)
+    throw new Error(`Failed to upload file to storage: ${uploadResponse.status} ${uploadResponse.statusText}`)
+  }
+
   return { key: meta.key, name: meta.name }
 }
 

--- a/portals/apps/oga-app/src/services/upload.ts
+++ b/portals/apps/oga-app/src/services/upload.ts
@@ -2,16 +2,8 @@
  * OGA-app–specific upload implementation. Points to this app's backend;
  * when OGA moves to a separate repo, this file can target OGA-specific endpoints/S3 without touching shared UI.
  */
-import { getEnv } from '../runtimeConfig'
 import type { ApiClient } from '../api'
-
-const API_BASE_URL = (() => {
-  const value = getEnv('VITE_API_BASE_URL')
-  if (!value) {
-    throw new Error('Missing required environment variable: VITE_API_BASE_URL')
-  }
-  return value
-})()
+import { API_BASE_URL } from '../constants'
 
 interface UploadMetadataRequest {
   filename: string

--- a/portals/apps/trader-app/src/constants/index.ts
+++ b/portals/apps/trader-app/src/constants/index.ts
@@ -2,13 +2,9 @@
  * Application-wide constants
  */
 
-import { getEnv } from '../runtimeConfig'
+import { getRequiredEnv } from '../runtimeConfig'
 
-const API_BASE_URL = getEnv('VITE_API_BASE_URL')
-
-if (!API_BASE_URL) {
-  throw new Error('Missing required environment variable: VITE_API_BASE_URL')
-}
+export const API_BASE_URL = getRequiredEnv('VITE_API_BASE_URL')
 
 // TODO: Replace with actual auth context
 export const DEFAULT_TRADER_ID = 'trader-123'

--- a/portals/apps/trader-app/src/constants/index.ts
+++ b/portals/apps/trader-app/src/constants/index.ts
@@ -6,9 +6,6 @@ import { getRequiredEnv } from '../runtimeConfig'
 
 export const API_BASE_URL = getRequiredEnv('VITE_API_BASE_URL')
 
-// TODO: Replace with actual auth context
-export const DEFAULT_TRADER_ID = 'trader-123'
-
 // API Configuration
 export const API_CONFIG = {
   BASE_URL: API_BASE_URL,

--- a/portals/apps/trader-app/src/constants/index.ts
+++ b/portals/apps/trader-app/src/constants/index.ts
@@ -4,12 +4,18 @@
 
 import { getEnv } from '../runtimeConfig'
 
+const API_BASE_URL = getEnv('VITE_API_BASE_URL')
+
+if (!API_BASE_URL) {
+  throw new Error('Missing required environment variable: VITE_API_BASE_URL')
+}
+
 // TODO: Replace with actual auth context
 export const DEFAULT_TRADER_ID = 'trader-123'
 
 // API Configuration
 export const API_CONFIG = {
-  BASE_URL: getEnv('VITE_API_BASE_URL', 'http://localhost:8080/api/v1')!,
+  BASE_URL: API_BASE_URL,
   TIMEOUT: 30000, // 30 seconds
 } as const
 

--- a/portals/apps/trader-app/src/runtimeConfig.ts
+++ b/portals/apps/trader-app/src/runtimeConfig.ts
@@ -40,6 +40,15 @@ export function getEnv(name: string, fallback?: string): string | undefined {
   return fallback
 }
 
+export function getRequiredEnv(name: string): string {
+  const value = getEnv(name)
+  if (!value || value.trim() === '') {
+    throw new Error(`Missing required environment variable: ${name}`)
+  }
+
+  return value
+}
+
 export function getBooleanEnv(name: string, fallback = false): boolean {
   const value = getEnv(name)
   if (!value) {

--- a/portals/apps/trader-app/src/services/api.ts
+++ b/portals/apps/trader-app/src/services/api.ts
@@ -1,10 +1,4 @@
-import { getEnv } from '../runtimeConfig'
-
-const API_BASE_URL = getEnv('VITE_API_BASE_URL')
-
-if (!API_BASE_URL) {
-  throw new Error('Missing required environment variable: VITE_API_BASE_URL')
-}
+import { API_BASE_URL } from '../constants'
 
 export type QueryParams = Record<string, string | number | undefined>
 export type AccessTokenProvider = () => Promise<string | null | undefined>

--- a/portals/apps/trader-app/src/services/api.ts
+++ b/portals/apps/trader-app/src/services/api.ts
@@ -1,6 +1,10 @@
 import { getEnv } from '../runtimeConfig'
 
-const API_BASE_URL = getEnv('VITE_API_BASE_URL', 'http://localhost:8080/api/v1')!
+const API_BASE_URL = getEnv('VITE_API_BASE_URL')
+
+if (!API_BASE_URL) {
+  throw new Error('Missing required environment variable: VITE_API_BASE_URL')
+}
 
 export type QueryParams = Record<string, string | number | undefined>
 export type AccessTokenProvider = () => Promise<string | null | undefined>

--- a/portals/apps/trader-app/src/services/upload.ts
+++ b/portals/apps/trader-app/src/services/upload.ts
@@ -12,37 +12,51 @@ export interface UploadResponse {
 }
 
 export async function uploadFile(apiClient: ApiClient, file: File): Promise<UploadResponse> {
-  const formData = new FormData()
-  formData.append('file', file)
-
-  const response = await fetch(`${API_BASE_URL}/uploads`, {
+  // Request presigned URL and metadata from backend
+  const metadataResponse = await fetch(`${API_BASE_URL}/uploads`, {
     method: 'POST',
-    headers: await apiClient.getAuthHeaders(false),
-    body: formData,
+    headers: {
+      ...(await apiClient.getAuthHeaders(false)),
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify({
+      filename: file.name,
+      mime_type: file.type || 'application/octet-stream',
+      size: file.size,
+    }),
   })
 
-  if (!response.ok) {
-    const errorText = await response.text()
-    console.error(`Upload error ${response.status}: ${errorText}`)
-    throw new Error(`Failed to upload file: ${response.status} ${response.statusText}`)
+  if (!metadataResponse.ok) {
+    const errorText = await metadataResponse.text()
+    console.error(`Metadata request error ${metadataResponse.status}: ${errorText}`)
+    throw new Error(`Failed to initialize upload: ${metadataResponse.status} ${metadataResponse.statusText}`)
   }
 
-  const meta = (await response.json()) as { key: string; name: string }
+  const meta = (await metadataResponse.json()) as { key: string; name: string; upload_url: string }
+
+  // Upload file bytes directly to the storage destination (presigned URL)
+  const uploadResponse = await fetch(meta.upload_url, {
+    method: 'PUT',
+    headers: {
+      'Content-Type': file.type || 'application/octet-stream',
+    },
+    body: file,
+  })
+
+  if (!uploadResponse.ok) {
+    const errorText = await uploadResponse.text()
+    console.error(`Direct storage upload error ${uploadResponse.status}: ${errorText}`)
+    throw new Error(`Failed to upload file to storage: ${uploadResponse.status} ${uploadResponse.statusText}`)
+  }
+
   return { key: meta.key, name: meta.name }
 }
 
 export async function getDownloadUrl(apiClient: ApiClient, key: string): Promise<{ url: string; expiresAt: number }> {
-  const response = await fetch(`${API_BASE_URL}/uploads/${key}`, {
-    headers: await apiClient.getAuthHeaders(false),
-  })
-
-  if (!response.ok) {
-    throw new Error(`Failed to get download URL: ${response.status} ${response.statusText}`)
-  }
-
-  const data = (await response.json()) as { download_url: string; expires_at: number }
-  const url = data.download_url.startsWith('/')
-    ? `${new URL(API_BASE_URL).origin}${data.download_url}`
-    : data.download_url
-  return { url, expiresAt: data.expires_at }
+  // Use the API client to fetch the download metadata (download_url and expires_at)
+  // The endpoint matches the OGA portal backend's expectation.
+  const response = await apiClient.get<{ download_url: string; expires_at: number }>(
+    `/api/oga/uploads/${key}`
+  )
+  return { url: response.download_url, expiresAt: response.expires_at }
 }

--- a/portals/apps/trader-app/src/services/upload.ts
+++ b/portals/apps/trader-app/src/services/upload.ts
@@ -5,7 +5,30 @@
 import { getEnv } from '../runtimeConfig'
 import type { ApiClient } from './api'
 
-const API_BASE_URL = getEnv('VITE_API_BASE_URL', 'http://localhost:8080/api/v1')!
+const API_BASE_URL = (() => {
+  const value = getEnv('VITE_API_BASE_URL')
+  if (!value) {
+    throw new Error('Missing required environment variable: VITE_API_BASE_URL')
+  }
+  return value
+})()
+
+interface UploadMetadataRequest {
+  filename: string
+  mime_type: string
+  size: number
+}
+
+interface UploadMetadataResponse {
+  key: string
+  name: string
+  upload_url: string
+}
+
+interface DownloadMetadataResponse {
+  download_url: string
+  expires_at: number
+}
 
 export interface UploadResponse {
   key: string
@@ -13,30 +36,17 @@ export interface UploadResponse {
 }
 
 export async function uploadFile(apiClient: ApiClient, file: File): Promise<UploadResponse> {
-  // Request presigned URL and metadata from backend
-  const metadataResponse = await fetch(`${API_BASE_URL}/uploads`, {
-    method: 'POST',
-    headers: {
-      ...(await apiClient.getAuthHeaders(false)),
-      'Content-Type': 'application/json',
-    },
-    body: JSON.stringify({
+  const metadata = await apiClient.post<UploadMetadataRequest, UploadMetadataResponse>(
+    '/uploads',
+    {
       filename: file.name,
       mime_type: file.type || 'application/octet-stream',
       size: file.size,
-    }),
-  })
-
-  if (!metadataResponse.ok) {
-    const errorText = await metadataResponse.text()
-    console.error(`Metadata request error ${metadataResponse.status}: ${errorText}`)
-    throw new Error(`Failed to initialize upload: ${metadataResponse.status} ${metadataResponse.statusText}`)
-  }
-
-  const meta = (await metadataResponse.json()) as { key: string; name: string; upload_url: string }
+    }
+  )
 
   // Upload file bytes directly to the storage destination (presigned URL)
-  const uploadResponse = await fetch(meta.upload_url, {
+  const uploadResponse = await fetch(metadata.upload_url, {
     method: 'PUT',
     headers: {
       'Content-Type': file.type || 'application/octet-stream',
@@ -50,15 +60,11 @@ export async function uploadFile(apiClient: ApiClient, file: File): Promise<Uplo
     throw new Error(`Failed to upload file to storage: ${uploadResponse.status} ${uploadResponse.statusText}`)
   }
 
-  return { key: meta.key, name: meta.name }
+  return { key: metadata.key, name: metadata.name }
 }
 
 export async function getDownloadUrl(apiClient: ApiClient, key: string): Promise<{ url: string; expiresAt: number }> {
-  // Use the API client to fetch the download metadata (download_url and expires_at)
-  // from the main backend's uploads endpoint.
-  const response = await apiClient.get<{ download_url: string; expires_at: number }>(
-    `/uploads/${key}`
-  )
+  const response = await apiClient.get<DownloadMetadataResponse>(`/uploads/${key}`)
 
   // Normalize the URL if it's a relative path (common in local dev)
   const url = response.download_url.startsWith('/')

--- a/portals/apps/trader-app/src/services/upload.ts
+++ b/portals/apps/trader-app/src/services/upload.ts
@@ -2,9 +2,10 @@
  * Trader-app–specific upload implementation. Points to this app's backend;
  * when the API or auth changes, only this file is updated.
  */
+import { getEnv } from '../runtimeConfig'
 import type { ApiClient } from './api'
 
-const API_BASE_URL = import.meta.env.VITE_API_BASE_URL || 'http://localhost:8080/api/v1'
+const API_BASE_URL = getEnv('VITE_API_BASE_URL', 'http://localhost:8080/api/v1')!
 
 export interface UploadResponse {
   key: string
@@ -54,9 +55,15 @@ export async function uploadFile(apiClient: ApiClient, file: File): Promise<Uplo
 
 export async function getDownloadUrl(apiClient: ApiClient, key: string): Promise<{ url: string; expiresAt: number }> {
   // Use the API client to fetch the download metadata (download_url and expires_at)
-  // The endpoint matches the OGA portal backend's expectation.
+  // from the main backend's uploads endpoint.
   const response = await apiClient.get<{ download_url: string; expires_at: number }>(
-    `/api/oga/uploads/${key}`
+    `/uploads/${key}`
   )
-  return { url: response.download_url, expiresAt: response.expires_at }
+
+  // Normalize the URL if it's a relative path (common in local dev)
+  const url = response.download_url.startsWith('/')
+    ? new URL(API_BASE_URL).origin + response.download_url
+    : response.download_url
+
+  return { url, expiresAt: response.expires_at }
 }

--- a/portals/apps/trader-app/src/services/upload.ts
+++ b/portals/apps/trader-app/src/services/upload.ts
@@ -2,16 +2,8 @@
  * Trader-app–specific upload implementation. Points to this app's backend;
  * when the API or auth changes, only this file is updated.
  */
-import { getEnv } from '../runtimeConfig'
 import type { ApiClient } from './api'
-
-const API_BASE_URL = (() => {
-  const value = getEnv('VITE_API_BASE_URL')
-  if (!value) {
-    throw new Error('Missing required environment variable: VITE_API_BASE_URL')
-  }
-  return value
-})()
+import { API_BASE_URL } from '../constants'
 
 interface UploadMetadataRequest {
   filename: string


### PR DESCRIPTION
https://github.com/user-attachments/assets/eae8042a-d02c-4308-ac39-ddb1e3bf190d


## Summary
Migrate OGA and Trader portals to presigned URL. Delete the legacy `multipart/form-data` processing from the backend, and cleans up associated helper logic

## Changes
#### Frontend
- Presigned URL Flow: refactor `uploadFile` in `oga-app` and `trader-app` to implement the 2-step process (POST for metadata/URL → PUT binary content directly to storage)
- Correct download metadata routes for both portals (`/api/oga/uploads` for OGA and `/uploads` for Trader) and standardized `API_BASE_URL` usage
- URL normalization: add logic to handle relative paths returned by the backend, ensuring files are correctly resolved across different origins in local development

#### Backend
- Cleanup legacy: remove the `multipart/form-data` upload path from the HTTP handler and deleted the `UploadLegacy` service method and `countingReader` helper structs

## Testing
- Ran start-dev.sh` and tested trader file upload and view file 

**Need to update templates to test OGA file upload and view file**