### PR TITLE
feat(oga-app): Replace TypeScript config files with YAML-based configuration

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -88,11 +88,11 @@ OGA_DB_USER=postgres
 OGA_DB_PASSWORD=changeme
 OGA_DB_NAME=oga_db
 OGA_DB_SSLMODE=disable
-# OGA frontend instance keys (normally do not need changes)
-OGA_APP_NPQS_INSTANCE_CONFIG=npqs
-OGA_APP_FCAU_INSTANCE_CONFIG=fcau
-OGA_APP_IRD_INSTANCE_CONFIG=ird
-OGA_APP_CDA_INSTANCE_CONFIG=cda
+# OGA frontend branding config paths
+OGA_APP_NPQS_BRANDING_PATH=./src/configs/npqs.yaml
+OGA_APP_FCAU_BRANDING_PATH=./src/configs/fcau.yaml
+OGA_APP_IRD_BRANDING_PATH=./src/configs/ird.yaml
+OGA_APP_CDA_BRANDING_PATH=./src/configs/cda.yaml
 
 # -------------------------------------------------------------------
 # OGA -> NSW outbound OAuth2 (required)

--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,7 @@ backend/configs/*
 
 # Files uploaded by users to the server
 **/bucket/
+# OGA Branding Configs
+portals/apps/oga-app/src/configs/
+!portals/apps/oga-app/src/configs/types.ts
+!portals/apps/oga-app/src/configs/default.yaml

--- a/portals/apps/oga-app/.env.example
+++ b/portals/apps/oga-app/.env.example
@@ -3,11 +3,12 @@
 # Frontend Development Server Port
 VITE_PORT=5174
 
-# Instance Configuration ID
-# This value determines which OGA portal configuration to load at runtime.
-# It must match a corresponding config file in src/configs/ named <value>.config.ts
-# e.g. setting this to "npqs" will load src/configs/npqs.config.ts
-VITE_INSTANCE_CONFIG=npqs
+# Branding Configuration Path
+# This value determines which OGA portal branding configuration to load at build time.
+# It can be an absolute path or a relative path from the app root.
+# e.g. "./src/configs/npqs.yaml", "../../shared/brand.yaml", or "/abs/path/to/config.yaml"
+# Branding configs are merged on top of src/configs/default.yaml
+VITE_BRANDING_PATH=./src/configs/default.yaml
 
 # Backend API Base URL
 VITE_API_BASE_URL=http://localhost:8081
@@ -29,7 +30,7 @@ VITE_APP_URL=http://localhost:5174
 # cd portals/apps/oga-app
 
 # export VITE_PORT=5174
-# export VITE_INSTANCE_CONFIG="npqs"
+# export VITE_BRANDING_PATH="./src/configs/npqs.yaml"
 # export VITE_API_BASE_URL="http://localhost:8081"
 # export VITE_IDP_BASE_URL="https://localhost:8090"
 # export VITE_IDP_CLIENT_ID="OGA_PORTAL_APP_NPQS"
@@ -41,7 +42,7 @@ VITE_APP_URL=http://localhost:5174
 # cd portals/apps/oga-app
 
 # export VITE_PORT=5175
-# export VITE_INSTANCE_CONFIG="fcau"
+# export VITE_BRANDING_PATH="./src/configs/fcau.yaml"
 # export VITE_API_BASE_URL="http://localhost:8082"
 # export VITE_IDP_BASE_URL="https://localhost:8090"
 # export VITE_IDP_CLIENT_ID="OGA_PORTAL_APP_FCAU"
@@ -53,7 +54,7 @@ VITE_APP_URL=http://localhost:5174
 # cd portals/apps/oga-app
 
 # export VITE_PORT=5176
-# export VITE_INSTANCE_CONFIG="ird"
+# export VITE_BRANDING_PATH="./src/configs/ird.yaml"
 # export VITE_API_BASE_URL="http://localhost:8083"
 # export VITE_IDP_BASE_URL="https://localhost:8090"
 # export VITE_IDP_CLIENT_ID="OGA_PORTAL_APP_IRD"
@@ -65,7 +66,7 @@ VITE_APP_URL=http://localhost:5174
 # cd portals/apps/oga-app
 
 # export VITE_PORT=5177
-# export VITE_INSTANCE_CONFIG="cda"
+# export VITE_BRANDING_PATH="./src/configs/cda.yaml"
 # export VITE_API_BASE_URL="http://localhost:8084"
 # export VITE_IDP_BASE_URL="https://localhost:8090"
 # export VITE_IDP_CLIENT_ID="OGA_PORTAL_APP_CDA"

--- a/portals/apps/oga-app/README.md
+++ b/portals/apps/oga-app/README.md
@@ -6,7 +6,7 @@ This app uses Asgardeo/Thunder OIDC for sign-in.
 
 Required environment variables:
 
