### PR TITLE
feat: enhance Task List view and standardize workflow states

### DIFF
--- a/portals/apps/trader-app/src/components/WorkflowViewer/ActionCard.tsx
+++ b/portals/apps/trader-app/src/components/WorkflowViewer/ActionCard.tsx
@@ -16,7 +16,7 @@ import {
   ClockIcon,
   ReaderIcon,
   InfoCircledIcon,
-  LockClosedIcon
+  LockClosedIcon, CrossCircledIcon
 } from '@radix-ui/react-icons'
 import type { WorkflowNode, WorkflowNodeState } from '../../services/types/consignment'
 
@@ -55,10 +55,10 @@ const statusConfig: Record<
     label: 'Locked',
     icon: <LockClosedIcon className="w-3 h-3" />,
   },
-  REJECTED: {
+  FAILED: {
     color: 'red',
-    label: 'Rejected',
-    icon: <CheckCircledIcon className="w-4 h-4" />,
+    label: 'Failed',
+    icon: <CrossCircledIcon className="w-4 h-4" />,
   },
 }
 

--- a/portals/apps/trader-app/src/components/WorkflowViewer/ActionCard.tsx
+++ b/portals/apps/trader-app/src/components/WorkflowViewer/ActionCard.tsx
@@ -1,30 +1,24 @@
 import React from 'react'
-import { useNavigate } from 'react-router-dom'
-import {
-  Text,
-  Badge,
-  Button,
-  Card,
-  Flex,
-  Box,
-} from '@radix-ui/themes'
+import {useNavigate} from 'react-router-dom'
+import {Badge, Box, Button, Card, Flex, Text,} from '@radix-ui/themes'
 import {
   CheckCircledIcon,
-  PlayIcon,
-  UpdateIcon,
-  FileTextIcon,
   ClockIcon,
-  ReaderIcon,
+  CrossCircledIcon,
+  FileTextIcon,
   InfoCircledIcon,
-  LockClosedIcon, CrossCircledIcon
+  LockClosedIcon,
+  PlayIcon,
+  ReaderIcon,
+  UpdateIcon
 } from '@radix-ui/react-icons'
-import type { WorkflowNode, WorkflowNodeState } from '../../services/types/consignment'
+import type {WorkflowNode, WorkflowNodeState} from '../../services/types/consignment'
 
 const nodeTypeIcons: Record<string, React.ReactNode> = {
-  SIMPLE_FORM: <FileTextIcon className="w-4 h-4" />,
-  WAIT_FOR_EVENT: <ClockIcon className="w-4 h-4" />,
-  PAYMENT: <ReaderIcon className="w-4 h-4" />,
-  DOCUMENT_UPLOAD: <ReaderIcon className="w-4 h-4" />,
+  SIMPLE_FORM: <FileTextIcon className="w-4 h-4"/>,
+  WAIT_FOR_EVENT: <ClockIcon className="w-4 h-4"/>,
+  PAYMENT: <ReaderIcon className="w-4 h-4"/>,
+  DOCUMENT_UPLOAD: <ReaderIcon className="w-4 h-4"/>,
 }
 
 const statusConfig: Record<
@@ -38,27 +32,27 @@ const statusConfig: Record<
   COMPLETED: {
     color: 'green',
     label: 'Completed',
-    icon: <CheckCircledIcon className="w-4 h-4" />,
+    icon: <CheckCircledIcon className="w-4 h-4"/>,
   },
   READY: {
     color: 'blue',
     label: 'Ready',
-    icon: <PlayIcon className="w-4 h-4" />,
+    icon: <PlayIcon className="w-4 h-4"/>,
   },
   IN_PROGRESS: {
     color: 'orange',
     label: 'In Progress',
-    icon: <UpdateIcon className="w-4 h-4" />,
+    icon: <UpdateIcon className="w-4 h-4"/>,
   },
   LOCKED: {
     color: 'gray',
     label: 'Locked',
-    icon: <LockClosedIcon className="w-3 h-3" />,
+    icon: <LockClosedIcon className="w-3 h-3"/>,
   },
   FAILED: {
     color: 'red',
     label: 'Failed',
-    icon: <CrossCircledIcon className="w-4 h-4" />,
+    icon: <CrossCircledIcon className="w-4 h-4"/>,
   },
 }
 
@@ -75,12 +69,12 @@ const statusStyles: Record<string, string> = {
   red: 'bg-red-50 text-red-600 border-red-100',
 }
 
