### PR TITLE
feat(activity): implement JSONBuilder and RESTCaller activities with templating support

### DIFF
--- a/backend/internal/taskworkflow/activity/README.md
+++ b/backend/internal/taskworkflow/activity/README.md
@@ -1,0 +1,208 @@
+# Task Workflow Activities
+
+The `activity` package contains activity executors used by the task-as-workflow runtime under `backend/internal/taskworkflow`.
+
+Each activity executor receives:
+- `Config`: activity-specific configuration loaded from the workflow node template
+- `Inputs`: runtime values mapped into the node by the workflow engine
+
+Each executor returns a structured `Result`. On successful execution, `Result.Outputs` is written back into workflow state through the node's `output_mapping`.
+
+## Execution Contract
+
+All activities implement:
+
+```go
+type Executor interface {
+    Name() ActivityType
+    Execute(ctx context.Context, request Request) (*Result, error)
+}
+```
+
+`Request` contains:
+
+```go
+type Request struct {
+    WorkflowID string
+    RunID      string
+    NodeID     string
+    Config     map[string]any
+    Inputs     map[string]any
+}
+```
+
+`Result` contains:
+
+```go
+type Status string
+
+const (
+    StatusSucceeded Status = "SUCCEEDED"
+    StatusFailed    Status = "FAILED"
+    StatusRetryable Status = "RETRYABLE"
+)
+
+type Result struct {
+    Outputs       map[string]any
+    RenderPayload map[string]any
+    Status        Status
+    PersistRender bool
+    Message       string
+}
+```
+
+## Result Semantics
+
+- Return `error` for technical failures such as invalid config, template resolution problems, request construction failures, marshalling failures, or transport failures.
+- Return `Result{Status: StatusSucceeded, ...}` for successful execution.
+- `Result.Outputs` is the only field currently consumed by the activity handler when completing a workflow node.
+- `RenderPayload`, `PersistRender`, and `Message` are part of the activity contract now but are not yet persisted or forwarded by the handler.
+- Non-success statuses are currently treated as handler errors until a dedicated failure/update path is added.
+
+## Templating Rules
+
+Activities that build structured payloads use `backend/pkg/jsonutils/resolver.go`.
+
+Supported placeholder forms:
+- `"$name"`: whole-value replacement
+- `"${student.grade}"`: whole-value replacement with dotted path key
+- `"prefix-${version}"`: string interpolation
+
+Lookup is currently performed against `request.Inputs` by exact key match.
+
+Example input map:
+
+```json
+{
+  "workflow_id": "wf-123",
+  "task_id": "task-456",
+  "page": 2
+}
+```
+
+Example template:
+
+```json
+{
+  "id": "$task_id",
+  "label": "task-${page}"
+}
+```
+
+Resolved output:
+
+```json
+{
+  "id": "task-456",
+  "label": "task-2"
+}
+```
+
+## JSON_BUILDER
+
+`JSON_BUILDER` resolves a configured template against `Inputs` and marshals the resolved structure to JSON.
+
+### Config
+
+```json
+{
+  "template": {
+    "request": {
+      "id": "$workflow_id",
+      "name": "$name",
+      "label": "workflow-${version}"
+    }
+  },
+  "outputKey": "request_body"
+}
+```
+
+Fields:
+- `template`: any JSON-like structure to resolve and marshal
+- `outputKey`: optional result key; defaults to `"json"`
+
+### Behavior
+
+- `template` is required
+- the template is resolved with placeholders using `Inputs`
+- the resolved structure is marshalled to JSON
+- the output value is returned as `json.RawMessage`
+- successful execution returns `StatusSucceeded`
+
+### Result
+
+Example result:
+
+```json
+{
+  "outputs": {
+    "request_body": "{\"request\":{\"id\":\"wf-123\",\"name\":\"export\",\"label\":\"workflow-2\"}}"
+  },
+  "status": "SUCCEEDED"
+}
+```
+
+In Go, `outputs.request_body` is returned as `json.RawMessage`.
+
+## REST_CALLER
+
+`REST_CALLER` builds an outbound HTTP request from templated config, performs the call through `backend/pkg/remote`, and returns the decoded response.
+
+### Config
+
+```json
+{
+  "serviceId": "customs-asycuda",
+  "method": "POST",
+  "path": "/api/consignments/${consignment_id}/documents/${document_type}",
+  "query": {
+    "version": "$api_version",
+    "includeMeta": "$include_meta"
+  },
+  "headers": {
+    "X-Correlation-Id": "$workflow_id"
+  },
+  "body": {
+    "request": {
+      "assessmentNo": "$assessment_no"
+    }
+  },
+  "outputKey": "customs_response"
+}
+```
+
+Fields:
+- `serviceId`: optional remote registry service ID
+- `method`: optional HTTP method; defaults to `GET`
+- `path`: required request path, supports placeholders
+- `query`: optional query parameter template
+- `headers`: optional header template
+- `body`: optional JSON body template
+- `outputKey`: optional result key; defaults to `"api_response"`
+
+### Behavior
+
+- `path`, `query`, `headers`, and `body` are resolved against `Inputs`
+- query values are stringified into URL query parameters
+- header values are stringified into HTTP headers
+- body remains structured and is passed to the remote client
+- response payload is decoded into `any` and returned under `outputKey`
+- successful execution returns `StatusSucceeded`
+
+### Current Limitation
+
+`REST_CALLER` currently uses the JSON request path in `backend/pkg/remote`.
+
+That means:
+- request bodies are JSON-marshalled
+- `Content-Type: application/json` is used
+- raw XML, SOAP envelopes, and other non-JSON wire formats are not supported yet
+
+## Adding New Activities
+
+When adding a new activity:
+- keep parsing and execution logic inside this package
+- define a small config struct per activity
+- add unit tests for config parsing and execution behavior
+- return a `Result` with an explicit `Status`
+- document the config contract in this README

