### PR TITLE
feat(persistence): add task workflow task storage

### DIFF
--- a/backend/internal/database/migrations/012_create_task_workflow_tasks.down.sql
+++ b/backend/internal/database/migrations/012_create_task_workflow_tasks.down.sql
@@ -1,0 +1,5 @@
+BEGIN;
+
+DROP TABLE IF EXISTS task_workflow_tasks;
+
+COMMIT;

--- a/backend/internal/database/migrations/012_create_task_workflow_tasks.up.sql
+++ b/backend/internal/database/migrations/012_create_task_workflow_tasks.up.sql
@@ -1,0 +1,24 @@
+BEGIN;
+
+CREATE TABLE IF NOT EXISTS task_workflow_tasks (
+    task_id text NOT NULL PRIMARY KEY,
+    macro_workflow_id text NOT NULL,
+    task_template_id text NOT NULL,
+    state varchar(50) NOT NULL,
+    data jsonb NOT NULL DEFAULT '{}'::jsonb,
+    created_at timestamp with time zone DEFAULT now() NOT NULL,
+    updated_at timestamp with time zone DEFAULT now() NOT NULL
+);
+
+COMMENT ON TABLE task_workflow_tasks IS 'Durable records for tasks executed inside task workflows';
+COMMENT ON COLUMN task_workflow_tasks.task_id IS 'Unique task instance ID';
+COMMENT ON COLUMN task_workflow_tasks.macro_workflow_id IS 'Outer workflow instance that owns this task workflow task';
+COMMENT ON COLUMN task_workflow_tasks.task_template_id IS 'Template used to execute/render this task';
+COMMENT ON COLUMN task_workflow_tasks.state IS 'Current task state';
+COMMENT ON COLUMN task_workflow_tasks.data IS 'JSON payload used to render the task';
+
+CREATE INDEX IF NOT EXISTS idx_task_workflow_tasks_macro_workflow_id ON task_workflow_tasks (macro_workflow_id);
+CREATE INDEX IF NOT EXISTS idx_task_workflow_tasks_task_template_id ON task_workflow_tasks (task_template_id);
+CREATE INDEX IF NOT EXISTS idx_task_workflow_tasks_state ON task_workflow_tasks (state);
+
+COMMIT;

--- a/backend/internal/taskworkflow/persistence/doc.go
+++ b/backend/internal/taskworkflow/persistence/doc.go
@@ -1,0 +1,17 @@
+// Package persistence stores task workflow task records.
+//
+// The package exposes two store shapes with different authority levels:
+//
+//   - Store is the full task workflow repository. Use it only from orchestration
+//     code that owns task workflow lifecycle decisions, such as creating task
+//     rows during initialization, looking up tasks by macro workflow, or
+//     deleting task records.
+//
+//   - TaskScopedStore is the restricted store passed to code executing a single
+//     task. It is bound to one task ID at construction time and only allows that
+//     task to read or update its own state and render data.
+//
+// In general, runtime/manager code should hold Store and construct
+// TaskScopedStore values for subtasks. Subtasks, activities, plugins, and
+// rendering helpers should not receive Store directly.
+package persistence