-export const ActionCard = ({ step, consignmentId }: ActionCardProps) => {
+export const ActionCard = ({step, consignmentId}: ActionCardProps) => {
   const navigate = useNavigate()
-  const config = statusConfig[step.state] || { color: 'gray', label: step.state, icon: null }
+  const config = statusConfig[step.state] || {color: 'gray', label: step.state, icon: null}
 
   const handleOpen = () => {
-      navigate(`/consignments/${consignmentId}/tasks/${step.id}`)
+    navigate(`/consignments/${consignmentId}/tasks/${step.id}`)
   }
 
   const label = step.workflowNodeTemplate.name || `Step ${step.id.split('-').pop()}`
@@ -88,12 +82,13 @@ export const ActionCard = ({ step, consignmentId }: ActionCardProps) => {
   const isViewable = step.state !== 'LOCKED' && !isExecutable
 
   return (
-    <Card variant="classic" className="mb-3 hover:shadow-lg transition-all duration-200 bg-white border border-gray-100 shadow-sm">
+    <Card variant="classic"
+          className="mb-3 hover:shadow-lg transition-all duration-200 bg-white border border-gray-100 shadow-sm">
       <Flex direction="column" gap="3">
         <Flex align="start" justify="between" gap="3">
           <Flex align="center" gap="3" className="flex-1 min-w-0">
             <Box className={`p-2.5 rounded-lg border ${statusStyles[config.color] || statusStyles.gray}`}>
-              {nodeTypeIcons[step.workflowNodeTemplate.type] || <FileTextIcon className="w-5 h-5" />}
+              {nodeTypeIcons[step.workflowNodeTemplate.type] || <FileTextIcon className="w-5 h-5"/>}
             </Box>
             <Box className="flex-1 min-w-0">
               <Text size="3" weight="bold" className="block truncate text-gray-900">
@@ -107,9 +102,9 @@ export const ActionCard = ({ step, consignmentId }: ActionCardProps) => {
                   </Flex>
                 </Badge>
                 {step.workflowNodeTemplate.type && (
-                   <Text size="1" color="gray" className="uppercase tracking-wider font-medium opacity-70">
-                     • {step.workflowNodeTemplate.type.replace(/_/g, ' ')}
-                   </Text>
+                  <Text size="1" color="gray" className="uppercase tracking-wider font-medium opacity-70">
+                    • {step.workflowNodeTemplate.type.replace(/_/g, ' ')}
+                  </Text>
                 )}
               </Flex>
             </Box>
@@ -122,7 +117,7 @@ export const ActionCard = ({ step, consignmentId }: ActionCardProps) => {
                 onClick={handleOpen}
                 className="cursor-pointer"
               >
-                <PlayIcon />
+                <PlayIcon/>
                 Start Task
               </Button>
             )}
@@ -134,7 +129,7 @@ export const ActionCard = ({ step, consignmentId }: ActionCardProps) => {
                 onClick={handleOpen}
                 className="cursor-pointer"
               >
-                <ReaderIcon />
+                <ReaderIcon/>
                 View Details
               </Button>
             )}
@@ -143,19 +138,19 @@ export const ActionCard = ({ step, consignmentId }: ActionCardProps) => {
 
         {step.workflowNodeTemplate.description && (
           <Box className="bg-gray-50/50 p-2 rounded border border-gray-100/50">
-             <Text size="2" color="gray" className="leading-relaxed">
-               {step.workflowNodeTemplate.description}
-             </Text>
+            <Text size="2" color="gray" className="leading-relaxed">
+              {step.workflowNodeTemplate.description}
+            </Text>
           </Box>
         )}
 
         {step.extendedState && (
-           <Flex align="center" gap="1" className="text-orange-600">
-              <InfoCircledIcon className="w-3.5 h-3.5" />
-              <Text size="1" weight="medium" className="italic">
-                {step.extendedState}
-              </Text>
-           </Flex>
+          <Flex align="center" gap="1" className="text-orange-600">
+            <InfoCircledIcon className="w-3.5 h-3.5"/>
+            <Text size="1" weight="medium" className="italic">
+              {step.extendedState}
+            </Text>
+          </Flex>
         )}
       </Flex>
     </Card>

--- a/portals/apps/trader-app/src/components/WorkflowViewer/ActionListView.tsx
+++ b/portals/apps/trader-app/src/components/WorkflowViewer/ActionListView.tsx
@@ -1,21 +1,9 @@
-import { useMemo } from 'react'
-import {
-  Text,
-  Badge,
-  Flex,
-  Box,
-  Heading,
-  Button,
-} from '@radix-ui/themes'
-import {
-  CheckCircledIcon,
-  UpdateIcon,
-  ClockIcon,
-  ReloadIcon,
-} from '@radix-ui/react-icons'
-import type { WorkflowNode } from '../../services/types/consignment'
-import { ActionCard } from './ActionCard'
-import { CollapsibleSection } from './CollapsibleSection'
+import {useMemo} from 'react'
+import {Badge, Box, Button, Flex, Heading, Text,} from '@radix-ui/themes'
+import {CheckCircledIcon, ClockIcon, ReloadIcon, UpdateIcon,} from '@radix-ui/react-icons'
+import type {WorkflowNode} from '../../services/types/consignment'
+import {ActionCard} from './ActionCard'
+import {CollapsibleSection} from './CollapsibleSection'
 
 interface ActionListViewProps {
   steps: WorkflowNode[]
@@ -26,14 +14,14 @@ interface ActionListViewProps {
   consignmentState?: string
 }
 
-export function ActionListView({ 
-  steps, 
-  consignmentId, 
-  onRefresh,
-  refreshing = false, 
-  className = "",
-  consignmentState
-}: ActionListViewProps) {
+export function ActionListView({
+                                 steps,
+                                 consignmentId,
+                                 onRefresh,
+                                 refreshing = false,
+                                 className = "",
+                                 consignmentState
+                               }: ActionListViewProps) {
   const filteredSteps = useMemo(() => {
     return steps.filter(step => {
       const type = step.workflowNodeTemplate.type?.toUpperCase();
@@ -50,7 +38,7 @@ export function ActionListView({
   }, [filteredSteps])
 
   const isConsignmentTerminal = consignmentState === 'FINISHED' || consignmentState === 'FAILED';
-  
+
   const displaySteps = useMemo(() => {
     if (isConsignmentTerminal) {
       return filteredSteps.filter(s => s.state === 'COMPLETED' || s.state === 'FAILED');
@@ -61,13 +49,13 @@ export function ActionListView({
   const RefreshButton = (onRefresh && !isConsignmentTerminal) ? (
     <Button
       variant="soft"
-      color="gray"
+      color="blue"
       size="2"
       onClick={onRefresh}
       disabled={refreshing}
       className="cursor-pointer"
     >
-      <ReloadIcon className={refreshing ? 'animate-spin' : ''} />
+      <ReloadIcon className={refreshing ? 'animate-spin' : ''}/>
       Refresh
     </Button>
   ) : null;
@@ -78,19 +66,20 @@ export function ActionListView({
         {isConsignmentTerminal ? (
           <Box mb="6">
             <Flex align="center" justify="between" my="4" px="3">
-               <Flex align="center" gap="2">
-                 <div className={`w-1.5 h-5 ${consignmentState === 'FINISHED' ? 'bg-green-500' : 'bg-red-500'} rounded-full`} />
-                 <Heading size="4" color={consignmentState === 'FINISHED' ? 'green' : 'red'} weight="bold">
-                   Task History
-                 </Heading>
-                 <Badge color={consignmentState === 'FINISHED' ? 'green' : 'red'} variant="solid" radius="full">
-                   {displaySteps.length}
-                 </Badge>
-               </Flex>
+              <Flex align="center" gap="2">
+                <div
+                  className={`w-1.5 h-5 ${consignmentState === 'FINISHED' ? 'bg-green-500' : 'bg-red-500'} rounded-full`}/>
+                <Heading size="4" color={consignmentState === 'FINISHED' ? 'green' : 'red'} weight="bold">
+                  Task History
+                </Heading>
+                <Badge color={consignmentState === 'FINISHED' ? 'green' : 'red'} variant="solid" radius="full">
+                  {displaySteps.length}
+                </Badge>
+              </Flex>
             </Flex>
             <Box px="0.5">
               {displaySteps.map((step) => (
-                <ActionCard key={step.id} step={step} consignmentId={consignmentId} />
+                <ActionCard key={step.id} step={step} consignmentId={consignmentId}/>
               ))}
             </Box>
           </Box>
@@ -99,58 +88,63 @@ export function ActionListView({
             {groups.active.length > 0 ? (
               <Box mb="6">
                 <Flex align="center" justify="between" my="4" px="3">
-                   <Flex align="center" gap="2">
-                     <div className="w-1.5 h-5 bg-blue-500 rounded-full" />
-                     <Heading size="4" color="blue" weight="bold">
-                       Action Required
-                     </Heading>
-                     <Badge color="blue" variant="solid" radius="full">
-                       {groups.active.length}
-                     </Badge>
-                   </Flex>
-                   {RefreshButton}
+                  <Flex align="center" gap="2">
+                    <div className="w-1.5 h-5 bg-blue-500 rounded-full"/>
+                    <Heading size="4" color="blue" weight="bold">
+                      Action Required
+                    </Heading>
+                    <Badge color="blue" variant="solid" radius="full">
+                      {groups.active.length}
+                    </Badge>
+                  </Flex>
+                  {RefreshButton}
                 </Flex>
                 <Box px="0.5">
                   {groups.active.map((step) => (
-                    <ActionCard key={step.id} step={step} consignmentId={consignmentId} />
+                    <ActionCard key={step.id} step={step} consignmentId={consignmentId}/>
                   ))}
                 </Box>
               </Box>
             ) : filteredSteps.length > 0 && filteredSteps.every((s) => s.state === 'COMPLETED') ? (
-                <Box py="10" px="6" mb="6" className="text-center bg-green-50/50 rounded-xl border border-green-100 shadow-sm relative">
-                    {onRefresh && (
-                      <div className="absolute top-3 right-3">
-                        {RefreshButton}
-                      </div>
-                    )}
-                    <div className="w-16 h-16 bg-green-100 rounded-full flex items-center justify-center mx-auto mb-4 border border-green-200">
-                      <CheckCircledIcon className="w-10 h-10 text-green-600" />
-                    </div>
-                    <Heading size="4" color="green" mb="2">Process Complete</Heading>
-                    <Text size="3" color="green" className="opacity-80">All workflow steps have been finished successfully. No further actions are required.</Text>
-                </Box>
-            ) : filteredSteps.length > 0 ? (
-              <Box py="8" px="6" mb="6" className="text-center bg-white rounded-xl border border-gray-200 border-dashed shadow-sm relative">
+              <Box py="10" px="6" mb="6"
+                   className="text-center bg-green-50/50 rounded-xl border border-green-100 shadow-sm relative">
                 {onRefresh && (
                   <div className="absolute top-3 right-3">
                     {RefreshButton}
                   </div>
                 )}
-                <ClockIcon className="w-12 h-12 text-slate-400 mx-auto mb-3" />
+                <div
+                  className="w-16 h-16 bg-green-100 rounded-full flex items-center justify-center mx-auto mb-4 border border-green-200">
+                  <CheckCircledIcon className="w-10 h-10 text-green-600"/>
+                </div>
+                <Heading size="4" color="green" mb="2">Process Complete</Heading>
+                <Text size="3" color="green" className="opacity-80">All workflow steps have been finished successfully.
+                  No further actions are required.</Text>
+              </Box>
+            ) : filteredSteps.length > 0 ? (
+              <Box py="8" px="6" mb="6"
+                   className="text-center bg-white rounded-xl border border-gray-200 border-dashed shadow-sm relative">
+                {onRefresh && (
+                  <div className="absolute top-3 right-3">
+                    {RefreshButton}
+                  </div>
+                )}
+                <ClockIcon className="w-12 h-12 text-slate-400 mx-auto mb-3"/>
                 <Heading size="3" color="gray" mb="1">Waiting for Updates</Heading>
-                <Text size="2" color="gray">Current steps are being processed. Next tasks will unlock automatically.</Text>
+                <Text size="2" color="gray">Current steps are being processed. Next tasks will unlock
+                  automatically.</Text>
               </Box>
             ) : null}
 
             <CollapsibleSection title="Upcoming Tasks" count={groups.upcoming.length}>
               {groups.upcoming.map((step) => (
-                <ActionCard key={step.id} step={step} consignmentId={consignmentId} />
+                <ActionCard key={step.id} step={step} consignmentId={consignmentId}/>
               ))}
             </CollapsibleSection>
 
             <CollapsibleSection title="Process History" count={groups.finished.length} color="green">
               {groups.finished.map((step) => (
-                <ActionCard key={step.id} step={step} consignmentId={consignmentId} />
+                <ActionCard key={step.id} step={step} consignmentId={consignmentId}/>
               ))}
             </CollapsibleSection>
           </>
@@ -166,7 +160,7 @@ export function ActionListView({
           className="bg-white/60 backdrop-blur-sm z-10 rounded-lg"
         >
           <Flex direction="column" align="center" gap="3">
-            <UpdateIcon className="animate-spin w-8 h-8 text-blue-600" />
+            <UpdateIcon className="animate-spin w-8 h-8 text-blue-600"/>
             <Text weight="medium" color="blue">Updating your list...</Text>
           </Flex>
         </Flex>

--- a/portals/apps/trader-app/src/components/WorkflowViewer/ActionListView.tsx
+++ b/portals/apps/trader-app/src/components/WorkflowViewer/ActionListView.tsx
@@ -5,11 +5,13 @@ import {
   Flex,
   Box,
   Heading,
+  Button,
 } from '@radix-ui/themes'
 import {
   CheckCircledIcon,
   UpdateIcon,
   ClockIcon,
+  ReloadIcon,
 } from '@radix-ui/react-icons'
 import type { WorkflowNode } from '../../services/types/consignment'
 import { ActionCard } from './ActionCard'
@@ -27,6 +29,7 @@ interface ActionListViewProps {
 export function ActionListView({ 
   steps, 
   consignmentId, 
+  onRefresh,
   refreshing = false, 
   className = "",
   consignmentState
@@ -55,19 +58,35 @@ export function ActionListView({
     return filteredSteps;
   }, [filteredSteps, isConsignmentTerminal]);
 
+  const RefreshButton = (onRefresh && !isConsignmentTerminal) ? (
+    <Button
+      variant="soft"
+      color="gray"
+      size="2"
+      onClick={onRefresh}
+      disabled={refreshing}
+      className="cursor-pointer"
+    >
+      <ReloadIcon className={refreshing ? 'animate-spin' : ''} />
+      Refresh
+    </Button>
+  ) : null;
+
   return (
     <div className={`w-full flex flex-col min-h-0 relative ${className}`}>
       <div className="flex-1 overflow-y-auto pr-2 custom-scrollbar min-h-0">
         {isConsignmentTerminal ? (
           <Box mb="6">
-            <Flex align="center" gap="2" mb="4" px="1">
-               <div className={`w-1.5 h-5 ${consignmentState === 'FINISHED' ? 'bg-green-500' : 'bg-red-500'} rounded-full`} />
-               <Heading size="4" color={consignmentState === 'FINISHED' ? 'green' : 'red'} weight="bold">
-                 Task History
-               </Heading>
-               <Badge color={consignmentState === 'FINISHED' ? 'green' : 'red'} variant="solid" radius="full">
-                 {displaySteps.length}
-               </Badge>
+            <Flex align="center" justify="between" my="4" px="3">
+               <Flex align="center" gap="2">
+                 <div className={`w-1.5 h-5 ${consignmentState === 'FINISHED' ? 'bg-green-500' : 'bg-red-500'} rounded-full`} />
+                 <Heading size="4" color={consignmentState === 'FINISHED' ? 'green' : 'red'} weight="bold">
+                   Task History
+                 </Heading>
+                 <Badge color={consignmentState === 'FINISHED' ? 'green' : 'red'} variant="solid" radius="full">
+                   {displaySteps.length}
+                 </Badge>
+               </Flex>
             </Flex>
             <Box px="0.5">
               {displaySteps.map((step) => (
@@ -79,14 +98,17 @@ export function ActionListView({
           <>
             {groups.active.length > 0 ? (
               <Box mb="6">
-                <Flex align="center" gap="2" mb="4" px="1">
-                   <div className="w-1.5 h-5 bg-blue-500 rounded-full" />
-                   <Heading size="4" color="blue" weight="bold">
-                     Action Required
-                   </Heading>
-                   <Badge color="blue" variant="solid" radius="full">
-                     {groups.active.length}
-                   </Badge>
+                <Flex align="center" justify="between" my="4" px="3">
+                   <Flex align="center" gap="2">
+                     <div className="w-1.5 h-5 bg-blue-500 rounded-full" />
+                     <Heading size="4" color="blue" weight="bold">
+                       Action Required
+                     </Heading>
+                     <Badge color="blue" variant="solid" radius="full">
+                       {groups.active.length}
+                     </Badge>
+                   </Flex>
+                   {RefreshButton}
                 </Flex>
                 <Box px="0.5">
                   {groups.active.map((step) => (
@@ -95,7 +117,12 @@ export function ActionListView({
                 </Box>
               </Box>
             ) : groups.finished.length === filteredSteps.length && filteredSteps.length > 0 ? (
-                <Box py="10" px="6" className="text-center bg-green-50/50 rounded-xl border border-green-100 shadow-sm">
+                <Box py="10" px="6" mb="6" className="text-center bg-green-50/50 rounded-xl border border-green-100 shadow-sm relative">
+                    {onRefresh && (
+                      <div className="absolute top-3 right-3">
+                        {RefreshButton}
+                      </div>
+                    )}
                     <div className="w-16 h-16 bg-green-100 rounded-full flex items-center justify-center mx-auto mb-4 border border-green-200">
                       <CheckCircledIcon className="w-10 h-10 text-green-600" />
                     </div>
@@ -103,7 +130,12 @@ export function ActionListView({
                     <Text size="3" color="green" className="opacity-80">All workflow steps have been finished successfully. No further actions are required.</Text>
                 </Box>
             ) : filteredSteps.length > 0 ? (
-              <Box py="8" px="6" className="text-center bg-white rounded-xl border border-gray-200 border-dashed shadow-sm">
+              <Box py="8" px="6" mb="6" className="text-center bg-white rounded-xl border border-gray-200 border-dashed shadow-sm relative">
+                {onRefresh && (
+                  <div className="absolute top-3 right-3">
+                    {RefreshButton}
+                  </div>
+                )}
                 <ClockIcon className="w-12 h-12 text-slate-400 mx-auto mb-3" />
                 <Heading size="3" color="gray" mb="1">Waiting for Updates</Heading>
                 <Text size="2" color="gray">Current steps are being processed. Next tasks will unlock automatically.</Text>

--- a/portals/apps/trader-app/src/components/WorkflowViewer/ActionListView.tsx
+++ b/portals/apps/trader-app/src/components/WorkflowViewer/ActionListView.tsx
@@ -116,7 +116,7 @@ export function ActionListView({
                   ))}
                 </Box>
               </Box>
-            ) : groups.finished.length === filteredSteps.length && filteredSteps.length > 0 ? (
+            ) : filteredSteps.length > 0 && filteredSteps.every((s) => s.state === 'COMPLETED') ? (
                 <Box py="10" px="6" mb="6" className="text-center bg-green-50/50 rounded-xl border border-green-100 shadow-sm relative">
                     {onRefresh && (
                       <div className="absolute top-3 right-3">

--- a/portals/apps/trader-app/src/components/WorkflowViewer/ActionListView.tsx
+++ b/portals/apps/trader-app/src/components/WorkflowViewer/ActionListView.tsx
@@ -21,69 +21,108 @@ interface ActionListViewProps {
   onRefresh?: () => void
   refreshing?: boolean
   className?: string
+  consignmentState?: string
 }
 
 export function ActionListView({ 
   steps, 
   consignmentId, 
   refreshing = false, 
-  className = "" 
+  className = "",
+  consignmentState
 }: ActionListViewProps) {
+  const filteredSteps = useMemo(() => {
+    return steps.filter(step => {
+      const type = step.workflowNodeTemplate.type?.toUpperCase();
+      return type !== 'START' && type !== 'END' && type !== 'GATEWAY' && type !== 'END_NODE';
+    });
+  }, [steps]);
+
   const groups = useMemo(() => {
     return {
-      active: steps.filter((s) => s.state === 'READY' || s.state === 'IN_PROGRESS'),
-      upcoming: steps.filter((s) => s.state === 'LOCKED'),
-      finished: steps.filter((s) => s.state === 'COMPLETED' || s.state === 'REJECTED'),
+      active: filteredSteps.filter((s) => s.state === 'READY' || s.state === 'IN_PROGRESS'),
+      upcoming: filteredSteps.filter((s) => s.state === 'LOCKED'),
+      finished: filteredSteps.filter((s) => s.state === 'COMPLETED' || s.state === 'FAILED'),
     }
-  }, [steps])
+  }, [filteredSteps])
+
+  const isConsignmentTerminal = consignmentState === 'FINISHED' || consignmentState === 'FAILED';
+  
+  const displaySteps = useMemo(() => {
+    if (isConsignmentTerminal) {
+      return filteredSteps.filter(s => s.state === 'COMPLETED' || s.state === 'FAILED');
+    }
+    return filteredSteps;
+  }, [filteredSteps, isConsignmentTerminal]);
 
   return (
     <div className={`w-full flex flex-col min-h-0 relative ${className}`}>
       <div className="flex-1 overflow-y-auto pr-2 custom-scrollbar min-h-0">
-        {groups.active.length > 0 ? (
+        {isConsignmentTerminal ? (
           <Box mb="6">
             <Flex align="center" gap="2" mb="4" px="1">
-               <div className="w-1.5 h-5 bg-blue-500 rounded-full" />
-               <Heading size="4" color="blue" weight="bold">
-                 Action Required
+               <div className={`w-1.5 h-5 ${consignmentState === 'FINISHED' ? 'bg-green-500' : 'bg-red-500'} rounded-full`} />
+               <Heading size="4" color={consignmentState === 'FINISHED' ? 'green' : 'red'} weight="bold">
+                 Task History
                </Heading>
-               <Badge color="blue" variant="solid" radius="full">
-                 {groups.active.length}
+               <Badge color={consignmentState === 'FINISHED' ? 'green' : 'red'} variant="solid" radius="full">
+                 {displaySteps.length}
                </Badge>
             </Flex>
             <Box px="0.5">
-              {groups.active.map((step) => (
+              {displaySteps.map((step) => (
                 <ActionCard key={step.id} step={step} consignmentId={consignmentId} />
               ))}
             </Box>
           </Box>
-        ) : groups.finished.length === steps.length && steps.length > 0 ? (
-            <Box py="10" px="6" className="text-center bg-green-50/50 rounded-xl border border-green-100 shadow-sm">
-                <div className="w-16 h-16 bg-green-100 rounded-full flex items-center justify-center mx-auto mb-4 border border-green-200">
-                  <CheckCircledIcon className="w-10 h-10 text-green-600" />
-                </div>
-                <Heading size="4" color="green" mb="2">Process Complete</Heading>
-                <Text size="3" color="green" className="opacity-80">All workflow steps have been finished successfully. No further actions are required.</Text>
-            </Box>
-        ) : steps.length > 0 ? (
-          <Box py="8" px="6" className="text-center bg-white rounded-xl border border-gray-200 border-dashed shadow-sm">
-            <ClockIcon className="w-12 h-12 text-slate-400 mx-auto mb-3" />
-            <Heading size="3" color="gray" mb="1">Waiting for Updates</Heading>
-            <Text size="2" color="gray">Current steps are being processed. Next tasks will unlock automatically.</Text>
-          </Box>
-        ) : null}
+        ) : (
+          <>
+            {groups.active.length > 0 ? (
+              <Box mb="6">
+                <Flex align="center" gap="2" mb="4" px="1">
+                   <div className="w-1.5 h-5 bg-blue-500 rounded-full" />
+                   <Heading size="4" color="blue" weight="bold">
+                     Action Required
+                   </Heading>
+                   <Badge color="blue" variant="solid" radius="full">
+                     {groups.active.length}
+                   </Badge>
+                </Flex>
+                <Box px="0.5">
+                  {groups.active.map((step) => (
+                    <ActionCard key={step.id} step={step} consignmentId={consignmentId} />
+                  ))}
+                </Box>
+              </Box>
+            ) : groups.finished.length === filteredSteps.length && filteredSteps.length > 0 ? (
+                <Box py="10" px="6" className="text-center bg-green-50/50 rounded-xl border border-green-100 shadow-sm">
+                    <div className="w-16 h-16 bg-green-100 rounded-full flex items-center justify-center mx-auto mb-4 border border-green-200">
+                      <CheckCircledIcon className="w-10 h-10 text-green-600" />
+                    </div>
+                    <Heading size="4" color="green" mb="2">Process Complete</Heading>
+                    <Text size="3" color="green" className="opacity-80">All workflow steps have been finished successfully. No further actions are required.</Text>
+                </Box>
+            ) : filteredSteps.length > 0 ? (
+              <Box py="8" px="6" className="text-center bg-white rounded-xl border border-gray-200 border-dashed shadow-sm">
+                <ClockIcon className="w-12 h-12 text-slate-400 mx-auto mb-3" />
+                <Heading size="3" color="gray" mb="1">Waiting for Updates</Heading>
+                <Text size="2" color="gray">Current steps are being processed. Next tasks will unlock automatically.</Text>
+              </Box>
+            ) : null}
 
-        <CollapsibleSection title="Upcoming Tasks" count={groups.upcoming.length}>
-          {groups.upcoming.map((step) => (
-            <ActionCard key={step.id} step={step} consignmentId={consignmentId} />
-          ))}
-        </CollapsibleSection>
+            <CollapsibleSection title="Upcoming Tasks" count={groups.upcoming.length}>
+              {groups.upcoming.map((step) => (
+                <ActionCard key={step.id} step={step} consignmentId={consignmentId} />
+              ))}
+            </CollapsibleSection>
 
-        <CollapsibleSection title="Process History" count={groups.finished.length} color="green">
-          {groups.finished.map((step) => (
-            <ActionCard key={step.id} step={step} consignmentId={consignmentId} />
-          ))}
-        </CollapsibleSection>
+            <CollapsibleSection title="Process History" count={groups.finished.length} color="green">
+              {groups.finished.map((step) => (
+                <ActionCard key={step.id} step={step} consignmentId={consignmentId} />
+              ))}
+            </CollapsibleSection>
+          </>
+        )}
       </div>
 
       {refreshing && (

--- a/portals/apps/trader-app/src/components/WorkflowViewer/WorkflowNode.tsx
+++ b/portals/apps/trader-app/src/components/WorkflowViewer/WorkflowNode.tsx
@@ -13,6 +13,7 @@ import {
   FileTextIcon,
   ClockIcon,
   ReaderIcon,
+  CrossCircledIcon,
 } from '@radix-ui/react-icons'
 
 export interface WorkflowNodeData extends Record<string, unknown> {
@@ -64,11 +65,12 @@ const statusConfig: Record<
     iconColor: 'text-slate-400',
     statusIcon: <LockClosedIcon className="w-3 h-3 text-slate-400" />,
   },
-  REJECTED: {
+  FAILED: {
     bgColor: 'bg-red-50',
     borderColor: 'border-red-400',
     textColor: 'text-red-700',
     iconColor: 'text-red-600',
+    statusIcon: <CrossCircledIcon className="w-4 h-4 text-red-600" />,
   },
 }
 
@@ -94,7 +96,7 @@ export function WorkflowNode({ data }: NodeProps<WorkflowNodeType>) {
         return 'bg-emerald-500 hover:bg-emerald-600 active:bg-emerald-700'
       case 'IN_PROGRESS':
         return 'bg-orange-500 hover:bg-orange-600 active:bg-orange-700'
-      case 'REJECTED':
+      case 'FAILED':
         return 'bg-red-500 hover:bg-red-600 active:bg-red-700'
       default:
         return 'bg-slate-500 hover:bg-slate-600 active:bg-slate-700'

--- a/portals/apps/trader-app/src/components/WorkflowViewer/WorkflowViewer.tsx
+++ b/portals/apps/trader-app/src/components/WorkflowViewer/WorkflowViewer.tsx
@@ -182,7 +182,7 @@ function WorkflowViewerContent({ steps, className = '', onRefresh, refreshing = 
         <div className="absolute top-3 right-3 z-10">
           <Button
             variant="soft"
-            color="gray"
+            color="blue"
             size="2"
             onClick={onRefresh}
             disabled={refreshing}

--- a/portals/apps/trader-app/src/screens/ConsignmentDetailScreen.tsx
+++ b/portals/apps/trader-app/src/screens/ConsignmentDetailScreen.tsx
@@ -244,6 +244,7 @@ export function ConsignmentDetailScreen() {
                   consignmentId={consignmentId!} 
                   onRefresh={handleRefresh} 
                   refreshing={refreshing} 
+                  consignmentState={consignment.state}
                 />
               ) : (
                 <WorkflowViewer 

--- a/portals/apps/trader-app/src/screens/ConsignmentScreen.tsx
+++ b/portals/apps/trader-app/src/screens/ConsignmentScreen.tsx
@@ -315,9 +315,10 @@ export function ConsignmentScreen() {
                 <Select.Trigger placeholder="State" />
                 <Select.Content>
                   <Select.Item value="all">All States</Select.Item>
+                  <Select.Item value="INITIALIZED">Initialized</Select.Item>
                   <Select.Item value="IN_PROGRESS">In Progress</Select.Item>
                   <Select.Item value="FINISHED">Finished</Select.Item>
-                  <Select.Item value="REQUIRES_REWORK">Requires Rework</Select.Item>
+                  <Select.Item value="FAILED">Failed</Select.Item>
                 </Select.Content>
               </Select.Root>
               <Select.Root

--- a/portals/apps/trader-app/src/services/types/consignment.ts
+++ b/portals/apps/trader-app/src/services/types/consignment.ts
@@ -10,11 +10,10 @@ export type TradeFlow = 'IMPORT' | 'EXPORT'
 export type ConsignmentState =
   | 'INITIALIZED'
   | 'IN_PROGRESS'
-  | 'REQUIRES_REWORK'
+  | 'FAILED'
   | 'FINISHED'
-  | 'COMPLETED'
 
-export type WorkflowNodeState = 'READY' | 'LOCKED' | 'IN_PROGRESS' | 'COMPLETED' | 'REJECTED'
+export type WorkflowNodeState = 'READY' | 'LOCKED' | 'IN_PROGRESS' | 'COMPLETED' | 'FAILED'
 
 export type StepType = 'SIMPLE_FORM' | 'WAIT_FOR_EVENT' | 'PAYMENT'
 

--- a/portals/apps/trader-app/src/services/types/consignment.ts
+++ b/portals/apps/trader-app/src/services/types/consignment.ts
@@ -15,7 +15,14 @@ export type ConsignmentState =
 
 export type WorkflowNodeState = 'READY' | 'LOCKED' | 'IN_PROGRESS' | 'COMPLETED' | 'FAILED'
 
-export type StepType = 'SIMPLE_FORM' | 'WAIT_FOR_EVENT' | 'PAYMENT'
+export type StepType =
+  | 'SIMPLE_FORM'
+  | 'WAIT_FOR_EVENT'
+  | 'PAYMENT'
+  | 'START'
+  | 'END'
+  | 'GATEWAY'
+  | 'END_NODE'
 
 export interface GlobalContext {
   consigneeAddress: string

--- a/portals/apps/trader-app/src/utils/consignmentUtils.ts
+++ b/portals/apps/trader-app/src/utils/consignmentUtils.ts
@@ -12,7 +12,7 @@ export function getStateColor(
       return 'orange'
     case 'FINISHED':
       return 'green'
-    case 'REQUIRES_REWORK':
+    case 'FAILED':
       return 'red'
     default:
       return 'gray'


### PR DESCRIPTION
## Summary

This PR enhances the workflow task list and node visualization in the trader application. It focuses on decluttering the view and providing better user controls.

## Type of Change

- [x] New feature (non-breaking change which adds functionality)
- [x] Refactoring (no functional changes)

## Changes Made

- **1. Removing Non-"TASK" Nodes**: Filtered out system nodes (`START`, `END`, `GATEWAY`, `END_NODE`) from the `ActionListView` to focus exclusively on user-actionable tasks.
- **2. Implementation of Refresh Button**: Added a manual `Reload` button to the `ActionListView` allowing users to refresh the workflow state without a full page reload.
- **Terminal State UI**: Created a specialized "Task History" layout for consignments that have reached `FINISHED` or `FAILED` states, providing a clear audit trail.
- **State Standardization**: Renamed `REJECTED` and `REQUIRES_REWORK` to `FAILED` throughout the application types, components, and utilities for backend consistency.

## Testing

- [x] I have tested this change locally

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings

## Related Issues

Closes #412

## Screenshots/Demo

### 1. Removing non "TASK" nodes
<img width="2560" height="1440" alt="Screenshot 2026-04-28 at 11 33 38" src="https://github.com/user-attachments/assets/14139f1e-e6be-4513-ab4b-1db6a8685f77" />

### 2. Implementation of the refresh button
<img width="2560" height="1440" alt="Screenshot 2026-04-28 at 12 28 42" src="https://github.com/user-attachments/assets/f400a98d-b4ad-4533-a60a-897b1b1b45d0" />

## Additional Notes

Renaming `REJECTED` to `FAILED` aligns with backend naming conventions.
