### PR TITLE
Lowercase repo name in Release Workflow

### DIFF
--- a/.github/workflows/gitops-release.yml
+++ b/.github/workflows/gitops-release.yml
@@ -15,7 +15,7 @@ permissions:
 
 env:
   REGISTRY: ghcr.io
-  GITOPS_REPO: OpenNSW/nsw-gitops 
+  GITOPS_REPO: opennsw/nsw-gitops 
 
 jobs:
   # Build and publish all images in parallel


### PR DESCRIPTION
after https://github.com/OpenNSW/nsw/pull/421, we want to verify bridge between `nsw` and `nsw-gitops`, but build failed with `ERROR: failed to build: invalid tag "ghcr.io/OpenNSW/nsw-backend:1.5.0-test": repository name must be lowercase`

This fixes that, see latest build logs https://github.com/OpenNSW/nsw/actions/runs/25148925702/job/73714732613