--- a/backend/internal/taskworkflow/activity/activities.go
+++ b/backend/internal/taskworkflow/activity/activities.go
@@ -1,0 +1,35 @@
+package activity
+
+import (
+	"context"
+
+	taskPlugin "github.com/OpenNSW/nsw/internal/task/plugin"
+)
+
+type ActivityType = taskPlugin.Type
+
+const (
+	ActivityTypeJSONBuilder ActivityType = "JSON_BUILDER"
+	ActivityTypeRESTCaller  ActivityType = "REST_CALLER"
+)
+
+type Status string
+
+const (
+	StatusSucceeded Status = "SUCCEEDED"
+	StatusFailed    Status = "FAILED"
+	StatusRetryable Status = "RETRYABLE"
+)
+
+type Result struct {
+	Outputs       map[string]any `json:"outputs,omitempty"`
+	RenderPayload map[string]any `json:"renderPayload,omitempty"`
+	Status        Status         `json:"status,omitempty"`
+	PersistRender bool           `json:"persistRender,omitempty"`
+	Message       string         `json:"message,omitempty"`
+}
+
+type Executor interface {
+	Name() ActivityType
+	Execute(ctx context.Context, request Request) (*Result, error)
+}

--- a/backend/internal/taskworkflow/activity/integration/rest_caller_test.go
+++ b/backend/internal/taskworkflow/activity/integration/rest_caller_test.go
@@ -1,0 +1,109 @@
+package integration
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/OpenNSW/nsw/internal/taskworkflow/activity"
+	"github.com/OpenNSW/nsw/pkg/remote"
+)
+
+func TestRESTCallerExecuteIntegration(t *testing.T) {
+	if os.Getenv("ENABLE_ACTIVITY_INTEGRATION_TESTS") != "1" {
+		t.Skip("set ENABLE_ACTIVITY_INTEGRATION_TESTS=1 to run activity integration tests")
+	}
+
+	t.Run("dispatches resolved request through remote manager", func(t *testing.T) {
+		var capturedPath string
+		var capturedQuery string
+		var capturedHeader string
+		var capturedBody map[string]any
+
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			capturedPath = r.URL.Path
+			capturedQuery = r.URL.RawQuery
+			capturedHeader = r.Header.Get("X-Workflow-Id")
+
+			if r.Body != nil {
+				defer r.Body.Close()
+				require.NoError(t, json.NewDecoder(r.Body).Decode(&capturedBody))
+			}
+
+			w.Header().Set("Content-Type", "application/json")
+			require.NoError(t, json.NewEncoder(w).Encode(map[string]any{
+				"ok":         true,
+				"request_id": "req-123",
+			}))
+		}))
+		defer server.Close()
+
+		registryPath := filepath.Join(t.TempDir(), "services.json")
+		require.NoError(t, os.WriteFile(registryPath, []byte(`{
+  "version": "1.0",
+  "services": [
+    {
+      "id": "test-service",
+      "url": "`+server.URL+`",
+      "timeout": "5s"
+    }
+  ]
+}`), 0o600))
+
+		rm := remote.NewManager()
+		require.NoError(t, rm.LoadServices(registryPath))
+
+		caller := activity.NewRESTCaller(rm)
+		result, err := caller.Execute(context.Background(), activity.Request{
+			Config: map[string]any{
+				"serviceId": "test-service",
+				"method":    "POST",
+				"path":      "/api/workflows/${workflow_id}/tasks/${task_id}",
+				"query": map[string]any{
+					"include": "$include",
+					"page":    "$page",
+				},
+				"headers": map[string]any{
+					"X-Workflow-Id": "$workflow_id",
+				},
+				"body": map[string]any{
+					"request": map[string]any{
+						"id":    "$task_id",
+						"label": "task-${page}",
+					},
+				},
+				"outputKey": "api_response",
+			},
+			Inputs: map[string]any{
+				"workflow_id": "wf-123",
+				"task_id":     "task-456",
+				"include":     "details",
+				"page":        2,
+			},
+		})
+
+		require.NoError(t, err)
+		require.NotNil(t, result)
+		assert.Equal(t, activity.StatusSucceeded, result.Status)
+		assert.Equal(t, "/api/workflows/wf-123/tasks/task-456", capturedPath)
+		assert.Equal(t, "include=details&page=2", capturedQuery)
+		assert.Equal(t, "wf-123", capturedHeader)
+		assert.Equal(t, map[string]any{
+			"request": map[string]any{
+				"id":    "task-456",
+				"label": "task-2",
+			},
+		}, capturedBody)
+		assert.Equal(t, map[string]any{
+			"ok":         true,
+			"request_id": "req-123",
+		}, result.Outputs["api_response"])
+	})
+}