-- `VITE_INSTANCE_CONFIG`: OGA config id to load (`npqs`, `fcau`, ...)
+- `VITE_BRANDING_PATH`: Path to OGA branding YAML config (e.g. `./src/configs/npqs.yaml`)
 - `VITE_API_BASE_URL`: OGA backend API base URL (for example `http://localhost:8081`)
 - `VITE_IDP_BASE_URL`: IdP base URL (for example `https://localhost:8090`)
 - `VITE_IDP_CLIENT_ID`: OGA-specific IdP application client id
@@ -21,16 +21,42 @@ Each OGA deployment should use its own IdP application configuration.
 Example:
 
 - NPQS deployment
-  - `VITE_INSTANCE_CONFIG=npqs`
+  - `VITE_BRANDING_PATH=./src/configs/npqs.yaml`
   - `VITE_IDP_CLIENT_ID=OGA_PORTAL_APP_NPQS`
 - FCAU deployment
-  - `VITE_INSTANCE_CONFIG=fcau`
+  - `VITE_BRANDING_PATH=./src/configs/fcau.yaml`
   - `VITE_IDP_CLIENT_ID=OGA_PORTAL_APP_FCAU`
 - CDA deployment
-  - `VITE_INSTANCE_CONFIG=cda`
+  - `VITE_BRANDING_PATH=./src/configs/cda.yaml`
   - `VITE_IDP_CLIENT_ID=OGA_PORTAL_APP_CDA`
 
 This allows IdP-level user access restriction per OGA app registration.
+
+## Configuration
+
+OGA instance branding and feature configuration is defined via YAML files.
+
+### How it works
+
+1. `src/configs/default.yaml` provides base fallback values for all instances.
+2. A custom YAML file (specified via `VITE_BRANDING_PATH`) overrides specific values for each OGA.
+3. At build time, Vite reads the YAML files from the filesystem (at any path), merges them, and injects the result into the application.
+4. The merged config is validated before the app renders.
+
+### Adding a new OGA instance
+
+1. Create a new YAML file anywhere on your system (e.g., `./src/brand.yaml`, `../shared/npqs.yaml`, or `/etc/oga/config.yaml`).
+2. Edit the `branding.appName` field (required).
+3. Set `VITE_BRANDING_PATH` to the path of your YAML file in your environment.
+
+### Config schema
+
+```yaml
+branding:
+  appName: "My OGA Name"       # Required
+  logoUrl: ""                   # Optional
+  favicon: ""                   # Optional
+```
 
 ## Local development
 

--- a/portals/apps/oga-app/package.json
+++ b/portals/apps/oga-app/package.json
@@ -23,6 +23,7 @@
         "react-dom": "^19.2.0",
         "react-router-dom": "^7.13.0",
         "tailwind-merge": "^3.4.0",