--- a/backend/internal/taskworkflow/persistence/scoped_store.go
+++ b/backend/internal/taskworkflow/persistence/scoped_store.go
@@ -61,12 +61,7 @@ func (s *taskScopedStore) Get() (*TaskScopedRecord, error) {
 }
 
 func (s *taskScopedStore) GetState() (plugin.State, error) {
-	task, err := s.store.GetByTaskID(s.taskID)
-	if err != nil {
-		return "", err
-	}
-
-	return task.State, nil
+	return s.store.GetStateByTaskID(s.taskID)
 }
 
 func (s *taskScopedStore) SetState(state plugin.State) error {
@@ -74,12 +69,7 @@ func (s *taskScopedStore) SetState(state plugin.State) error {
 }
 
 func (s *taskScopedStore) GetData() (json.RawMessage, error) {
-	task, err := s.store.GetByTaskID(s.taskID)
-	if err != nil {
-		return nil, err
-	}
-
-	return task.Data, nil
+	return s.store.GetDataByTaskID(s.taskID)
 }
 
 func (s *taskScopedStore) SetData(data json.RawMessage) error {

--- a/backend/internal/taskworkflow/persistence/scoped_store.go
+++ b/backend/internal/taskworkflow/persistence/scoped_store.go
@@ -1,0 +1,87 @@
+package persistence
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/OpenNSW/nsw/internal/task/plugin"
+)
+
+// TaskScopedRecord is the subset of a task workflow row exposed to a single
+// task through TaskScopedStore.
+type TaskScopedRecord struct {
+	TaskID string          `json:"taskId"`
+	State  plugin.State    `json:"state"`
+	Data   json.RawMessage `json:"data"`
+}
+
+// TaskScopedStore restricts persistence access to one task row.
+//
+// It is intended for subtasks, activities, plugins, or task render code that
+// should only read/update the current task's state and render data. The task ID
+// is bound by NewTaskScopedStore, so callers cannot target another task.
+type TaskScopedStore interface {
+	Get() (*TaskScopedRecord, error)
+	GetState() (plugin.State, error)
+	SetState(plugin.State) error
+	GetData() (json.RawMessage, error)
+	SetData(json.RawMessage) error
+}
+
+type taskScopedStore struct {
+	store  Store
+	taskID string
+}
+
+func NewTaskScopedStore(store Store, taskID string) (TaskScopedStore, error) {
+	if store == nil {
+		return nil, fmt.Errorf("store cannot be nil")
+	}
+	if taskID == "" {
+		return nil, fmt.Errorf("taskID cannot be empty")
+	}
+
+	return &taskScopedStore{
+		store:  store,
+		taskID: taskID,
+	}, nil
+}
+
+func (s *taskScopedStore) Get() (*TaskScopedRecord, error) {
+	task, err := s.store.GetByTaskID(s.taskID)
+	if err != nil {
+		return nil, err
+	}
+
+	return &TaskScopedRecord{
+		TaskID: task.TaskID,
+		State:  task.State,
+		Data:   task.Data,
+	}, nil
+}
+
+func (s *taskScopedStore) GetState() (plugin.State, error) {
+	task, err := s.store.GetByTaskID(s.taskID)
+	if err != nil {
+		return "", err
+	}
+
+	return task.State, nil
+}
+
+func (s *taskScopedStore) SetState(state plugin.State) error {
+	return s.store.UpdateState(s.taskID, state)
+}
+
+func (s *taskScopedStore) GetData() (json.RawMessage, error) {
+	task, err := s.store.GetByTaskID(s.taskID)
+	if err != nil {
+		return nil, err
+	}
+
+	return task.Data, nil
+}
+
+func (s *taskScopedStore) SetData(data json.RawMessage) error {
+	return s.store.UpdateData(s.taskID, data)
+}

--- a/backend/internal/taskworkflow/persistence/scoped_store_test.go
+++ b/backend/internal/taskworkflow/persistence/scoped_store_test.go
@@ -1,0 +1,181 @@
+package persistence
+
+import (
+	"encoding/json"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+
+	"github.com/OpenNSW/nsw/internal/task/plugin"
+)
+
+type mockStore struct {
+	mock.Mock
+}
+
+func (m *mockStore) Create(task *TaskWorkflowTask) error {
+	args := m.Called(task)
+	return args.Error(0)
+}
+
+func (m *mockStore) GetByTaskID(taskID string) (*TaskWorkflowTask, error) {
+	args := m.Called(taskID)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).(*TaskWorkflowTask), args.Error(1)
+}
+
+func (m *mockStore) GetByMacroWorkflowID(macroWorkflowID string) ([]TaskWorkflowTask, error) {
+	args := m.Called(macroWorkflowID)
+	return args.Get(0).([]TaskWorkflowTask), args.Error(1)
+}
+
+func (m *mockStore) Update(task *TaskWorkflowTask) error {
+	args := m.Called(task)
+	return args.Error(0)
+}
+
+func (m *mockStore) UpdateState(taskID string, state plugin.State) error {
+	args := m.Called(taskID, state)
+	return args.Error(0)
+}
+
+func (m *mockStore) UpdateData(taskID string, data json.RawMessage) error {
+	args := m.Called(taskID, data)
+	return args.Error(0)
+}
+
+func (m *mockStore) Delete(taskID string) error {
+	args := m.Called(taskID)
+	return args.Error(0)
+}
+
+func TestNewTaskScopedStore(t *testing.T) {
+	t.Run("rejects nil store", func(t *testing.T) {
+		scoped, err := NewTaskScopedStore(nil, "task-1")
+
+		assert.Nil(t, scoped)
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "store cannot be nil")
+	})
+
+	t.Run("rejects empty taskID", func(t *testing.T) {
+		scoped, err := NewTaskScopedStore(new(mockStore), "")
+
+		assert.Nil(t, scoped)
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "taskID cannot be empty")
+	})
+
+	t.Run("returns restricted interface", func(t *testing.T) {
+		scoped, err := NewTaskScopedStore(new(mockStore), "task-1")
+
+		assert.NoError(t, err)
+		assert.NotNil(t, scoped)
+	})
+}
+
+func TestTaskScopedStoreGet(t *testing.T) {
+	store := new(mockStore)
+	data := json.RawMessage(`{"form":"render"}`)
+	store.On("GetByTaskID", "task-1").Return(&TaskWorkflowTask{
+		TaskID:          "task-1",
+		MacroWorkflowID: "macro-1",
+		TaskTemplateID:  "template-1",
+		State:           plugin.InProgress,
+		Data:            data,
+	}, nil).Once()
+
+	scoped, err := NewTaskScopedStore(store, "task-1")
+	assert.NoError(t, err)
+
+	record, err := scoped.Get()
+
+	assert.NoError(t, err)
+	assert.Equal(t, &TaskScopedRecord{
+		TaskID: "task-1",
+		State:  plugin.InProgress,
+		Data:   data,
+	}, record)
+	store.AssertExpectations(t)
+}
+
+func TestTaskScopedStoreGetState(t *testing.T) {
+	store := new(mockStore)
+	store.On("GetByTaskID", "task-1").Return(&TaskWorkflowTask{
+		TaskID: "task-1",
+		State:  plugin.Completed,
+	}, nil).Once()
+
+	scoped, err := NewTaskScopedStore(store, "task-1")
+	assert.NoError(t, err)
+
+	state, err := scoped.GetState()
+
+	assert.NoError(t, err)
+	assert.Equal(t, plugin.Completed, state)
+	store.AssertExpectations(t)
+}
+
+func TestTaskScopedStoreSetState(t *testing.T) {
+	store := new(mockStore)
+	store.On("UpdateState", "task-1", plugin.Failed).Return(nil).Once()
+
+	scoped, err := NewTaskScopedStore(store, "task-1")
+	assert.NoError(t, err)
+
+	err = scoped.SetState(plugin.Failed)
+
+	assert.NoError(t, err)
+	store.AssertExpectations(t)
+}
+
+func TestTaskScopedStoreGetData(t *testing.T) {
+	store := new(mockStore)
+	data := json.RawMessage(`{"field":"value"}`)
+	store.On("GetByTaskID", "task-1").Return(&TaskWorkflowTask{
+		TaskID: "task-1",
+		Data:   data,
+	}, nil).Once()
+
+	scoped, err := NewTaskScopedStore(store, "task-1")
+	assert.NoError(t, err)
+
+	got, err := scoped.GetData()
+
+	assert.NoError(t, err)
+	assert.Equal(t, data, got)
+	store.AssertExpectations(t)
+}
+
+func TestTaskScopedStoreSetData(t *testing.T) {
+	store := new(mockStore)
+	data := json.RawMessage(`{"field":"updated"}`)
+	store.On("UpdateData", "task-1", data).Return(nil).Once()
+
+	scoped, err := NewTaskScopedStore(store, "task-1")
+	assert.NoError(t, err)
+
+	err = scoped.SetData(data)
+
+	assert.NoError(t, err)
+	store.AssertExpectations(t)
+}
+
+func TestTaskScopedStorePassesThroughErrors(t *testing.T) {
+	store := new(mockStore)
+	wantErr := errors.New("store failed")
+	store.On("GetByTaskID", "task-1").Return(nil, wantErr).Once()
+
+	scoped, err := NewTaskScopedStore(store, "task-1")
+	assert.NoError(t, err)
+
+	record, err := scoped.Get()
+
+	assert.Nil(t, record)
+	assert.ErrorIs(t, err, wantErr)
+	store.AssertExpectations(t)
+}