--- a/backend/internal/taskworkflow/activity/jsonbuilder.go
+++ b/backend/internal/taskworkflow/activity/jsonbuilder.go
@@ -1,0 +1,100 @@
+package activity
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	"github.com/OpenNSW/nsw/pkg/jsonutils"
+)
+
+type Request struct {
+	WorkflowID string
+	RunID      string
+	NodeID     string
+	Config     map[string]any
+	Inputs     map[string]any
+}
+
+type JSONBuilderInput struct {
+	Data any `json:"data"`
+}
+
+type JSONBuilderOutput struct {
+	JSON json.RawMessage `json:"json"`
+}
+
+type JSONBuilderConfig struct {
+	Template  any    `json:"template"`
+	OutputKey string `json:"outputKey,omitempty"`
+}
+
+type JSONBuilder struct{}
+
+func NewJSONBuilder() *JSONBuilder {
+	return &JSONBuilder{}
+}
+
+func (a *JSONBuilder) Name() ActivityType {
+	return ActivityTypeJSONBuilder
+}
+
+func (a *JSONBuilder) Build(_ context.Context, input JSONBuilderInput) (*JSONBuilderOutput, error) {
+	data, err := json.Marshal(input.Data)
+	if err != nil {
+		return nil, fmt.Errorf("marshal json builder input: %w", err)
+	}
+
+	return &JSONBuilderOutput{
+		JSON: data,
+	}, nil
+}
+
+func (a *JSONBuilder) Execute(ctx context.Context, request Request) (*Result, error) {
+	cfg, err := parseJSONBuilderConfig(request.Config)
+	if err != nil {
+		return nil, err
+	}
+	if cfg.Template == nil {
+		return nil, fmt.Errorf("json builder: template is required")
+	}
+
+	data := jsonutils.ResolveTemplateWithPlaceholders(cfg.Template, func(key string) any {
+		return request.Inputs[key]
+	})
+
+	result, err := a.Build(ctx, JSONBuilderInput{Data: data})
+	if err != nil {
+		return nil, err
+	}
+
+	outputKey := cfg.OutputKey
+	if outputKey == "" {
+		outputKey = "json"
+	}
+
+	return &Result{
+		Outputs: map[string]any{
+			outputKey: result.JSON,
+		},
+		Status: StatusSucceeded,
+	}, nil
+}
+
+func parseJSONBuilderConfig(raw map[string]any) (*JSONBuilderConfig, error) {
+	if len(raw) == 0 {
+		return &JSONBuilderConfig{}, nil
+	}
+
+	configBytes, err := json.Marshal(raw)
+	if err != nil {
+		return nil, fmt.Errorf("marshal json builder config: %w", err)
+	}
+
+	var cfg JSONBuilderConfig
+	if err := json.Unmarshal(configBytes, &cfg); err != nil {
+		return nil, fmt.Errorf("parse json builder config: %w", err)
+	}
+
+	return &cfg, nil
+}

--- a/backend/internal/taskworkflow/activity/jsonbuilder_test.go
+++ b/backend/internal/taskworkflow/activity/jsonbuilder_test.go
@@ -1,0 +1,114 @@
+package activity
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestJSONBuilderBuild(t *testing.T) {
+	t.Run("builds json from input data", func(t *testing.T) {
+		builder := NewJSONBuilder()
+
+		result, err := builder.Build(context.Background(), JSONBuilderInput{
+			Data: map[string]any{
+				"name":  "task-workflow",
+				"count": 2,
+				"meta": map[string]any{
+					"enabled": true,
+				},
+			},
+		})
+
+		require.NoError(t, err)
+		assert.JSONEq(t, `{"count":2,"meta":{"enabled":true},"name":"task-workflow"}`, string(result.JSON))
+	})
+
+	t.Run("returns error when input cannot be marshalled", func(t *testing.T) {
+		builder := NewJSONBuilder()
+
+		result, err := builder.Build(context.Background(), JSONBuilderInput{
+			Data: map[string]any{
+				"invalid": func() {},
+			},
+		})
+
+		require.Error(t, err)
+		assert.Nil(t, result)
+		assert.Contains(t, err.Error(), "marshal json builder input")
+	})
+}
+
+func TestJSONBuilderExecute(t *testing.T) {
+	t.Run("uses resolved template from config", func(t *testing.T) {
+		builder := NewJSONBuilder()
+
+		result, err := builder.Execute(context.Background(), Request{
+			Config: map[string]any{
+				"template": map[string]any{
+					"request": map[string]any{
+						"id":      "$workflow_id",
+						"name":    "$name",
+						"version": "$version",
+						"label":   "workflow-${version}",
+						"meta": map[string]any{
+							"enabled": "$enabled",
+						},
+					},
+				},
+			},
+			Inputs: map[string]any{
+				"workflow_id": "wf-1",
+				"name":        "task-workflow",
+				"version":     2,
+				"enabled":     true,
+			},
+		})
+
+		require.NoError(t, err)
+		require.NotNil(t, result)
+		raw, ok := result.Outputs["json"].(json.RawMessage)
+		require.True(t, ok)
+		assert.JSONEq(t, `{"request":{"id":"wf-1","name":"task-workflow","version":2,"label":"workflow-2","meta":{"enabled":true}}}`, string(raw))
+	})
+
+	t.Run("supports custom output key", func(t *testing.T) {
+		builder := NewJSONBuilder()
+
+		result, err := builder.Execute(context.Background(), Request{
+			Config: map[string]any{
+				"outputKey": "request_body",
+				"template": map[string]any{
+					"id": "$task_id",
+				},
+			},
+			Inputs: map[string]any{
+				"task_id": "task-1",
+			},
+		})
+
+		require.NoError(t, err)
+		require.NotNil(t, result)
+		raw, ok := result.Outputs["request_body"].(json.RawMessage)
+		require.True(t, ok)
+		assert.JSONEq(t, `{"id":"task-1"}`, string(raw))
+	})
+
+	t.Run("returns error when template is not configured", func(t *testing.T) {
+		builder := NewJSONBuilder()
+
+		result, err := builder.Execute(context.Background(), Request{
+			Inputs: map[string]any{
+				"name":    "task-workflow",
+				"version": 2,
+			},
+		})
+
+		require.Error(t, err)
+		require.Nil(t, result)
+		assert.Contains(t, err.Error(), "template is required")
+	})
+}

