### PR TITLE
Fix OGA workflow screens blank state when API returns zero results

### DIFF
--- a/portals/apps/oga-app/src/screens/WorkflowListScreen.tsx
+++ b/portals/apps/oga-app/src/screens/WorkflowListScreen.tsx
@@ -1,7 +1,7 @@
 import { useState, useEffect } from 'react'
 import { useNavigate } from 'react-router-dom'
 import { Badge, Text, TextField, Spinner, IconButton } from '@radix-ui/themes'
-import { MagnifyingGlassIcon, ChevronLeftIcon, ChevronRightIcon } from '@radix-ui/react-icons'
+import { MagnifyingGlassIcon, ChevronLeftIcon, ChevronRightIcon, ArchiveIcon } from '@radix-ui/react-icons'
 import { fetchWorkflows, type WorkflowSummary } from '../api'
 import { useApi } from '../services/useApi'
 
@@ -27,8 +27,13 @@ export function WorkflowListScreen() {
           pageSize: PAGE_SIZE,
           q: searchQuery 
         })
-        setWorkflows(result.items)
-        setTotal(result.total)
+        setWorkflows(result.items || [])
+        setTotal(result.total || 0)
+        // Reset to page 1 if current page is out of bounds
+        const maxPages = Math.max(1, Math.ceil((result.total || 0) / PAGE_SIZE))
+        if (page > maxPages) {
+          setPage(1)
+        }
       } catch (error) {
         console.error('Failed to fetch workflows:', error)
       } finally {
@@ -193,19 +198,5 @@ export function WorkflowListScreen() {
         )}
       </div>
     </div>
-  )
-}
-
-function ArchiveIcon({ className }: { className?: string }) {
-  return (
-    <svg
-      className={className}
-      xmlns="http://www.w3.org/2000/svg"
-      fill="none"
-      viewBox="0 0 24 24"
-      stroke="currentColor"
-    >
-      <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M5 8h14M5 8a2 2 0 110-4h14a2 2 0 110 4M5 8v10a2 2 0 002 2h10a2 2 0 002-2V8m-9 4h4" />
-    </svg>
   )
 }

--- a/portals/apps/oga-app/src/screens/WorkflowTasksScreen.tsx
+++ b/portals/apps/oga-app/src/screens/WorkflowTasksScreen.tsx
@@ -1,7 +1,7 @@
 import { useState, useEffect } from 'react'
 import { useParams, useNavigate } from 'react-router-dom'
 import { Badge, Text, Spinner, IconButton, Button } from '@radix-ui/themes'
-import { ChevronLeftIcon, ChevronRightIcon, ArrowLeftIcon } from '@radix-ui/react-icons'
+import { ChevronLeftIcon, ChevronRightIcon, ArrowLeftIcon, ArchiveIcon } from '@radix-ui/react-icons'
 import { fetchApplications, type OGAApplication } from '../api'
 import { useApi } from '../services/useApi'
 
