### PR TITLE
Add Zero-Touch GitOps Release workflow

### DIFF
--- a/.github/workflows/gitops-release.yml
+++ b/.github/workflows/gitops-release.yml
@@ -1,0 +1,166 @@
+name: Zero-Touch GitOps Release
+
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Manual version override (e.g., 1.5.0)'
+        required: false
+
+permissions:
+  contents: read
+  packages: write
+
+env:
+  REGISTRY: ghcr.io
+  GITOPS_REPO: OpenNSW/nsw-gitops 
+
+jobs:
+  # Build and publish all images in parallel
+  build-and-push:
+    name: Build & Push - ${{ matrix.service_name }}
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - service_name: NSW Backend API
+            image_name: nsw-backend
+            context: ./backend
+            dockerfile: ./backend/Dockerfile
+          - service_name: NSW DB Migrations
+            image_name: nsw-api-migrations
+            context: .
+            dockerfile: ./backend/migrations.Dockerfile
+          - service_name: OGA Backend
+            image_name: nsw-oga-backend
+            context: ./oga
+            dockerfile: ./oga/Dockerfile
+          - service_name: Trader Portal
+            image_name: nsw-trader-portal
+            context: ./portals
+            dockerfile: ./portals/apps/trader-app/Dockerfile
+          - service_name: OGA Portal
+            image_name: nsw-oga-portal
+            context: ./portals
+            dockerfile: ./portals/apps/oga-app/Dockerfile
+
+    steps:
+      - name: Checkout Application Repository
+        uses: actions/checkout@v4
+
+      - name: Extract Release Version
+        id: version
+        run: |
+          if [ "${{ github.event_name }}" == "workflow_dispatch" ] && [ -n "${{ github.event.inputs.version }}" ]; then
+            VERSION="${{ github.event.inputs.version }}"
+          else
+            VERSION_TAG="${{ github.event.release.tag_name || github.ref_name }}"
+            VERSION="${VERSION_TAG#v}"
+          fi
+          echo "version=$VERSION" >> $GITHUB_OUTPUT
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and Push Docker Image
+        uses: docker/build-push-action@v6
+        with:
+          context: ${{ matrix.context }}
+          file: ${{ matrix.dockerfile }}
+          push: true
+          tags: |
+            ${{ env.REGISTRY }}/${{ github.repository_owner }}/${{ matrix.image_name }}:${{ steps.version.outputs.version }}
+            ${{ env.REGISTRY }}/${{ github.repository_owner }}/${{ matrix.image_name }}:latest
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+  # The GitOps Bridge (Cross-Repo Commit)
+  update-gitops-state:
+    name: Update ArgoCD Manifests
+    runs-on: ubuntu-latest
+    needs: build-and-push
+    steps:
+      - name: Extract Version
+        id: version
+        run: |
+          if [ "${{ github.event_name }}" == "workflow_dispatch" ] && [ -n "${{ github.event.inputs.version }}" ]; then
+            VERSION="${{ github.event.inputs.version }}"
+          else
+            VERSION_TAG="${{ github.event.release.tag_name || github.ref_name }}"
+            VERSION="${VERSION_TAG#v}"
+          fi
+          echo "version=$VERSION" >> $GITHUB_OUTPUT
+
+      - name: Checkout GitOps Repository
+        uses: actions/checkout@v4
+        with:
+          repository: ${{ env.GITOPS_REPO }}
+          token: ${{ secrets.GITOPS_PAT }}
+          path: gitops-repo
+
+      - name: Update Helm Manifests
+        run: |
+          cd gitops-repo
+          VERSION="${{ steps.version.outputs.version }}"
+          echo "Updating all DEV and STAGING manifests to version: $VERSION"
+
+          # Target the specific files in the nsw-gitops repo
+          MANIFESTS=(
+            "apps/core/nsw-api/dev/values.yaml"
+            "apps/core/nsw-api/staging/values.yaml"
+            "apps/portals/trader-app/dev/values.yaml"
+            "apps/portals/trader-app/staging/values.yaml"
+            "apps/oga-backends/fcau/dev/values.yaml"
+            "apps/oga-backends/fcau/staging/values.yaml"
+            "apps/oga-backends/ird/dev/values.yaml"
+            "apps/oga-backends/ird/staging/values.yaml"
+            "apps/oga-backends/npqs/dev/values.yaml"
+            "apps/oga-backends/npqs/staging/values.yaml"
+            "apps/portals/oga-app/fcau/dev/values.yaml"
+            "apps/portals/oga-app/fcau/staging/values.yaml"
+            "apps/portals/oga-app/ird/dev/values.yaml"
+            "apps/portals/oga-app/ird/staging/values.yaml"
+            "apps/portals/oga-app/npqs/dev/values.yaml"
+            "apps/portals/oga-app/npqs/staging/values.yaml"
+          )
+
+          for FILE in "${MANIFESTS[@]}"; do
+            if [ -f "$FILE" ]; then
+              # Update standard image tag
+              yq eval ".image.tag = \"$VERSION\"" -i "$FILE"
+              
+              # Special Case: Update migration tag for nsw-api
+              if [[ "$FILE" == *"nsw-api"* ]]; then
+                yq eval ".dbMigrations.image.tag = \"$VERSION\"" -i "$FILE"
+              fi
+              
+              echo "Updated $FILE"
+            else
+              echo "⚠️ Skipping $FILE (not found)"
+            fi
+          done
+
+      - name: Commit and Push to GitOps Repo
+        run: |
+          cd gitops-repo
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          
+          if [[ -n "$(git status --porcelain)" ]]; then
+            git add .
+            git commit -m "chore(cd): update dev/staging tags to v${{ steps.version.outputs.version }}"
+            git push origin main
+            echo "Successfully pushed updates to GitOps repository."
+          else
+            echo "No changes detected. Images are already at version ${{ steps.version.outputs.version }}."
+          fi


### PR DESCRIPTION
## Summary
To achieve a true Zero-Touch GitOps Release, we must bridge `nsw` with `nsw-gitops`. Because these are now two separate repositories, the GitHub Action running in `nsw` needs permission to push commits to `nsw-gitops`.

**This PR adds a script to handle the parallel image building and the cross-repository commit**

## VERIFICATION to be done after this is merged to `main` 
1. Go to the **Actions** tab in `nsw` repo
2. Select **Zero-Touch GitOps Release** on the left sidebar.
3. Click the **Run workflow** dropdown on the right.
4. In the **Manual version override** box, type `1.5.0-test`.
5. Click **Run workflow**.
6. Verify: once GitHub Action completes successfully, check in `nsw-gitops` there's a NEW commit authored by the bot, and if we inspect `apps/core/nsw-api/dev/values.yaml`, the `image.tag` will have successfully flipped to `1.5.0-test`

## Type of Change
- [x] New feature (non-breaking change which adds functionality)

## Changes Made
`.github/workflows/gitops-release.yml`
- Parallel Builds: configure a matrix-based build strategy to concurrently build and push five core service images to GHCR:
    - NSW Backend API
    - NSW DB Migrations
    - OGA Backend
    - Trader Portal
    - OGA Portal
- GitOps Integration: add a "Bridge" job that performs a cross-repository commit to the `OpenNSW/nsw-gitops` repository. This auto- updates the `image.tag` values in `dev` and `staging` manifests for all services

## Deployment Notes
The workflow is configured to trigger on published releases but can also be manually invoked via the `workflow_dispatch` event for testing or emergency version overrides