--- a/backend/internal/taskworkflow/activity/rest_caller.go
+++ b/backend/internal/taskworkflow/activity/rest_caller.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/url"
+	"reflect"
 	"strings"
 
 	"github.com/OpenNSW/nsw/pkg/jsonutils"
@@ -63,7 +64,10 @@ func (a *RESTCaller) Execute(ctx context.Context, request Request) (*Result, err
 func (a *RESTCaller) buildRequest(request Request) (string, remote.Request, string, error) {
 	var cfg RESTCallerConfig
 
-	configBytes, _ := json.Marshal(request.Config)
+	configBytes, err := json.Marshal(request.Config)
+	if err != nil {
+		return "", remote.Request{}, "", fmt.Errorf("rest caller: marshal config: %w", err)
+	}
 	if len(configBytes) == 0 || string(configBytes) == "null" {
 		return "", remote.Request{}, "", fmt.Errorf("rest caller: config is required")
 	}
@@ -87,9 +91,9 @@ func (a *RESTCaller) buildRequest(request Request) (string, remote.Request, stri
 	}
 
 	resolvedPath := jsonutils.ResolveTemplateWithPlaceholders(cfg.Path, lookup)
-	path, ok := resolvedPath.(string)
-	if !ok {
-		path = fmt.Sprint(resolvedPath)
+	path, err := stringifyScalarValue("path", resolvedPath)
+	if err != nil {
+		return "", remote.Request{}, "", fmt.Errorf("rest caller: resolve path: %w", err)
 	}
 
 	resolvedQuery, err := resolveStringMap(jsonutils.ResolveTemplateWithPlaceholders(cfg.Query, lookup))
@@ -129,10 +133,42 @@ func resolveStringMap(value any) (map[string]string, error) {
 
 	out := make(map[string]string, len(resolvedMap))
 	for key, rawValue := range resolvedMap {
-		out[key] = fmt.Sprint(rawValue)
+		stringValue, err := stringifyScalarValue(key, rawValue)
+		if err != nil {
+			return nil, err
+		}
+		out[key] = stringValue
 	}
 
 	return out, nil
+}
+
+func stringifyScalarValue(key string, value any) (string, error) {
+	if value == nil {
+		return "", fmt.Errorf("%q must resolve to a scalar value, got nil", key)
+	}
+
+	switch resolved := value.(type) {
+	case string:
+		return resolved, nil
+	case bool:
+		return fmt.Sprint(resolved), nil
+	case int, int8, int16, int32, int64:
+		return fmt.Sprint(resolved), nil
+	case uint, uint8, uint16, uint32, uint64:
+		return fmt.Sprint(resolved), nil
+	case float32, float64:
+		return fmt.Sprint(resolved), nil
+	case json.Number:
+		return resolved.String(), nil
+	}
+
+	kind := reflect.TypeOf(value).Kind()
+	if kind == reflect.Slice || kind == reflect.Array || kind == reflect.Map || kind == reflect.Struct {
+		return "", fmt.Errorf("%q must resolve to a scalar value, got %T", key, value)
+	}
+
+	return fmt.Sprint(value), nil
 }
 
 func toURLValues(values map[string]string) url.Values {

--- a/backend/internal/taskworkflow/activity/rest_caller.go
+++ b/backend/internal/taskworkflow/activity/rest_caller.go
@@ -1,0 +1,149 @@
+package activity
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/url"
+	"strings"
+
+	"github.com/OpenNSW/nsw/pkg/jsonutils"
+	"github.com/OpenNSW/nsw/pkg/remote"
+)
+
+type RESTCaller struct {
+	remoteManager *remote.Manager
+}
+
+func NewRESTCaller(remoteManager *remote.Manager) *RESTCaller {
+	return &RESTCaller{
+		remoteManager: remoteManager,
+	}
+}
+
+func (a *RESTCaller) Name() ActivityType {
+	return ActivityTypeRESTCaller
+}
+
+type RESTCallerConfig struct {
+	ServiceID string         `json:"serviceId,omitempty"`
+	Method    string         `json:"method,omitempty"`
+	Path      string         `json:"path,omitempty"`
+	Query     map[string]any `json:"query,omitempty"`
+	Headers   map[string]any `json:"headers,omitempty"`
+	Body      any            `json:"body,omitempty"`
+	OutputKey string         `json:"outputKey,omitempty"`
+}
+
+func (a *RESTCaller) Execute(ctx context.Context, request Request) (*Result, error) {
+	if a.remoteManager == nil {
+		return nil, fmt.Errorf("rest caller: remote manager is required")
+	}
+
+	serviceID, req, outputKey, err := a.buildRequest(request)
+	if err != nil {
+		return nil, err
+	}
+
+	// 4. Perform the API call
+	var responseData any
+	if err := a.remoteManager.Call(ctx, serviceID, req, &responseData); err != nil {
+		return nil, fmt.Errorf("rest caller: api call failed: %w", err)
+	}
+
+	// 5. Return the result to be written back to global context
+	return &Result{
+		Outputs: map[string]any{
+			outputKey: responseData,
+		},
+		Status: StatusSucceeded,
+	}, nil
+}
+
+func (a *RESTCaller) buildRequest(request Request) (string, remote.Request, string, error) {
+	var cfg RESTCallerConfig
+
+	configBytes, _ := json.Marshal(request.Config)
+	if len(configBytes) == 0 || string(configBytes) == "null" {
+		return "", remote.Request{}, "", fmt.Errorf("rest caller: config is required")
+	}
+
+	if err := json.Unmarshal(configBytes, &cfg); err != nil {
+		return "", remote.Request{}, "", fmt.Errorf("rest caller: failed to parse config: %w", err)
+	}
+
+	if cfg.Path == "" {
+		return "", remote.Request{}, "", fmt.Errorf("rest caller: path is required")
+	}
+	if cfg.Method == "" {
+		cfg.Method = "GET"
+	}
+	if cfg.OutputKey == "" {
+		cfg.OutputKey = "api_response"
+	}
+
+	lookup := func(key string) any {
+		return request.Inputs[key]
+	}
+
+	resolvedPath := jsonutils.ResolveTemplateWithPlaceholders(cfg.Path, lookup)
+	path, ok := resolvedPath.(string)
+	if !ok {
+		path = fmt.Sprint(resolvedPath)
+	}
+
+	resolvedQuery, err := resolveStringMap(jsonutils.ResolveTemplateWithPlaceholders(cfg.Query, lookup))
+	if err != nil {
+		return "", remote.Request{}, "", fmt.Errorf("rest caller: resolve query: %w", err)
+	}
+
+	resolvedHeaders, err := resolveStringMap(jsonutils.ResolveTemplateWithPlaceholders(cfg.Headers, lookup))
+	if err != nil {
+		return "", remote.Request{}, "", fmt.Errorf("rest caller: resolve headers: %w", err)
+	}
+
+	req := remote.Request{
+		Method:  strings.ToUpper(cfg.Method),
+		Path:    path,
+		Query:   toURLValues(resolvedQuery),
+		Headers: resolvedHeaders,
+		Retry:   &remote.DefaultRetryConfig,
+	}
+
+	if cfg.Body != nil {
+		req.Body = jsonutils.ResolveTemplateWithPlaceholders(cfg.Body, lookup)
+	}
+
+	return cfg.ServiceID, req, cfg.OutputKey, nil
+}
+
+func resolveStringMap(value any) (map[string]string, error) {
+	if value == nil {
+		return nil, nil
+	}
+
+	resolvedMap, ok := value.(map[string]any)
+	if !ok {
+		return nil, fmt.Errorf("expected object, got %T", value)
+	}
+
+	out := make(map[string]string, len(resolvedMap))
+	for key, rawValue := range resolvedMap {
+		out[key] = fmt.Sprint(rawValue)
+	}
+
+	return out, nil
+}
+
+func toURLValues(values map[string]string) url.Values {
+	if len(values) == 0 {
+		return nil
+	}
+
+	query := make(url.Values, len(values))
+	for key, value := range values {
+		query.Set(key, value)
+	}
+
+	return query
+}

--- a/backend/internal/taskworkflow/activity/rest_caller_test.go
+++ b/backend/internal/taskworkflow/activity/rest_caller_test.go
@@ -105,6 +105,63 @@ func TestRESTCallerBuildRequest(t *testing.T) {
 		assert.Equal(t, "true", req.Headers["X-Active"])
 	})
 
+	t.Run("returns error when path resolves to complex value", func(t *testing.T) {
+		caller := NewRESTCaller(nil)
+
+		_, _, _, err := caller.buildRequest(Request{
+			Config: map[string]any{
+				"path": "$path",
+			},
+			Inputs: map[string]any{
+				"path": map[string]any{"invalid": true},
+			},
+		})
+
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "resolve path")
+		assert.Contains(t, err.Error(), "must resolve to a scalar value")
+	})
+
+	t.Run("returns error when query value resolves to complex value", func(t *testing.T) {
+		caller := NewRESTCaller(nil)
+
+		_, _, _, err := caller.buildRequest(Request{
+			Config: map[string]any{
+				"path": "/search",
+				"query": map[string]any{
+					"filters": "$filters",
+				},
+			},
+			Inputs: map[string]any{
+				"filters": []any{"a", "b"},
+			},
+		})
+
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "resolve query")
+		assert.Contains(t, err.Error(), "must resolve to a scalar value")
+	})
+
+	t.Run("returns error when header value resolves to complex value", func(t *testing.T) {
+		caller := NewRESTCaller(nil)
+
+		_, _, _, err := caller.buildRequest(Request{
+			Config: map[string]any{
+				"path": "/search",
+				"headers": map[string]any{
+					"X-Filters": "$filters",
+				},
+			},
+			Inputs: map[string]any{
+				"filters": map[string]any{"status": "open"},
+			},
+		})
+
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "resolve headers")
+		assert.Contains(t, err.Error(), "must resolve to a scalar value")
+	})
+
 	t.Run("requires path in config", func(t *testing.T) {
 		caller := NewRESTCaller(nil)
 
@@ -189,6 +246,14 @@ func TestResolveStringMap(t *testing.T) {
 		_, err := resolveStringMap("invalid")
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "expected object")
+	})
+
+	t.Run("returns error for object values that are not scalar", func(t *testing.T) {
+		_, err := resolveStringMap(map[string]any{
+			"filters": map[string]any{"status": "open"},
+		})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "must resolve to a scalar value")
 	})
 }
 