+        "yaml": "^2.8.3",
         "zod": "^3.25.76"
     },
     "devDependencies": {

--- a/portals/apps/oga-app/src/config.ts
+++ b/portals/apps/oga-app/src/config.ts
@@ -1,34 +1,10 @@
-import type {UIConfig} from "./configs/types.ts";
-import { getEnv } from './runtimeConfig';
+import { validateConfig } from './configs/types';
+import type { UIConfig } from './configs/types';
 
-
-const configModules = import.meta.glob<{ config: UIConfig }>(
-  './configs/*.config.ts',
-  { eager: true }
-);
+declare const __BRANDING_CONFIG__: unknown;
 
 function loadConfig(): UIConfig {
-  const instance = getEnv('VITE_INSTANCE_CONFIG');
-
-  if (!instance) {
-    throw new Error(
-      'VITE_INSTANCE_CONFIG environment variable is not set. ' +
-      'Please specify which instance to build (e.g., client-a, client-b)'
-    );
-  }
-
-  const configPath = `./configs/${instance}.config.ts`;
-
-
-  const configModule = configModules[configPath];
-
-  if (!configModule) {
-    throw new Error(
-      `Config not found for environment: ${instance}. Available: ${Object.keys(configModules).join(', ')}`
-    );
-  }
-
-  return configModule.config;
+  return validateConfig(__BRANDING_CONFIG__, 'VITE_BRANDING_PATH');
 }
 
 export const appConfig = loadConfig();

--- a/portals/apps/oga-app/src/configs/cda.config.ts
+++ b/portals/apps/oga-app/src/configs/cda.config.ts
@@ -1,9 +1,0 @@
-import type {UIConfig} from "./types.ts";
-
-export const config: UIConfig = {
-  branding: {
-    appName: "Coconut Development Authority (CDA)",
-    logoUrl: "",
-    favicon: ""
-  },
-}

--- a/portals/apps/oga-app/src/configs/default.yaml
+++ b/portals/apps/oga-app/src/configs/default.yaml
@@ -1,0 +1,4 @@
+branding:
+  appName: "OGA Officer Portal"
+  logoUrl: ""
+  favicon: ""

--- a/portals/apps/oga-app/src/configs/fcau.config.ts
+++ b/portals/apps/oga-app/src/configs/fcau.config.ts
@@ -1,9 +1,0 @@
-import type {UIConfig} from "./types.ts";
-
-export const config: UIConfig = {
-  branding: {
-    appName: "Food Control Administration Unit (FCAU)",
-    logoUrl: "",
-    favicon: ""
-  },
-}

--- a/portals/apps/oga-app/src/configs/ird.config.ts
+++ b/portals/apps/oga-app/src/configs/ird.config.ts
@@ -1,9 +1,0 @@
-import type {UIConfig} from "./types.ts";
-
-export const config: UIConfig = {
-  branding: {
-    appName: "Inland Revenue Department (IRD)",
-    logoUrl: "",
-    favicon: ""
-  },
-}

--- a/portals/apps/oga-app/src/configs/npqs.config.ts
+++ b/portals/apps/oga-app/src/configs/npqs.config.ts
@@ -1,9 +1,0 @@
-import type {UIConfig} from "./types.ts";
-
-export const config: UIConfig = {
-  branding: {
-    appName: "National Plant Quarantine Service (NPQS)",
-    logoUrl: "",
-    favicon: ""
-  },
-}

--- a/portals/apps/oga-app/src/configs/types.ts
+++ b/portals/apps/oga-app/src/configs/types.ts
@@ -1,16 +1,32 @@
-export interface UIConfig {
-  branding: {
-    appName: string;
-    logoUrl?: string;
-    favicon?: string;
-  },
-  theme?: {
-    fontFamily: string;
-    borderRadius: string;
-  },
-  features?: {
-    preConsignment: boolean;
-    consignmentManagement: boolean;
-    reportingDashboard: boolean;
-  },
+import { z } from 'zod';
+
+export const UIConfigSchema = z.object({
+  branding: z.object({
+    appName: z.string().min(1),
+    logoUrl: z.string().optional(),
+    favicon: z.string().optional(),
+  }),
+  theme: z.object({
+    fontFamily: z.string(),
+    borderRadius: z.string(),
+  }).optional(),
+  features: z.object({
+    preConsignment: z.boolean(),
+    consignmentManagement: z.boolean(),
+    reportingDashboard: z.boolean(),
+  }).optional(),
+});
+
+export type UIConfig = z.infer<typeof UIConfigSchema>;
+
+export function validateConfig(parsed: unknown, instanceId: string): UIConfig {
+  const result = UIConfigSchema.safeParse(parsed);
+  if (!result.success) {
+    throw new Error(
+      "Invalid configuration for " + instanceId + ":\n" +
+      result.error.issues.map(i => "- " + i.path.join('.') + ": " + i.message).join('\n')
+    );
+  }
+  return result.data;
 }
+

--- a/portals/apps/oga-app/src/vite-env.d.ts
+++ b/portals/apps/oga-app/src/vite-env.d.ts
@@ -1,0 +1,3 @@
+/// <reference types="vite/client" />
+
+declare const __BRANDING_CONFIG__: unknown;

--- a/portals/apps/oga-app/vite.config.ts
+++ b/portals/apps/oga-app/vite.config.ts
@@ -2,12 +2,51 @@ import { defineConfig } from 'vite'
 import react from '@vitejs/plugin-react-swc'
 import tailwindcss from "@tailwindcss/vite";
 import path from "node:path";
+import fs from 'node:fs';
+import { parse as parseYaml } from 'yaml';
+
+function deepMerge(base: any, override: any): any {
+  const result = { ...base };
+  for (const key of Object.keys(override)) {
+    if (
+      override[key] && typeof override[key] === 'object' && !Array.isArray(override[key]) &&
+      base[key] && typeof base[key] === 'object' && !Array.isArray(base[key])
+    ) {
+      result[key] = deepMerge(base[key], override[key]);
+    } else {
+      result[key] = override[key];
+    }
+  }
+  return result;
+}
+
+// Load base config
+const defaultYamlPath = path.resolve(import.meta.dirname, 'src/configs/default.yaml');
+const defaultYaml = fs.readFileSync(defaultYamlPath, 'utf8');
+let mergedConfig = parseYaml(defaultYaml);
+
+// Load custom branding if provided
+const brandingPath = process.env.VITE_BRANDING_PATH;
+if (brandingPath) {
+  const absolutePath = path.resolve(import.meta.dirname, brandingPath);
+  if (fs.existsSync(absolutePath)) {
+    const customYaml = fs.readFileSync(absolutePath, 'utf8');
+    const customConfig = parseYaml(customYaml);
+    mergedConfig = deepMerge(mergedConfig, customConfig);
+    console.log(`[Vite] Loaded branding configuration from: ${absolutePath}`);
+  } else {
+    console.warn(`[Vite] Branding configuration file not found at: ${absolutePath}`);
+  }
+}
 
 // https://vite.dev/config/
 export default defineConfig({
   plugins: [react(), tailwindcss()],
   server: {
     port: process.env.VITE_PORT ? parseInt(process.env.VITE_PORT, 10) : 5174,
+  },
+  define: {
+    __BRANDING_CONFIG__: JSON.stringify(mergedConfig),
   },
   resolve: {
     alias: {

--- a/portals/pnpm-lock.yaml
+++ b/portals/pnpm-lock.yaml
@@ -43,6 +43,9 @@ importers:
       tailwind-merge:
         specifier: ^3.4.0
         version: 3.5.0
+      yaml:
+        specifier: ^2.8.3
+        version: 2.8.3
       zod:
         specifier: ^3.25.76
         version: 3.25.76
@@ -52,7 +55,7 @@ importers:
         version: 9.39.2
       '@tailwindcss/vite':
         specifier: ^4.1.18
-        version: 4.1.18(vite@7.3.1(@types/node@24.10.9)(jiti@2.6.1)(lightningcss@1.30.2))
+        version: 4.1.18(vite@7.3.1(@types/node@24.10.9)(jiti@2.6.1)(lightningcss@1.30.2)(yaml@2.8.3))
       '@types/node':
         specifier: ^24.10.1
         version: 24.10.9
@@ -64,7 +67,7 @@ importers:
         version: 19.2.3(@types/react@19.2.9)
       '@vitejs/plugin-react-swc':
         specifier: ^4.2.2
-        version: 4.2.2(vite@7.3.1(@types/node@24.10.9)(jiti@2.6.1)(lightningcss@1.30.2))
+        version: 4.2.2(vite@7.3.1(@types/node@24.10.9)(jiti@2.6.1)(lightningcss@1.30.2)(yaml@2.8.3))
       eslint:
         specifier: ^9.39.1
         version: 9.39.2(jiti@2.6.1)
@@ -88,7 +91,7 @@ importers:
         version: 8.53.1(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3)
       vite:
         specifier: ^7.2.4
-        version: 7.3.1(@types/node@24.10.9)(jiti@2.6.1)(lightningcss@1.30.2)
+        version: 7.3.1(@types/node@24.10.9)(jiti@2.6.1)(lightningcss@1.30.2)(yaml@2.8.3)
 
   apps/trader-app:
     dependencies:
@@ -128,7 +131,7 @@ importers:
         version: 9.39.2
       '@tailwindcss/vite':
         specifier: ^4.1.18
-        version: 4.1.18(vite@7.3.1(@types/node@24.10.9)(jiti@2.6.1)(lightningcss@1.30.2))
+        version: 4.1.18(vite@7.3.1(@types/node@24.10.9)(jiti@2.6.1)(lightningcss@1.30.2)(yaml@2.8.3))
       '@types/node':
         specifier: ^24.10.1
         version: 24.10.9
@@ -140,7 +143,7 @@ importers:
         version: 19.2.3(@types/react@19.2.9)
       '@vitejs/plugin-react-swc':
         specifier: ^4.2.2
-        version: 4.2.2(vite@7.3.1(@types/node@24.10.9)(jiti@2.6.1)(lightningcss@1.30.2))
+        version: 4.2.2(vite@7.3.1(@types/node@24.10.9)(jiti@2.6.1)(lightningcss@1.30.2)(yaml@2.8.3))
       eslint:
         specifier: ^9.39.1
         version: 9.39.2(jiti@2.6.1)
@@ -164,7 +167,7 @@ importers:
         version: 8.53.1(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3)
       vite:
         specifier: ^7.2.4
-        version: 7.3.1(@types/node@24.10.9)(jiti@2.6.1)(lightningcss@1.30.2)
+        version: 7.3.1(@types/node@24.10.9)(jiti@2.6.1)(lightningcss@1.30.2)(yaml@2.8.3)
 
   packages/jsonforms-renderers:
     dependencies:
@@ -189,7 +192,7 @@ importers:
     devDependencies:
       '@tailwindcss/vite':
         specifier: ^4.0.9
-        version: 4.1.18(vite@6.4.1(@types/node@22.19.11)(jiti@2.6.1)(lightningcss@1.30.2))
+        version: 4.1.18(vite@6.4.1(@types/node@22.19.11)(jiti@2.6.1)(lightningcss@1.30.2)(yaml@2.8.3))
       '@types/node':
         specifier: ^22.10.2
         version: 22.19.11
@@ -201,7 +204,7 @@ importers:
         version: 19.2.3(@types/react@19.2.9)
       '@vitejs/plugin-react':
         specifier: ^5.1.1
-        version: 5.1.2(vite@6.4.1(@types/node@22.19.11)(jiti@2.6.1)(lightningcss@1.30.2))
+        version: 5.1.2(vite@6.4.1(@types/node@22.19.11)(jiti@2.6.1)(lightningcss@1.30.2)(yaml@2.8.3))
       tailwindcss:
         specifier: ^4.0.9
         version: 4.1.18
@@ -210,10 +213,10 @@ importers:
         version: 5.7.3
       vite:
         specifier: ^6.2.0
-        version: 6.4.1(@types/node@22.19.11)(jiti@2.6.1)(lightningcss@1.30.2)
+        version: 6.4.1(@types/node@22.19.11)(jiti@2.6.1)(lightningcss@1.30.2)(yaml@2.8.3)
       vite-plugin-dts:
         specifier: ^4.5.0
-        version: 4.5.4(@types/node@22.19.11)(rollup@4.56.0)(typescript@5.7.3)(vite@6.4.1(@types/node@22.19.11)(jiti@2.6.1)(lightningcss@1.30.2))
+        version: 4.5.4(@types/node@22.19.11)(rollup@4.56.0)(typescript@5.7.3)(vite@6.4.1(@types/node@22.19.11)(jiti@2.6.1)(lightningcss@1.30.2)(yaml@2.8.3))
 
   packages/ui:
     dependencies:
@@ -232,7 +235,7 @@ importers:
     devDependencies:
       '@tailwindcss/vite':
         specifier: ^4.0.9
-        version: 4.1.18(vite@6.4.1(@types/node@22.19.11)(jiti@2.6.1)(lightningcss@1.30.2))
+        version: 4.1.18(vite@6.4.1(@types/node@22.19.11)(jiti@2.6.1)(lightningcss@1.30.2)(yaml@2.8.3))
       '@types/node':
         specifier: ^22.10.2
         version: 22.19.11
@@ -244,7 +247,7 @@ importers:
         version: 19.2.3(@types/react@19.2.9)
       '@vitejs/plugin-react':
         specifier: ^5.1.1
-        version: 5.1.2(vite@6.4.1(@types/node@22.19.11)(jiti@2.6.1)(lightningcss@1.30.2))
+        version: 5.1.2(vite@6.4.1(@types/node@22.19.11)(jiti@2.6.1)(lightningcss@1.30.2)(yaml@2.8.3))
       tailwindcss:
         specifier: ^4.0.9
         version: 4.1.18
@@ -253,10 +256,10 @@ importers:
         version: 5.7.3
       vite:
         specifier: ^6.2.0
-        version: 6.4.1(@types/node@22.19.11)(jiti@2.6.1)(lightningcss@1.30.2)
+        version: 6.4.1(@types/node@22.19.11)(jiti@2.6.1)(lightningcss@1.30.2)(yaml@2.8.3)
       vite-plugin-dts:
         specifier: ^4.5.0
-        version: 4.5.4(@types/node@22.19.11)(rollup@4.56.0)(typescript@5.7.3)(vite@6.4.1(@types/node@22.19.11)(jiti@2.6.1)(lightningcss@1.30.2))
+        version: 4.5.4(@types/node@22.19.11)(rollup@4.56.0)(typescript@5.7.3)(vite@6.4.1(@types/node@22.19.11)(jiti@2.6.1)(lightningcss@1.30.2)(yaml@2.8.3))
 
 packages:
 
@@ -3579,6 +3582,11 @@ packages:
     resolution: {integrity: sha512-r3vXyErRCYJ7wg28yvBY5VSoAF8ZvlcW9/BwUzEtUsjvX/DKs24dIkuwjtuprwJJHsbyUbLApepYTR1BN4uHrg==}
     engines: {node: '>= 6'}
 
+  yaml@2.8.3:
+    resolution: {integrity: sha512-AvbaCLOO2Otw/lW5bmh9d/WEdcDFdQp2Z2ZUH3pX9U2ihyUY0nvLv7J6TrWowklRGPYbB/IuIMfYgxaCPg5Bpg==}
+    engines: {node: '>= 14.6'}
+    hasBin: true
+
   yocto-queue@0.1.0:
     resolution: {integrity: sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==}
     engines: {node: '>=10'}
@@ -5223,19 +5231,19 @@ snapshots:
       '@tailwindcss/oxide-win32-arm64-msvc': 4.1.18
       '@tailwindcss/oxide-win32-x64-msvc': 4.1.18
 
-  '@tailwindcss/vite@4.1.18(vite@6.4.1(@types/node@22.19.11)(jiti@2.6.1)(lightningcss@1.30.2))':
+  '@tailwindcss/vite@4.1.18(vite@6.4.1(@types/node@22.19.11)(jiti@2.6.1)(lightningcss@1.30.2)(yaml@2.8.3))':
     dependencies:
       '@tailwindcss/node': 4.1.18
       '@tailwindcss/oxide': 4.1.18
       tailwindcss: 4.1.18
-      vite: 6.4.1(@types/node@22.19.11)(jiti@2.6.1)(lightningcss@1.30.2)
+      vite: 6.4.1(@types/node@22.19.11)(jiti@2.6.1)(lightningcss@1.30.2)(yaml@2.8.3)
 
-  '@tailwindcss/vite@4.1.18(vite@7.3.1(@types/node@24.10.9)(jiti@2.6.1)(lightningcss@1.30.2))':
+  '@tailwindcss/vite@4.1.18(vite@7.3.1(@types/node@24.10.9)(jiti@2.6.1)(lightningcss@1.30.2)(yaml@2.8.3))':
     dependencies:
       '@tailwindcss/node': 4.1.18
       '@tailwindcss/oxide': 4.1.18
       tailwindcss: 4.1.18
-      vite: 7.3.1(@types/node@24.10.9)(jiti@2.6.1)(lightningcss@1.30.2)
+      vite: 7.3.1(@types/node@24.10.9)(jiti@2.6.1)(lightningcss@1.30.2)(yaml@2.8.3)
 
   '@types/argparse@1.0.38': {}
 
@@ -5398,15 +5406,15 @@ snapshots:
       '@typescript-eslint/types': 8.53.1
       eslint-visitor-keys: 4.2.1
 
-  '@vitejs/plugin-react-swc@4.2.2(vite@7.3.1(@types/node@24.10.9)(jiti@2.6.1)(lightningcss@1.30.2))':
+  '@vitejs/plugin-react-swc@4.2.2(vite@7.3.1(@types/node@24.10.9)(jiti@2.6.1)(lightningcss@1.30.2)(yaml@2.8.3))':
     dependencies:
       '@rolldown/pluginutils': 1.0.0-beta.47
       '@swc/core': 1.15.10
-      vite: 7.3.1(@types/node@24.10.9)(jiti@2.6.1)(lightningcss@1.30.2)
+      vite: 7.3.1(@types/node@24.10.9)(jiti@2.6.1)(lightningcss@1.30.2)(yaml@2.8.3)
     transitivePeerDependencies:
       - '@swc/helpers'
 
-  '@vitejs/plugin-react@5.1.2(vite@6.4.1(@types/node@22.19.11)(jiti@2.6.1)(lightningcss@1.30.2))':
+  '@vitejs/plugin-react@5.1.2(vite@6.4.1(@types/node@22.19.11)(jiti@2.6.1)(lightningcss@1.30.2)(yaml@2.8.3))':
     dependencies:
       '@babel/core': 7.28.6
       '@babel/plugin-transform-react-jsx-self': 7.27.1(@babel/core@7.28.6)
@@ -5414,7 +5422,7 @@ snapshots:
       '@rolldown/pluginutils': 1.0.0-beta.53
       '@types/babel__core': 7.20.5
       react-refresh: 0.18.0
-      vite: 6.4.1(@types/node@22.19.11)(jiti@2.6.1)(lightningcss@1.30.2)
+      vite: 6.4.1(@types/node@22.19.11)(jiti@2.6.1)(lightningcss@1.30.2)(yaml@2.8.3)
     transitivePeerDependencies:
       - supports-color
 
@@ -6875,7 +6883,7 @@ snapshots:
 
   util-deprecate@1.0.2: {}
 
-  vite-plugin-dts@4.5.4(@types/node@22.19.11)(rollup@4.56.0)(typescript@5.7.3)(vite@6.4.1(@types/node@22.19.11)(jiti@2.6.1)(lightningcss@1.30.2)):
+  vite-plugin-dts@4.5.4(@types/node@22.19.11)(rollup@4.56.0)(typescript@5.7.3)(vite@6.4.1(@types/node@22.19.11)(jiti@2.6.1)(lightningcss@1.30.2)(yaml@2.8.3)):
     dependencies:
       '@microsoft/api-extractor': 7.55.2(@types/node@22.19.11)
       '@rollup/pluginutils': 5.3.0(rollup@4.56.0)
@@ -6888,13 +6896,13 @@ snapshots:
       magic-string: 0.30.21
       typescript: 5.7.3
     optionalDependencies:
-      vite: 6.4.1(@types/node@22.19.11)(jiti@2.6.1)(lightningcss@1.30.2)
+      vite: 6.4.1(@types/node@22.19.11)(jiti@2.6.1)(lightningcss@1.30.2)(yaml@2.8.3)
     transitivePeerDependencies:
       - '@types/node'
       - rollup
       - supports-color
 
-  vite@6.4.1(@types/node@22.19.11)(jiti@2.6.1)(lightningcss@1.30.2):
+  vite@6.4.1(@types/node@22.19.11)(jiti@2.6.1)(lightningcss@1.30.2)(yaml@2.8.3):
     dependencies:
       esbuild: 0.25.12
       fdir: 6.5.0(picomatch@4.0.3)
@@ -6907,8 +6915,9 @@ snapshots:
       fsevents: 2.3.3
       jiti: 2.6.1
       lightningcss: 1.30.2
+      yaml: 2.8.3
 
-  vite@7.3.1(@types/node@24.10.9)(jiti@2.6.1)(lightningcss@1.30.2):
+  vite@7.3.1(@types/node@24.10.9)(jiti@2.6.1)(lightningcss@1.30.2)(yaml@2.8.3):
     dependencies:
       esbuild: 0.27.2
       fdir: 6.5.0(picomatch@4.0.3)
@@ -6921,6 +6930,7 @@ snapshots:
       fsevents: 2.3.3
       jiti: 2.6.1
       lightningcss: 1.30.2
+      yaml: 2.8.3
 
   vscode-uri@3.1.0: {}
 
@@ -6945,6 +6955,8 @@ snapshots:
   yallist@4.0.0: {}
 
   yaml@1.10.2: {}
+
+  yaml@2.8.3: {}
 
   yocto-queue@0.1.0: {}
 

--- a/start-dev.sh
+++ b/start-dev.sh
@@ -135,10 +135,10 @@ OGA_NPQS_DB_PATH="${OGA_NPQS_DB_PATH:-./npqs.db}"
 OGA_FCAU_DB_PATH="${OGA_FCAU_DB_PATH:-./fcau.db}"
 OGA_IRD_DB_PATH="${OGA_IRD_DB_PATH:-./ird.db}"
 OGA_CDA_DB_PATH="${OGA_CDA_DB_PATH:-./cda.db}"
-OGA_APP_NPQS_INSTANCE_CONFIG="${OGA_APP_NPQS_INSTANCE_CONFIG:-npqs}"
-OGA_APP_FCAU_INSTANCE_CONFIG="${OGA_APP_FCAU_INSTANCE_CONFIG:-fcau}"
-OGA_APP_IRD_INSTANCE_CONFIG="${OGA_APP_IRD_INSTANCE_CONFIG:-ird}"
-OGA_APP_CDA_INSTANCE_CONFIG="${OGA_APP_CDA_INSTANCE_CONFIG:-cda}"
+OGA_APP_NPQS_BRANDING_PATH="${OGA_APP_NPQS_BRANDING_PATH:-./src/configs/npqs.yaml}"
+OGA_APP_FCAU_BRANDING_PATH="${OGA_APP_FCAU_BRANDING_PATH:-./src/configs/fcau.yaml}"
+OGA_APP_IRD_BRANDING_PATH="${OGA_APP_IRD_BRANDING_PATH:-./src/configs/ird.yaml}"
+OGA_APP_CDA_BRANDING_PATH="${OGA_APP_CDA_BRANDING_PATH:-./src/configs/cda.yaml}"
 
 OGA_NSW_NPQS_CLIENT_ID="${OGA_NSW_NPQS_CLIENT_ID:-NPQS_TO_NSW}"
 OGA_NSW_FCAU_CLIENT_ID="${OGA_NSW_FCAU_CLIENT_ID:-FCAU_TO_NSW}"
@@ -151,6 +151,27 @@ OGA_NSW_CDA_CLIENT_SECRET="${OGA_NSW_CDA_CLIENT_SECRET:-1234}"
 OGA_NSW_TOKEN_URL="${OGA_NSW_TOKEN_URL:-https://localhost:${IDP_PORT}/oauth2/token}"
 OGA_NSW_SCOPES="${OGA_NSW_SCOPES:-}"
 OGA_NSW_TOKEN_INSECURE_SKIP_VERIFY="${OGA_NSW_TOKEN_INSECURE_SKIP_VERIFY:-true}"
+
+ensure_branding_file() {
+  local config_dir="$ROOT_DIR/portals/apps/oga-app/src/configs"
+  local file_name="$1"
+  local app_name="$2"
+  local file_path="${config_dir}/${file_name}"
+  if [[ ! -f "$file_path" ]]; then
+    mkdir -p "$config_dir"
+    cat >"$file_path" <<EOF
+branding:
+  appName: "${app_name}"
+  logoUrl: ""
+  favicon: ""
+EOF
+  fi
+}
+
+ensure_branding_file "npqs.yaml" "National Plant Quarantine Service (NPQS)"
+ensure_branding_file "fcau.yaml" "Food Control Administration Unit (FCAU)"
+ensure_branding_file "ird.yaml" "Inland Revenue Department (IRD)"
+ensure_branding_file "cda.yaml" "Coconut Development Authority (CDA)"
 
 pids=()
 names=()
@@ -208,17 +229,17 @@ start_service "backend" "$ROOT_DIR/backend" env \
   go run ./cmd/server/main.go
 
 # OGA instance registry
-# Each row: name | backend_port | db_path | nsw_client_id | nsw_client_secret | app_port | instance_config | idp_client_id
+# Each row: name | backend_port | db_path | nsw_client_id | nsw_client_secret | app_port | branding_path | idp_client_id
 OGA_INSTANCES=(
-  "npqs|$OGA_NPQS_PORT|$OGA_NPQS_DB_PATH|$OGA_NSW_NPQS_CLIENT_ID|$OGA_NSW_NPQS_CLIENT_SECRET|$OGA_APP_NPQS_PORT|$OGA_APP_NPQS_INSTANCE_CONFIG|$NPQS_IDP_CLIENT_ID"
-  "fcau|$OGA_FCAU_PORT|$OGA_FCAU_DB_PATH|$OGA_NSW_FCAU_CLIENT_ID|$OGA_NSW_FCAU_CLIENT_SECRET|$OGA_APP_FCAU_PORT|$OGA_APP_FCAU_INSTANCE_CONFIG|$FCAU_IDP_CLIENT_ID"
-  "ird|$OGA_IRD_PORT|$OGA_IRD_DB_PATH|$OGA_NSW_IRD_CLIENT_ID|$OGA_NSW_IRD_CLIENT_SECRET|$OGA_APP_IRD_PORT|$OGA_APP_IRD_INSTANCE_CONFIG|$IRD_IDP_CLIENT_ID"
-  "cda|$OGA_CDA_PORT|$OGA_CDA_DB_PATH|$OGA_NSW_CDA_CLIENT_ID|$OGA_NSW_CDA_CLIENT_SECRET|$OGA_APP_CDA_PORT|$OGA_APP_CDA_INSTANCE_CONFIG|$CDA_IDP_CLIENT_ID"
+  "npqs|$OGA_NPQS_PORT|$OGA_NPQS_DB_PATH|$OGA_NSW_NPQS_CLIENT_ID|$OGA_NSW_NPQS_CLIENT_SECRET|$OGA_APP_NPQS_PORT|$OGA_APP_NPQS_BRANDING_PATH|$NPQS_IDP_CLIENT_ID"
+  "fcau|$OGA_FCAU_PORT|$OGA_FCAU_DB_PATH|$OGA_NSW_FCAU_CLIENT_ID|$OGA_NSW_FCAU_CLIENT_SECRET|$OGA_APP_FCAU_PORT|$OGA_APP_FCAU_BRANDING_PATH|$FCAU_IDP_CLIENT_ID"
+  "ird|$OGA_IRD_PORT|$OGA_IRD_DB_PATH|$OGA_NSW_IRD_CLIENT_ID|$OGA_NSW_IRD_CLIENT_SECRET|$OGA_APP_IRD_PORT|$OGA_APP_IRD_BRANDING_PATH|$IRD_IDP_CLIENT_ID"
+  "cda|$OGA_CDA_PORT|$OGA_CDA_DB_PATH|$OGA_NSW_CDA_CLIENT_ID|$OGA_NSW_CDA_CLIENT_SECRET|$OGA_APP_CDA_PORT|$OGA_APP_CDA_BRANDING_PATH|$CDA_IDP_CLIENT_ID"
 )
 
 # Launch OGA backends
 for entry in "${OGA_INSTANCES[@]}"; do
-  IFS='|' read -r name port db_path nsw_client_id nsw_client_secret app_port instance_config idp_client_id <<< "$entry"
+  IFS='|' read -r name port db_path nsw_client_id nsw_client_secret app_port branding_path idp_client_id <<< "$entry"
 
   start_service "oga-${name}" "$ROOT_DIR/oga" env \
     OGA_PORT="$port" \
@@ -257,11 +278,11 @@ start_service "trader-app" "$ROOT_DIR/portals/apps/trader-app" env \
 
 # Launch OGA portals
 for entry in "${OGA_INSTANCES[@]}"; do
-  IFS='|' read -r name port db_path nsw_client_id nsw_client_secret app_port instance_config idp_client_id <<< "$entry"
+  IFS='|' read -r name port db_path nsw_client_id nsw_client_secret app_port branding_path idp_client_id <<< "$entry"
 
   start_service "oga-app-${name}" "$ROOT_DIR/portals/apps/oga-app" env \
     VITE_PORT="$app_port" \
-    VITE_INSTANCE_CONFIG="$instance_config" \
+    VITE_BRANDING_PATH="$branding_path" \
     VITE_API_BASE_URL="http://localhost:${port}" \
     VITE_IDP_BASE_URL="$IDP_PUBLIC_URL" \
     VITE_IDP_CLIENT_ID="$idp_client_id" \


### PR DESCRIPTION
## Summary

Transitioned the OGA instance configuration from static TypeScript files to a flexible YAML-based system. This implementation allows loading branding configurations from **any path on the system** (absolute or relative) during the build process, facilitating easier multi-tenant deployments.

## Type of Change

- [x] New feature (non-breaking change which adds functionality)
- [x] Documentation update
- [x] Refactoring (no functional changes)

## Changes Made

- **System-Wide Path Support**: Introduced `VITE_BRANDING_PATH` environment variable. The build process can now read YAML files from any system location (e.g., `./src/brand.yaml`, `../../shared/npqs.yaml`, or `/etc/configs/branding.yaml`).
- **Build-time Injection**: Implemented a logic in `vite.config.ts` to read, parse, and deep-merge the custom YAML over a base `default.yaml`. The final configuration is injected into the app as a global constant (`__BRANDING_CONFIG__`).
- **Simplified App Code**: `src/config.ts` was refactored to remove all filesystem and parsing logic, making the browser bundle lighter and more secure.
- **Robust Validation**: Integrated `zod` schema validation to ensure the injected configuration is structurally sound before the app renders.
- **Git Protection**: Updated `.gitignore` to exclude instance-specific configs in `src/configs/` while keeping `default.yaml` and `types.ts` tracked.
- **Cleanup**: Removed boilerplate instance YAMLs and example files from the core repository.

## Testing

- [x] Verified local loading using relative paths within `src/`.
- [x] Verified loading using absolute paths outside the project root.
- [x] Verified that missing or invalid YAML files trigger appropriate build-time warnings/errors.

## Related Issues

Closes #393 

## Additional Notes

To configure an OGA instance:
1. Create a YAML file (e.g., `npqs.yaml`) anywhere on your machine.
2. Specify the path in your `.env` file: `VITE_BRANDING_PATH=/path/to/your/npqs.yaml`.
3. The build process will handle the rest.