--- a/backend/internal/taskworkflow/persistence/scoped_store_test.go
+++ b/backend/internal/taskworkflow/persistence/scoped_store_test.go
@@ -28,6 +28,16 @@ func (m *mockStore) GetByTaskID(taskID string) (*TaskWorkflowTask, error) {
 	return args.Get(0).(*TaskWorkflowTask), args.Error(1)
 }
 
+func (m *mockStore) GetStateByTaskID(taskID string) (plugin.State, error) {
+	args := m.Called(taskID)
+	return args.Get(0).(plugin.State), args.Error(1)
+}
+
+func (m *mockStore) GetDataByTaskID(taskID string) (json.RawMessage, error) {
+	args := m.Called(taskID)
+	return args.Get(0).(json.RawMessage), args.Error(1)
+}
+
 func (m *mockStore) GetByMacroWorkflowID(macroWorkflowID string) ([]TaskWorkflowTask, error) {
 	args := m.Called(macroWorkflowID)
 	return args.Get(0).([]TaskWorkflowTask), args.Error(1)
@@ -105,10 +115,7 @@ func TestTaskScopedStoreGet(t *testing.T) {
 
 func TestTaskScopedStoreGetState(t *testing.T) {
 	store := new(mockStore)
-	store.On("GetByTaskID", "task-1").Return(&TaskWorkflowTask{
-		TaskID: "task-1",
-		State:  plugin.Completed,
-	}, nil).Once()
+	store.On("GetStateByTaskID", "task-1").Return(plugin.Completed, nil).Once()
 
 	scoped, err := NewTaskScopedStore(store, "task-1")
 	assert.NoError(t, err)
@@ -136,10 +143,7 @@ func TestTaskScopedStoreSetState(t *testing.T) {
 func TestTaskScopedStoreGetData(t *testing.T) {
 	store := new(mockStore)
 	data := json.RawMessage(`{"field":"value"}`)
-	store.On("GetByTaskID", "task-1").Return(&TaskWorkflowTask{
-		TaskID: "task-1",
-		Data:   data,
-	}, nil).Once()
+	store.On("GetDataByTaskID", "task-1").Return(data, nil).Once()
 
 	scoped, err := NewTaskScopedStore(store, "task-1")
 	assert.NoError(t, err)

--- a/backend/internal/taskworkflow/persistence/store.go
+++ b/backend/internal/taskworkflow/persistence/store.go
@@ -34,6 +34,8 @@ func (TaskWorkflowTask) TableName() string {
 type Store interface {
 	Create(*TaskWorkflowTask) error
 	GetByTaskID(string) (*TaskWorkflowTask, error)
+	GetStateByTaskID(string) (plugin.State, error)
+	GetDataByTaskID(string) (json.RawMessage, error)
 	GetByMacroWorkflowID(string) ([]TaskWorkflowTask, error)
 	Update(*TaskWorkflowTask) error
 	UpdateState(string, plugin.State) error
@@ -65,6 +67,22 @@ func (s *TaskWorkflowStore) GetByTaskID(taskID string) (*TaskWorkflowTask, error
 	return &task, nil
 }
 
+func (s *TaskWorkflowStore) GetStateByTaskID(taskID string) (plugin.State, error) {
+	var task TaskWorkflowTask
+	if err := s.db.Select("state").First(&task, "task_id = ?", taskID).Error; err != nil {
+		return "", err
+	}
+	return task.State, nil
+}
+
+func (s *TaskWorkflowStore) GetDataByTaskID(taskID string) (json.RawMessage, error) {
+	var task TaskWorkflowTask
+	if err := s.db.Select("data").First(&task, "task_id = ?", taskID).Error; err != nil {
+		return nil, err
+	}
+	return task.Data, nil
+}
+
 func (s *TaskWorkflowStore) GetByMacroWorkflowID(macroWorkflowID string) ([]TaskWorkflowTask, error) {
 	var tasks []TaskWorkflowTask
 	if err := s.db.Where("macro_workflow_id = ?", macroWorkflowID).Find(&tasks).Error; err != nil {
@@ -74,7 +92,17 @@ func (s *TaskWorkflowStore) GetByMacroWorkflowID(macroWorkflowID string) ([]Task
 }
 
 func (s *TaskWorkflowStore) Update(task *TaskWorkflowTask) error {
-	return s.db.Save(task).Error
+	result := s.db.Model(&TaskWorkflowTask{}).
+		Where("task_id = ?", task.TaskID).
+		Select("*").
+		Updates(task)
+	if result.Error != nil {
+		return result.Error
+	}
+	if result.RowsAffected == 0 {
+		return gorm.ErrRecordNotFound
+	}
+	return nil
 }
 
 func (s *TaskWorkflowStore) UpdateState(taskID string, state plugin.State) error {
@@ -86,5 +114,12 @@ func (s *TaskWorkflowStore) UpdateData(taskID string, data json.RawMessage) erro
 }
 
 func (s *TaskWorkflowStore) Delete(taskID string) error {
-	return s.db.Delete(&TaskWorkflowTask{}, "task_id = ?", taskID).Error
+	result := s.db.Delete(&TaskWorkflowTask{}, "task_id = ?", taskID)
+	if result.Error != nil {
+		return result.Error
+	}
+	if result.RowsAffected == 0 {
+		return gorm.ErrRecordNotFound
+	}
+	return nil
 }

--- a/backend/internal/taskworkflow/persistence/store.go
+++ b/backend/internal/taskworkflow/persistence/store.go
@@ -17,8 +17,8 @@ type TaskWorkflowTask struct {
 	TaskTemplateID  string          `gorm:"type:text;column:task_template_id;not null;index" json:"taskTemplateId"`
 	State           plugin.State    `gorm:"type:varchar(50);column:state;not null;index" json:"state"`
 	Data            json.RawMessage `gorm:"type:jsonb;column:data;serializer:json;not null" json:"data"`
-	CreatedAt       time.Time       `gorm:"type:timestamptz;column:created_at;not null" json:"createdAt"`
-	UpdatedAt       time.Time       `gorm:"type:timestamptz;column:updated_at;not null" json:"updatedAt"`
+	CreatedAt       time.Time       `gorm:"type:timestamptz;column:created_at;not null;autoCreateTime" json:"createdAt"`
+	UpdatedAt       time.Time       `gorm:"type:timestamptz;column:updated_at;not null;autoUpdateTime" json:"updatedAt"`
 }
 
 func (TaskWorkflowTask) TableName() string {

--- a/backend/internal/taskworkflow/persistence/store.go
+++ b/backend/internal/taskworkflow/persistence/store.go
@@ -1,0 +1,90 @@
+package persistence
+
+import (
+	"encoding/json"
+	"fmt"
+	"time"
+
+	"gorm.io/gorm"
+
+	"github.com/OpenNSW/nsw/internal/task/plugin"
+)
+
+// TaskWorkflowTask represents one persisted task within a task workflow.
+type TaskWorkflowTask struct {
+	TaskID          string          `gorm:"type:text;column:task_id;not null;primaryKey" json:"taskId"`
+	MacroWorkflowID string          `gorm:"type:text;column:macro_workflow_id;not null;index" json:"macroWorkflowId"`
+	TaskTemplateID  string          `gorm:"type:text;column:task_template_id;not null;index" json:"taskTemplateId"`
+	State           plugin.State    `gorm:"type:varchar(50);column:state;not null;index" json:"state"`
+	Data            json.RawMessage `gorm:"type:jsonb;column:data;serializer:json;not null" json:"data"`
+	CreatedAt       time.Time       `gorm:"type:timestamptz;column:created_at;not null" json:"createdAt"`
+	UpdatedAt       time.Time       `gorm:"type:timestamptz;column:updated_at;not null" json:"updatedAt"`
+}
+
+func (TaskWorkflowTask) TableName() string {
+	return "task_workflow_tasks"
+}
+
+// Store is the full task workflow task repository.
+//
+// Use this from orchestration/runtime code that needs lifecycle-level access:
+// creating task rows, looking up tasks across a macro workflow, or deleting task
+// records. Do not pass Store to subtasks or renderers; use TaskScopedStore for
+// task-local access.
+type Store interface {
+	Create(*TaskWorkflowTask) error
+	GetByTaskID(string) (*TaskWorkflowTask, error)
+	GetByMacroWorkflowID(string) ([]TaskWorkflowTask, error)
+	Update(*TaskWorkflowTask) error
+	UpdateState(string, plugin.State) error
+	UpdateData(string, json.RawMessage) error
+	Delete(string) error
+}
+
+type TaskWorkflowStore struct {
+	db *gorm.DB
+}
+
+func NewTaskWorkflowStore(db *gorm.DB) (*TaskWorkflowStore, error) {
+	if db == nil {
+		return nil, fmt.Errorf("database connection cannot be nil")
+	}
+
+	return &TaskWorkflowStore{db: db}, nil
+}
+
+func (s *TaskWorkflowStore) Create(task *TaskWorkflowTask) error {
+	return s.db.Create(task).Error
+}
+
+func (s *TaskWorkflowStore) GetByTaskID(taskID string) (*TaskWorkflowTask, error) {
+	var task TaskWorkflowTask
+	if err := s.db.First(&task, "task_id = ?", taskID).Error; err != nil {
+		return nil, err
+	}
+	return &task, nil
+}
+
+func (s *TaskWorkflowStore) GetByMacroWorkflowID(macroWorkflowID string) ([]TaskWorkflowTask, error) {
+	var tasks []TaskWorkflowTask
+	if err := s.db.Where("macro_workflow_id = ?", macroWorkflowID).Find(&tasks).Error; err != nil {
+		return nil, err
+	}
+	return tasks, nil
+}
+
+func (s *TaskWorkflowStore) Update(task *TaskWorkflowTask) error {
+	return s.db.Save(task).Error
+}
+
+func (s *TaskWorkflowStore) UpdateState(taskID string, state plugin.State) error {
+	return s.db.Model(&TaskWorkflowTask{}).Where("task_id = ?", taskID).Update("state", state).Error
+}
+
+func (s *TaskWorkflowStore) UpdateData(taskID string, data json.RawMessage) error {
+	return s.db.Model(&TaskWorkflowTask{}).Where("task_id = ?", taskID).Update("data", data).Error
+}
+
+func (s *TaskWorkflowStore) Delete(taskID string) error {
+	return s.db.Delete(&TaskWorkflowTask{}, "task_id = ?", taskID).Error
+}

--- a/backend/internal/taskworkflow/persistence/store_test.go
+++ b/backend/internal/taskworkflow/persistence/store_test.go
@@ -1,0 +1,239 @@
+package persistence
+
+import (
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/DATA-DOG/go-sqlmock"
+	"github.com/stretchr/testify/assert"
+	"gorm.io/driver/postgres"
+	"gorm.io/gorm"
+
+	"github.com/OpenNSW/nsw/internal/task/plugin"
+)
+
+func setupStoreTestDB(t *testing.T) (*gorm.DB, sqlmock.Sqlmock) {
+	t.Helper()
+
+	db, mock, err := sqlmock.New()
+	assert.NoError(t, err)
+
+	gormDB, err := gorm.Open(postgres.New(postgres.Config{
+		Conn: db,
+	}), &gorm.Config{})
+	assert.NoError(t, err)
+
+	return gormDB, mock
+}
+
+func TestNewTaskWorkflowStore(t *testing.T) {
+	t.Run("rejects nil db", func(t *testing.T) {
+		store, err := NewTaskWorkflowStore(nil)
+
+		assert.Nil(t, store)
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "database connection cannot be nil")
+	})
+
+	t.Run("returns store", func(t *testing.T) {
+		db, mock := setupStoreTestDB(t)
+
+		store, err := NewTaskWorkflowStore(db)
+
+		assert.NoError(t, err)
+		assert.NotNil(t, store)
+		assert.NoError(t, mock.ExpectationsWereMet())
+	})
+}
+
+func TestTaskWorkflowStoreCreate(t *testing.T) {
+	db, mock := setupStoreTestDB(t)
+	store, err := NewTaskWorkflowStore(db)
+	assert.NoError(t, err)
+
+	task := &TaskWorkflowTask{
+		TaskID:          "task-1",
+		MacroWorkflowID: "macro-1",
+		TaskTemplateID:  "template-1",
+		State:           plugin.Initialized,
+		Data:            json.RawMessage(`{"screen":"form"}`),
+		CreatedAt:       time.Now().UTC(),
+		UpdatedAt:       time.Now().UTC(),
+	}
+
+	mock.ExpectBegin()
+	mock.ExpectExec(`INSERT INTO "task_workflow_tasks"`).
+		WithArgs(
+			task.TaskID,
+			task.MacroWorkflowID,
+			task.TaskTemplateID,
+			task.State,
+			sqlmock.AnyArg(),
+			sqlmock.AnyArg(),
+			sqlmock.AnyArg(),
+		).
+		WillReturnResult(sqlmock.NewResult(1, 1))
+	mock.ExpectCommit()
+
+	err = store.Create(task)
+
+	assert.NoError(t, err)
+	assert.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestTaskWorkflowStoreGetByTaskID(t *testing.T) {
+	db, mock := setupStoreTestDB(t)
+	store, err := NewTaskWorkflowStore(db)
+	assert.NoError(t, err)
+
+	data := []byte(`{"screen":"form"}`)
+	createdAt := time.Now().UTC()
+	updatedAt := createdAt.Add(time.Minute)
+
+	mock.ExpectQuery(`SELECT \* FROM "task_workflow_tasks" WHERE task_id = \$1 ORDER BY "task_workflow_tasks"."task_id" LIMIT \$2`).
+		WithArgs("task-1", 1).
+		WillReturnRows(sqlmock.NewRows([]string{
+			"task_id",
+			"macro_workflow_id",
+			"task_template_id",
+			"state",
+			"data",
+			"created_at",
+			"updated_at",
+		}).AddRow(
+			"task-1",
+			"macro-1",
+			"template-1",
+			plugin.InProgress,
+			data,
+			createdAt,
+			updatedAt,
+		))
+
+	task, err := store.GetByTaskID("task-1")
+
+	assert.NoError(t, err)
+	assert.Equal(t, "task-1", task.TaskID)
+	assert.Equal(t, "macro-1", task.MacroWorkflowID)
+	assert.Equal(t, "template-1", task.TaskTemplateID)
+	assert.Equal(t, plugin.InProgress, task.State)
+	assert.JSONEq(t, string(data), string(task.Data))
+	assert.Equal(t, createdAt, task.CreatedAt)
+	assert.Equal(t, updatedAt, task.UpdatedAt)
+	assert.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestTaskWorkflowStoreGetByMacroWorkflowID(t *testing.T) {
+	db, mock := setupStoreTestDB(t)
+	store, err := NewTaskWorkflowStore(db)
+	assert.NoError(t, err)
+
+	mock.ExpectQuery(`SELECT \* FROM "task_workflow_tasks" WHERE macro_workflow_id = \$1`).
+		WithArgs("macro-1").
+		WillReturnRows(sqlmock.NewRows([]string{
+			"task_id",
+			"macro_workflow_id",
+			"task_template_id",
+			"state",
+			"data",
+		}).
+			AddRow("task-1", "macro-1", "template-1", plugin.InProgress, []byte(`{"step":1}`)).
+			AddRow("task-2", "macro-1", "template-2", plugin.Completed, []byte(`{"step":2}`)))
+
+	tasks, err := store.GetByMacroWorkflowID("macro-1")
+
+	assert.NoError(t, err)
+	assert.Len(t, tasks, 2)
+	assert.Equal(t, "task-1", tasks[0].TaskID)
+	assert.Equal(t, "task-2", tasks[1].TaskID)
+	assert.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestTaskWorkflowStoreUpdate(t *testing.T) {
+	db, mock := setupStoreTestDB(t)
+	store, err := NewTaskWorkflowStore(db)
+	assert.NoError(t, err)
+
+	task := &TaskWorkflowTask{
+		TaskID:          "task-1",
+		MacroWorkflowID: "macro-1",
+		TaskTemplateID:  "template-1",
+		State:           plugin.Completed,
+		Data:            json.RawMessage(`{"done":true}`),
+		CreatedAt:       time.Now().UTC(),
+		UpdatedAt:       time.Now().UTC(),
+	}
+
+	mock.ExpectBegin()
+	mock.ExpectExec(`UPDATE "task_workflow_tasks" SET`).
+		WithArgs(
+			task.MacroWorkflowID,
+			task.TaskTemplateID,
+			task.State,
+			sqlmock.AnyArg(),
+			sqlmock.AnyArg(),
+			sqlmock.AnyArg(),
+			task.TaskID,
+		).
+		WillReturnResult(sqlmock.NewResult(1, 1))
+	mock.ExpectCommit()
+
+	err = store.Update(task)
+
+	assert.NoError(t, err)
+	assert.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestTaskWorkflowStoreUpdateState(t *testing.T) {
+	db, mock := setupStoreTestDB(t)
+	store, err := NewTaskWorkflowStore(db)
+	assert.NoError(t, err)
+
+	mock.ExpectBegin()
+	mock.ExpectExec(`UPDATE "task_workflow_tasks" SET "state"=\$1,"updated_at"=\$2 WHERE task_id = \$3`).
+		WithArgs(plugin.Failed, sqlmock.AnyArg(), "task-1").
+		WillReturnResult(sqlmock.NewResult(1, 1))
+	mock.ExpectCommit()
+
+	err = store.UpdateState("task-1", plugin.Failed)
+
+	assert.NoError(t, err)
+	assert.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestTaskWorkflowStoreUpdateData(t *testing.T) {
+	db, mock := setupStoreTestDB(t)
+	store, err := NewTaskWorkflowStore(db)
+	assert.NoError(t, err)
+
+	data := json.RawMessage(`{"field":"updated"}`)
+
+	mock.ExpectBegin()
+	mock.ExpectExec(`UPDATE "task_workflow_tasks" SET "data"=\$1,"updated_at"=\$2 WHERE task_id = \$3`).
+		WithArgs(sqlmock.AnyArg(), sqlmock.AnyArg(), "task-1").
+		WillReturnResult(sqlmock.NewResult(1, 1))
+	mock.ExpectCommit()
+
+	err = store.UpdateData("task-1", data)
+
+	assert.NoError(t, err)
+	assert.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestTaskWorkflowStoreDelete(t *testing.T) {
+	db, mock := setupStoreTestDB(t)
+	store, err := NewTaskWorkflowStore(db)
+	assert.NoError(t, err)
+
+	mock.ExpectBegin()
+	mock.ExpectExec(`DELETE FROM "task_workflow_tasks" WHERE task_id = \$1`).
+		WithArgs("task-1").
+		WillReturnResult(sqlmock.NewResult(1, 1))
+	mock.ExpectCommit()
+
+	err = store.Delete("task-1")
+
+	assert.NoError(t, err)
+	assert.NoError(t, mock.ExpectationsWereMet())
+}

--- a/backend/internal/taskworkflow/persistence/store_test.go
+++ b/backend/internal/taskworkflow/persistence/store_test.go
@@ -2,6 +2,7 @@ package persistence
 
 import (
 	"encoding/json"
+	"errors"
 	"testing"
 	"time"
 
@@ -124,6 +125,40 @@ func TestTaskWorkflowStoreGetByTaskID(t *testing.T) {
 	assert.NoError(t, mock.ExpectationsWereMet())
 }
 
+func TestTaskWorkflowStoreGetStateByTaskID(t *testing.T) {
+	db, mock := setupStoreTestDB(t)
+	store, err := NewTaskWorkflowStore(db)
+	assert.NoError(t, err)
+
+	mock.ExpectQuery(`SELECT "state" FROM "task_workflow_tasks" WHERE task_id = \$1 ORDER BY "task_workflow_tasks"."task_id" LIMIT \$2`).
+		WithArgs("task-1", 1).
+		WillReturnRows(sqlmock.NewRows([]string{"state"}).AddRow(plugin.Completed))
+
+	state, err := store.GetStateByTaskID("task-1")
+
+	assert.NoError(t, err)
+	assert.Equal(t, plugin.Completed, state)
+	assert.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestTaskWorkflowStoreGetDataByTaskID(t *testing.T) {
+	db, mock := setupStoreTestDB(t)
+	store, err := NewTaskWorkflowStore(db)
+	assert.NoError(t, err)
+
+	data := []byte(`{"field":"value"}`)
+
+	mock.ExpectQuery(`SELECT "data" FROM "task_workflow_tasks" WHERE task_id = \$1 ORDER BY "task_workflow_tasks"."task_id" LIMIT \$2`).
+		WithArgs("task-1", 1).
+		WillReturnRows(sqlmock.NewRows([]string{"data"}).AddRow(data))
+
+	got, err := store.GetDataByTaskID("task-1")
+
+	assert.NoError(t, err)
+	assert.JSONEq(t, string(data), string(got))
+	assert.NoError(t, mock.ExpectationsWereMet())
+}
+
 func TestTaskWorkflowStoreGetByMacroWorkflowID(t *testing.T) {
 	db, mock := setupStoreTestDB(t)
 	store, err := NewTaskWorkflowStore(db)
@@ -168,6 +203,7 @@ func TestTaskWorkflowStoreUpdate(t *testing.T) {
 	mock.ExpectBegin()
 	mock.ExpectExec(`UPDATE "task_workflow_tasks" SET`).
 		WithArgs(
+			task.TaskID,
 			task.MacroWorkflowID,
 			task.TaskTemplateID,
 			task.State,
@@ -182,6 +218,42 @@ func TestTaskWorkflowStoreUpdate(t *testing.T) {
 	err = store.Update(task)
 
 	assert.NoError(t, err)
+	assert.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestTaskWorkflowStoreUpdateReturnsNotFoundWhenNoRowsUpdated(t *testing.T) {
+	db, mock := setupStoreTestDB(t)
+	store, err := NewTaskWorkflowStore(db)
+	assert.NoError(t, err)
+
+	task := &TaskWorkflowTask{
+		TaskID:          "missing-task",
+		MacroWorkflowID: "macro-1",
+		TaskTemplateID:  "template-1",
+		State:           plugin.Completed,
+		Data:            json.RawMessage(`{"done":true}`),
+		CreatedAt:       time.Now().UTC(),
+		UpdatedAt:       time.Now().UTC(),
+	}
+
+	mock.ExpectBegin()
+	mock.ExpectExec(`UPDATE "task_workflow_tasks" SET`).
+		WithArgs(
+			task.TaskID,
+			task.MacroWorkflowID,
+			task.TaskTemplateID,
+			task.State,
+			sqlmock.AnyArg(),
+			sqlmock.AnyArg(),
+			sqlmock.AnyArg(),
+			task.TaskID,
+		).
+		WillReturnResult(sqlmock.NewResult(0, 0))
+	mock.ExpectCommit()
+
+	err = store.Update(task)
+
+	assert.True(t, errors.Is(err, gorm.ErrRecordNotFound))
 	assert.NoError(t, mock.ExpectationsWereMet())
 }
 
@@ -235,5 +307,22 @@ func TestTaskWorkflowStoreDelete(t *testing.T) {
 	err = store.Delete("task-1")
 
 	assert.NoError(t, err)
+	assert.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestTaskWorkflowStoreDeleteReturnsNotFoundWhenNoRowsDeleted(t *testing.T) {
+	db, mock := setupStoreTestDB(t)
+	store, err := NewTaskWorkflowStore(db)
+	assert.NoError(t, err)
+
+	mock.ExpectBegin()
+	mock.ExpectExec(`DELETE FROM "task_workflow_tasks" WHERE task_id = \$1`).
+		WithArgs("missing-task").
+		WillReturnResult(sqlmock.NewResult(0, 0))
+	mock.ExpectCommit()
+
+	err = store.Delete("missing-task")
+
+	assert.True(t, errors.Is(err, gorm.ErrRecordNotFound))
 	assert.NoError(t, mock.ExpectationsWereMet())
 }


### PR DESCRIPTION
## Summary

Adds persistence support for task workflow task records, including a full orchestration store and a scoped per-task store for restricted subtask access. This supports issue #395 by giving task workflows a durable place to record task ID, macro workflow ID, task template ID, task state, and render data.

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Other (please describe):

## Changes Made

- Added the `task_workflow_tasks` migration with `task_id`, `macro_workflow_id`, `task_template_id`, `state`, `data`, and timestamps.
- Added `TaskWorkflowTask` and a GORM-backed `TaskWorkflowStore` for lifecycle-level persistence operations.
- Added `TaskScopedStore`, a restricted wrapper bound to one task ID that only exposes state and data reads/writes.
- Added package documentation describing when to use the full store versus the scoped store.
- Added sqlmock-based tests for the full store and mock-backed tests for the scoped store.

## Testing

- [x] I have tested this change locally
- [x] I have added unit tests for new functionality
- [x] I have tested edge cases
- [x] All existing tests pass

Ran:

```sh
go test ./internal/taskworkflow/...
```

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have checked that there are no merge conflicts

## Related Issues

Related to #395

## Screenshots/Demo

Not applicable.

## Additional Notes

The scoped store intentionally wraps the full `Store` interface instead of direct database access. Runtime/orchestration code can hold the full store, while subtasks and render paths can receive only the restricted `TaskScopedStore`.

## Deployment Notes

Run the new database migration before relying on task workflow persistence.