--- a/backend/internal/taskworkflow/activity/rest_caller_test.go
+++ b/backend/internal/taskworkflow/activity/rest_caller_test.go
@@ -1,0 +1,211 @@
+package activity
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRESTCallerBuildRequest(t *testing.T) {
+	t.Run("resolves dynamic path query headers and body", func(t *testing.T) {
+		caller := NewRESTCaller(nil)
+
+		serviceID, req, outputKey, err := caller.buildRequest(Request{
+			Config: map[string]any{
+				"serviceId": "test-service",
+				"method":    "POST",
+				"path":      "/api/workflows/${workflow_id}/tasks/${task_id}",
+				"query": map[string]any{
+					"include": "$include",
+					"page":    "$page",
+				},
+				"headers": map[string]any{
+					"X-Workflow-Id": "$workflow_id",
+				},
+				"body": map[string]any{
+					"request": map[string]any{
+						"id":    "$task_id",
+						"label": "task-${page}",
+					},
+				},
+				"outputKey": "api_response",
+			},
+			Inputs: map[string]any{
+				"workflow_id": "wf-123",
+				"task_id":     "task-456",
+				"include":     "details",
+				"page":        2,
+			},
+		})
+
+		require.NoError(t, err)
+		assert.Equal(t, "test-service", serviceID)
+		assert.Equal(t, "POST", req.Method)
+		assert.Equal(t, "/api/workflows/wf-123/tasks/task-456", req.Path)
+		assert.Equal(t, "details", req.Query.Get("include"))
+		assert.Equal(t, "2", req.Query.Get("page"))
+		assert.Equal(t, "wf-123", req.Headers["X-Workflow-Id"])
+		assert.Equal(t, map[string]any{
+			"request": map[string]any{
+				"id":    "task-456",
+				"label": "task-2",
+			},
+		}, req.Body)
+		assert.Equal(t, "api_response", outputKey)
+		assert.NotNil(t, req.Retry)
+	})
+
+	t.Run("applies defaults and allows omitted optional fields", func(t *testing.T) {
+		caller := NewRESTCaller(nil)
+
+		serviceID, req, outputKey, err := caller.buildRequest(Request{
+			Config: map[string]any{
+				"path": "/health",
+			},
+		})
+
+		require.NoError(t, err)
+		assert.Empty(t, serviceID)
+		assert.Equal(t, "GET", req.Method)
+		assert.Equal(t, "/health", req.Path)
+		assert.Nil(t, req.Query)
+		assert.Empty(t, req.Headers)
+		assert.Nil(t, req.Body)
+		assert.Equal(t, "api_response", outputKey)
+		assert.NotNil(t, req.Retry)
+	})
+
+	t.Run("stringifies query and headers values", func(t *testing.T) {
+		caller := NewRESTCaller(nil)
+
+		_, req, _, err := caller.buildRequest(Request{
+			Config: map[string]any{
+				"path": "/search",
+				"query": map[string]any{
+					"page":   "$page",
+					"active": "$active",
+				},
+				"headers": map[string]any{
+					"X-Page":   "$page",
+					"X-Active": "$active",
+				},
+			},
+			Inputs: map[string]any{
+				"page":   3,
+				"active": true,
+			},
+		})
+
+		require.NoError(t, err)
+		assert.Equal(t, "3", req.Query.Get("page"))
+		assert.Equal(t, "true", req.Query.Get("active"))
+		assert.Equal(t, "3", req.Headers["X-Page"])
+		assert.Equal(t, "true", req.Headers["X-Active"])
+	})
+
+	t.Run("requires path in config", func(t *testing.T) {
+		caller := NewRESTCaller(nil)
+
+		_, _, _, err := caller.buildRequest(Request{
+			Config: map[string]any{
+				"serviceId": "test-service",
+			},
+		})
+
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "path is required")
+	})
+
+	t.Run("returns error when query config is not an object", func(t *testing.T) {
+		caller := NewRESTCaller(nil)
+
+		_, _, _, err := caller.buildRequest(Request{
+			Config: map[string]any{
+				"path":  "/search",
+				"query": "invalid",
+			},
+		})
+
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "failed to parse config")
+		assert.Contains(t, err.Error(), "cannot unmarshal string")
+	})
+
+	t.Run("returns error when headers config is not an object", func(t *testing.T) {
+		caller := NewRESTCaller(nil)
+
+		_, _, _, err := caller.buildRequest(Request{
+			Config: map[string]any{
+				"path":    "/search",
+				"headers": []any{"invalid"},
+			},
+		})
+
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "failed to parse config")
+		assert.Contains(t, err.Error(), "cannot unmarshal array")
+	})
+}
+
+func TestRESTCallerExecuteRequiresConfig(t *testing.T) {
+	_, err := NewRESTCaller(nil).Execute(context.Background(), Request{})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "remote manager is required")
+}
+
+func TestRESTCallerExecuteRequiresRemoteManager(t *testing.T) {
+	_, err := NewRESTCaller(nil).Execute(context.Background(), Request{
+		Config: map[string]any{
+			"path": "/health",
+		},
+	})
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "remote manager is required")
+}
+
+func TestResolveStringMap(t *testing.T) {
+	t.Run("returns nil for nil value", func(t *testing.T) {
+		result, err := resolveStringMap(nil)
+		require.NoError(t, err)
+		assert.Nil(t, result)
+	})
+
+	t.Run("stringifies object values", func(t *testing.T) {
+		result, err := resolveStringMap(map[string]any{
+			"page":   2,
+			"active": true,
+		})
+		require.NoError(t, err)
+		assert.Equal(t, map[string]string{
+			"page":   "2",
+			"active": "true",
+		}, result)
+	})
+
+	t.Run("returns error for non-object value", func(t *testing.T) {
+		_, err := resolveStringMap("invalid")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "expected object")
+	})
+}
+
+func TestToURLValues(t *testing.T) {
+	t.Run("returns nil for empty map", func(t *testing.T) {
+		assert.Nil(t, toURLValues(nil))
+		assert.Nil(t, toURLValues(map[string]string{}))
+	})
+
+	t.Run("converts map to url values", func(t *testing.T) {
+		values := toURLValues(map[string]string{
+			"page":   "2",
+			"active": "true",
+		})
+
+		require.NotNil(t, values)
+		assert.Equal(t, "2", values.Get("page"))
+		assert.Equal(t, "true", values.Get("active"))
+	})
+}