@@ -84,59 +84,70 @@ export function WorkflowTasksScreen() {
       </div>
 
       <div className="bg-white rounded-xl shadow-sm border border-gray-200 overflow-hidden">
-        <div className="overflow-x-auto">
-          <table className="w-full">
-            <thead>
-              <tr className="bg-gray-50/50 border-b border-gray-200 text-left">
-                <th className="px-6 py-4 text-xs font-semibold text-gray-500 uppercase tracking-wider">
-                  Task ID
-                </th>
-                <th className="px-6 py-4 text-xs font-semibold text-gray-500 uppercase tracking-wider">
-                  Verification Type
-                </th>
-                <th className="px-6 py-4 text-xs font-semibold text-gray-500 uppercase tracking-wider">
-                  Status
-                </th>
-                <th className="px-6 py-4 text-xs font-semibold text-gray-500 uppercase tracking-wider">
-                  Last Updated
-                </th>
-              </tr>
-            </thead>
-            <tbody className="divide-y divide-gray-200 bg-white">
-              {applications.map((app) => (
-                <tr
-                  key={app.taskId}
-                  onClick={() => { void navigate(`/workflows/${app.workflowId}?taskId=${app.taskId}`) }}
-                  className="hover:bg-blue-50/30 cursor-pointer transition-colors group text-sm"
-                >
-                  <td className="px-6 py-4 break-all font-mono text-blue-600 font-medium hover:underline">
-                    {app.taskId}
-                  </td>
-                  <td className="px-6 py-4 whitespace-nowrap text-gray-700 capitalize">
-                    {app.meta?.type || 'Standard'}
-                  </td>
-                  <td className="px-6 py-4 whitespace-nowrap">
-                    <Badge
-                      size="1"
-                      color={
-                        app.status === 'APPROVED' ? 'green' :
-                          app.status === 'REJECTED' ? 'red' :
-                            app.status === 'FEEDBACK_REQUESTED' ? 'amber' :
-                              'blue'
-                      }
-                      variant="surface"
-                    >
-                      {app.status}
-                    </Badge>
-                  </td>
-                  <td className="px-6 py-4 whitespace-nowrap text-gray-600">
-                    {formatDateForTable(app.updatedAt)}
-                  </td>
+        {total === 0 ? (
+          <div className="p-12 text-center">
+            <div className="bg-white w-16 h-16 rounded-full flex items-center justify-center mx-auto mb-4 shadow-sm border border-gray-100">
+              <ArchiveIcon className="w-8 h-8 text-gray-300" />
+            </div>
+            <Text size="3" color="gray" weight="medium">
+              No tasks found for this consignment.
+            </Text>
+          </div>
+        ) : (
+          <div className="overflow-x-auto">
+            <table className="w-full">
+              <thead>
+                <tr className="bg-gray-50/50 border-b border-gray-200 text-left">
+                  <th className="px-6 py-4 text-xs font-semibold text-gray-500 uppercase tracking-wider">
+                    Task ID
+                  </th>
+                  <th className="px-6 py-4 text-xs font-semibold text-gray-500 uppercase tracking-wider">
+                    Verification Type
+                  </th>
+                  <th className="px-6 py-4 text-xs font-semibold text-gray-500 uppercase tracking-wider">
+                    Status
+                  </th>
+                  <th className="px-6 py-4 text-xs font-semibold text-gray-500 uppercase tracking-wider">
+                    Last Updated
+                  </th>
                 </tr>
-              ))}
-            </tbody>
-          </table>
-        </div>
+              </thead>
+              <tbody className="divide-y divide-gray-200 bg-white">
+                {applications.map((app) => (
+                  <tr
+                    key={app.taskId}
+                    onClick={() => { void navigate(`/workflows/${app.workflowId}?taskId=${app.taskId}`) }}
+                    className="hover:bg-blue-50/30 cursor-pointer transition-colors group text-sm"
+                  >
+                    <td className="px-6 py-4 break-all font-mono text-blue-600 font-medium hover:underline">
+                      {app.taskId}
+                    </td>
+                    <td className="px-6 py-4 whitespace-nowrap text-gray-700 capitalize">
+                      {app.meta?.type || 'Standard'}
+                    </td>
+                    <td className="px-6 py-4 whitespace-nowrap">
+                      <Badge
+                        size="1"
+                        color={
+                          app.status === 'APPROVED' ? 'green' :
+                            app.status === 'REJECTED' ? 'red' :
+                              app.status === 'FEEDBACK_REQUESTED' ? 'amber' :
+                                'blue'
+                        }
+                        variant="surface"
+                      >
+                        {app.status}
+                      </Badge>
+                    </td>
+                    <td className="px-6 py-4 whitespace-nowrap text-gray-600">
+                      {formatDateForTable(app.updatedAt)}
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        )}
       </div>
 
       {/* Pagination */}


### PR DESCRIPTION
## Summary

This PR fixes a UI regression in OGA workflow listing screens where a zero-result API response could render a blank/non-actionable view. Instead of appearing empty or broken, the screens now render clear empty-state messaging so users can understand what happened and continue using the app.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Other (please describe):

## Changes Made

- Added zero-result guard in OGA workflow list fetch flow to safely handle `total == 0`.
- Ensured workflow list state resets to a stable first-page empty state when no records are returned.
- Added explicit empty-state rendering to the OGA workflow tasks screen when there are no tasks.
- Standardized empty-state icon usage across workflow list and workflow tasks screens using `Radix` `ArchiveIcon`.

## Testing

- [x] I have tested this change locally
- [ ] I have added unit tests for new functionality
- [x] I have tested edge cases
- [ ] All existing tests pass

Manual checks performed:
- Verified workflows page renders empty state instead of blank screen when API returns zero items.
- Verified pagination controls remain stable and no crash occurs when total is zero.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have checked that there are no merge conflicts

## Related Issues

Closes #406 

## Screenshots/Demo

After explicit empty state on zero results handling:
<img width="1512" height="909" alt="image" src="https://github.com/user-attachments/assets/0d3aefd6-3eb5-48fa-9d97-1585ae425102" />

## Deployment Notes

No special deployment steps required.