--- a/backend/pkg/jsonutils/resolver.go
+++ b/backend/pkg/jsonutils/resolver.go
@@ -1,5 +1,13 @@
 package jsonutils
 
+import (
+	"fmt"
+	"regexp"
+)
+
+var fullPlaceholderPattern = regexp.MustCompile(`^\$\{([^}]+)\}$|^\$([A-Za-z0-9_.-]+)$`)
+var interpolationPattern = regexp.MustCompile(`\$\{([^}]+)\}`)
+
 // ResolveTemplate recursively traverses a template structure and replaces string values
 // with results from the lookup function. It supports maps and slices.
 func ResolveTemplate(template any, lookup func(string) any) any {
@@ -17,9 +25,6 @@ func ResolveTemplate(template any, lookup func(string) any) any {
 		}
 		return newSlice
 	case string:
-		// Treat the string as a path to look up.
-		// If the lookup returns nil, we might want to keep the original or return nil.
-		// For now, let's return the lookup result.
 		if resolved := lookup(v); resolved != nil {
 			return resolved
 		}
@@ -27,4 +32,91 @@ func ResolveTemplate(template any, lookup func(string) any) any {
 	default:
 		return v
 	}
+}
+
+// ResolveTemplateWithPlaceholders recursively traverses a template structure and resolves:
+// - direct whole-string lookups like "consignment.id"
+// - placeholders in values like "$name" or "${student.grade}"
+// - placeholders in map keys like "grade_${student.grade}"
+func ResolveTemplateWithPlaceholders(template any, lookup func(string) any) any {
+	switch v := template.(type) {
+	case map[string]any:
+		newMap := make(map[string]any)
+		for k, val := range v {
+			newMap[resolveKey(k, lookup)] = ResolveTemplateWithPlaceholders(val, lookup)
+		}
+		return newMap
+	case []any:
+		newSlice := make([]any, len(v))
+		for i, val := range v {
+			newSlice[i] = ResolveTemplateWithPlaceholders(val, lookup)
+		}
+		return newSlice
+	case string:
+		return resolveString(v, lookup)
+	default:
+		return v
+	}
+}
+
+func resolveKey(key string, lookup func(string) any) string {
+	resolved := interpolateString(key, lookup)
+	if str, ok := resolved.(string); ok {
+		return str
+	}
+	return fmt.Sprint(resolved)
+}
+
+func resolveString(s string, lookup func(string) any) any {
+	if resolved, ok := interpolateStringIfPresent(s, lookup); ok {
+		return resolved
+	}
+
+	// Backwards-compatible behavior: resolve plain strings as direct lookup paths.
+	if resolved := lookup(s); resolved != nil {
+		return resolved
+	}
+	return s
+}
+
+func interpolateString(s string, lookup func(string) any) any {
+	if match := fullPlaceholderPattern.FindStringSubmatchIndex(s); match != nil {
+		if resolved, ok := lookupPlaceholder(s, match, lookup); ok {
+			return resolved
+		}
+		return s
+	}
+
+	return interpolationPattern.ReplaceAllStringFunc(s, func(token string) string {
+		match := interpolationPattern.FindStringSubmatchIndex(token)
+		if resolved, ok := lookupPlaceholder(token, match, lookup); ok {
+			return fmt.Sprint(resolved)
+		}
+		return token
+	})
+}
+
+func interpolateStringIfPresent(s string, lookup func(string) any) (any, bool) {
+	if fullPlaceholderPattern.MatchString(s) || interpolationPattern.MatchString(s) {
+		return interpolateString(s, lookup), true
+	}
+	return nil, false
+}
+
+func lookupPlaceholder(token string, match []int, lookup func(string) any) (any, bool) {
+	var key string
+	switch {
+	case len(match) >= 4 && match[2] != -1:
+		key = token[match[2]:match[3]]
+	case len(match) >= 6 && match[4] != -1:
+		key = token[match[4]:match[5]]
+	default:
+		return nil, false
+	}
+
+	resolved := lookup(key)
+	if resolved == nil {
+		return nil, false
+	}
+	return resolved, true
 }

--- a/backend/pkg/jsonutils/resolver_test.go
+++ b/backend/pkg/jsonutils/resolver_test.go
@@ -101,3 +101,82 @@ func TestResolveTemplate(t *testing.T) {
 		})
 	}
 }
+
+func TestResolveTemplateWithPlaceholders(t *testing.T) {
+	store := map[string]any{
+		"name":          "Alice",
+		"student.grade": 7,
+		"sections":      []any{"A", "B"},
+		"dynamic.key":   "student",
+		"plain.path":    "resolved",
+	}
+
+	lookup := func(key string) any {
+		return store[key]
+	}
+
+	tests := []struct {
+		name     string
+		template any
+		want     any
+	}{
+		{
+			name:     "Direct lookup stays supported",
+			template: "plain.path",
+			want:     "resolved",
+		},
+		{
+			name: "Placeholder interpolation in nested values",
+			template: map[string]any{
+				"name": "$name",
+				"school": map[string]any{
+					"class":    "Grade ${student.grade}",
+					"sections": "$sections",
+				},
+			},
+			want: map[string]any{
+				"name": "Alice",
+				"school": map[string]any{
+					"class":    "Grade 7",
+					"sections": []any{"A", "B"},
+				},
+			},
+		},
+		{
+			name: "Bare dollar inside a larger string is left literal",
+			template: map[string]any{
+				"text": "Hello $name",
+			},
+			want: map[string]any{
+				"text": "Hello $name",
+			},
+		},
+		{
+			name: "Placeholder interpolation in keys",
+			template: map[string]any{
+				"${dynamic.key}": map[string]any{
+					"grade_${student.grade}": "$name",
+				},
+			},
+			want: map[string]any{
+				"student": map[string]any{
+					"grade_7": "Alice",
+				},
+			},
+		},
+		{
+			name:     "Unknown placeholders are preserved",
+			template: "Grade ${unknown}",
+			want:     "Grade ${unknown}",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := ResolveTemplateWithPlaceholders(tt.template, lookup)
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("ResolveTemplateWithPlaceholders() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

This PR adds the initial atomic activity package under `backend/internal/taskworkflow/activity` and extends `backend/pkg/jsonutils/resolver.go` to support placeholder-based templating required by those activities.

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Other (please describe):

## Changes Made

- Added `backend/internal/taskworkflow/activity` with:
  - `JSON_BUILDER`
  - `REST_CALLER`
  - structured activity `Result` contract and status model
  - package-level README for config and execution semantics
  - unit tests for activity behavior
  - integration test scaffold for `REST_CALLER`
- Extended `backend/pkg/jsonutils/resolver.go` with placeholder interpolation support needed by activity config templating
- Added tests for the new resolver behavior in `backend/pkg/jsonutils/resolver_test.go`

## Testing

- [x] I have tested this change locally
- [x] I have added unit tests for new functionality
- [x] I have tested edge cases
- [x] All existing tests pass

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have checked that there are no merge conflicts

## Related Issues

Related to #395

## Screenshots/Demo

N/A

## Additional Notes

- The integration test under `backend/internal/taskworkflow/activity/integration` is gated behind `ENABLE_ACTIVITY_INTEGRATION_TESTS=1` because restricted environments may block `httptest` listeners.
- This PR focuses on the activity package and shared templating support only.

## Deployment Notes

No special deployment steps. This PR adds backend code, tests, and documentation for the initial atomic activity package and supporting JSON template resolution.
