### PR TITLE
Refactor local development scripts

### DIFF
--- a/backend/internal/database/migrations/004_insert_seed_workflow_node_templates.up.sql
+++ b/backend/internal/database/migrations/004_insert_seed_workflow_node_templates.up.sql
@@ -29,6 +29,9 @@ VALUES
             "formId": "11111111-1111-1111-1111-111111111111",
             "submission": {
                 "url": "https://7b0eb5f0-1ee3-4a0c-8946-82a893cb60c2.mock.pstmn.io/api/cusdec",
+                "request": {
+                    "taskCode": "cusdec_submission_v1"
+                },
                 "response": {
                     "display": {
                         "formId": "71e5e73a-ebb2-4750-aaa4-f71087adac43"

--- a/backend/internal/database/migrations/run.sh
+++ b/backend/internal/database/migrations/run.sh
@@ -14,7 +14,9 @@ else
     exit 1
 fi
 
-# Ensure environment variables are set
+CLEAN_RUN="${CLEAN_RUN:-false}"
+
+# Validate required DB environment variables
 for VAR in DB_HOST DB_PORT DB_USERNAME DB_PASSWORD DB_NAME; do
     if [ -z "${!VAR:-}" ]; then
         echo "Error: Required environment variable $VAR is not set."
@@ -30,16 +32,19 @@ FCAU_OGA_SUBMISSION_URL="${FCAU_OGA_SUBMISSION_URL:-http://localhost:8082/api/og
 PRECONSIGNMENT_OGA_SUBMISSION_URL="${PRECONSIGNMENT_OGA_SUBMISSION_URL:-http://localhost:8083/api/oga/inject}"
 CDA_OGA_SUBMISSION_URL="${CDA_OGA_SUBMISSION_URL:-http://localhost:8084/api/oga/inject}"
 
-# Force disconnect other users and drop the database
-# Using the 'postgres' database as a maintenance DB to execute the drop
-echo "Dropping database $DB_NAME..."
-PGPASSWORD=$DB_PASSWORD psql -h "$MIGRATION_DB_HOST" -p "$DB_PORT" -U "$DB_USERNAME" -d postgres -c "DROP DATABASE IF EXISTS $DB_NAME WITH (FORCE);"
+if [[ "$CLEAN_RUN" == "true" ]]; then
+    echo "Dropping database $DB_NAME..."
+    PGPASSWORD=$DB_PASSWORD psql -h "$MIGRATION_DB_HOST" -p "$DB_PORT" -U "$DB_USERNAME" -d postgres \
+        -c "DROP DATABASE IF EXISTS $DB_NAME WITH (FORCE);"
 
-# Recreate the database
-echo "Creating database $DB_NAME..."
-PGPASSWORD=$DB_PASSWORD psql -h "$MIGRATION_DB_HOST" -p "$DB_PORT" -U "$DB_USERNAME" -d postgres -c "CREATE DATABASE $DB_NAME;"
+    echo "Creating database $DB_NAME..."
+    PGPASSWORD=$DB_PASSWORD psql -h "$MIGRATION_DB_HOST" -p "$DB_PORT" -U "$DB_USERNAME" -d postgres \
+        -c "CREATE DATABASE $DB_NAME;"
+else
+    echo "Skipping database drop/recreate. Run with --clean-run to wipe."
+    exit 0
+fi
 
-# Define the file paths
 MIGRATIONS=(
     "001_initial_schema.up.sql"
     "002_insert_seed_hscodes.up.sql"
@@ -67,11 +72,6 @@ for FILE in "${MIGRATIONS[@]}"; do
             -v PRECONSIGNMENT_OGA_SUBMISSION_URL="$PRECONSIGNMENT_OGA_SUBMISSION_URL" \
             -v CDA_OGA_SUBMISSION_URL="$CDA_OGA_SUBMISSION_URL" \
             -h "$MIGRATION_DB_HOST" -p "$DB_PORT" -U "$DB_USERNAME" -d "$DB_NAME" -f "$FILE"
-        
-        if [ $? -ne 0 ]; then
-            echo "Error executing $FILE. Aborting."
-            exit 1
-        fi
     else
         echo "Warning: File $FILE not found, skipping."
     fi

--- a/start-dev.sh
+++ b/start-dev.sh
@@ -6,7 +6,7 @@ ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 ENV_FILE="${ENV_FILE:-$ROOT_DIR/.env}"
 RUN_IDP=true
 RUN_TEMPORAL=true
-RUN_MIGRATIONS=true
+CLEAN_RUN=false
 
 for arg in "$@"; do
   case "$arg" in
@@ -16,15 +16,15 @@ for arg in "$@"; do
     --skip-idp)
       RUN_IDP=false
       ;;
-    --skip-migrations)
-      RUN_MIGRATIONS=false
-      ;;
     --skip-temporal)
       RUN_TEMPORAL=false
       ;;
+    --clean-run)
+      CLEAN_RUN=true
+      ;;
     *)
       echo "Unknown argument: $arg"
-      echo "Usage: ./start-dev.sh [--env-file=/path/to/.env] [--skip-idp] [--skip-migrations] [--skip-temporal]"
+      echo "Usage: ./start-dev.sh [--env-file=/path/to/.env] [--skip-idp] [--skip-temporal] [--clean-run]"
       exit 1
       ;;
   esac
@@ -40,25 +40,17 @@ set -a
 source "$ENV_FILE"
 set +a
 
-for cmd in go pnpm docker; do
+for cmd in go pnpm docker temporal; do
   if ! command -v "$cmd" >/dev/null 2>&1; then
     echo "$cmd is required but was not found in PATH"
     exit 1
   fi
 done
 
-if [[ "$RUN_IDP" == "true" ]]; then
-  echo "Starting IDP..."
-  (
-    cd "$ROOT_DIR/idp"
-    docker compose up -d
-  )
-fi
-
+# Port defaults and env var fallbacks
 IDP_PORT="${IDP_PORT:-8090}"
 BACKEND_PORT="${BACKEND_PORT:-8080}"
 TRADER_APP_PORT="${TRADER_APP_PORT:-5173}"
-# Port Definitions
 OGA_APP_NPQS_PORT="${OGA_APP_NPQS_PORT:-5174}"
 OGA_APP_FCAU_PORT="${OGA_APP_FCAU_PORT:-5175}"
 OGA_APP_IRD_PORT="${OGA_APP_IRD_PORT:-5176}"
@@ -68,34 +60,18 @@ OGA_FCAU_PORT="${OGA_FCAU_PORT:-8082}"
 OGA_IRD_PORT="${OGA_IRD_PORT:-8083}"
 OGA_CDA_PORT="${OGA_CDA_PORT:-8084}"
 
+# Temporal settings with env var fallbacks
+TEMPORAL_HOST="${TEMPORAL_HOST:-localhost}"
+TEMPORAL_PORT="${TEMPORAL_PORT:-7233}"
+TEMPORAL_NAMESPACE="${TEMPORAL_NAMESPACE:-default}"
 
-if [[ "$RUN_MIGRATIONS" == "true" ]]; then
-  echo "Running backend migrations..."
-  (
-    cd "$ROOT_DIR/backend/internal/database/migrations"
-    ENV_FILE="$ENV_FILE" \
-      bash ./run.sh
-  )
-fi
-
-if [[ "$RUN_TEMPORAL" == "true" ]]; then
-  echo "Starting Temporal Workflow Manager..."
-  (
-    cd "$ROOT_DIR/temporal"
-    docker compose up -d
-  )
-fi
-
+# NSW Backednd env vars with defaults and fallbacks
 DB_HOST="${DB_HOST:-localhost}"
 DB_PORT="${DB_PORT:-5432}"
 DB_NAME="${DB_NAME:-nsw_db}"
 DB_USERNAME="${DB_USERNAME:-postgres}"
 DB_PASSWORD="${DB_PASSWORD:-changeme}"
 DB_SSLMODE="${DB_SSLMODE:-disable}"
-
-TEMPORAL_HOST="${TEMPORAL_HOST:-localhost}"
-TEMPORAL_PORT="${TEMPORAL_PORT:-7233}"
-TEMPORAL_NAMESPACE="${TEMPORAL_NAMESPACE:-default}"
 
 SERVER_DEBUG="${SERVER_DEBUG:-true}"
 SERVER_LOG_LEVEL="${SERVER_LOG_LEVEL:-info}"
@@ -107,6 +83,7 @@ AUTH_CLIENT_IDS="${AUTH_CLIENT_IDS:-TRADER_PORTAL_APP,FCAU_TO_NSW,NPQS_TO_NSW,IR
 AUTH_AUDIENCE="${AUTH_AUDIENCE:-NSW_API}"
 AUTH_JWKS_INSECURE_SKIP_VERIFY="${AUTH_JWKS_INSECURE_SKIP_VERIFY:-true}"
 
+# Trader App settings with defaults and fallbacks
 IDP_PUBLIC_URL="${IDP_PUBLIC_URL:-https://localhost:${IDP_PORT}}"
 TRADER_IDP_CLIENT_ID="${TRADER_IDP_CLIENT_ID:-TRADER_PORTAL_APP}"
 NPQS_IDP_CLIENT_ID="${NPQS_IDP_CLIENT_ID:-OGA_PORTAL_APP_NPQS}"
@@ -119,6 +96,7 @@ SHOW_AUTOFILL_BUTTON="${SHOW_AUTOFILL_BUTTON:-true}"
 TRADER_IDP_TRADER_GROUP_NAME="${TRADER_IDP_TRADER_GROUP_NAME:-Traders}"
 TRADER_IDP_CHA_GROUP_NAME="${TRADER_IDP_CHA_GROUP_NAME:-CHA}"
 
+# OGA settings with defaults and fallbacks
 OGA_FORMS_PATH="${OGA_FORMS_PATH:-./data/forms}"
 OGA_DEFAULT_FORM_ID="${OGA_DEFAULT_FORM_ID:-default}"
 OGA_ALLOWED_ORIGINS="${OGA_ALLOWED_ORIGINS:-*}"
@@ -152,6 +130,15 @@ OGA_NSW_TOKEN_URL="${OGA_NSW_TOKEN_URL:-https://localhost:${IDP_PORT}/oauth2/tok
 OGA_NSW_SCOPES="${OGA_NSW_SCOPES:-}"
 OGA_NSW_TOKEN_INSECURE_SKIP_VERIFY="${OGA_NSW_TOKEN_INSECURE_SKIP_VERIFY:-true}"
 
+# OGA instance registry
+# Each row: name | backend_port | db_path | nsw_client_id | nsw_client_secret | app_port | branding_path | idp_client_id | app_name
+OGA_INSTANCES=(
+  "npqs|$OGA_NPQS_PORT|$OGA_NPQS_DB_PATH|$OGA_NSW_NPQS_CLIENT_ID|$OGA_NSW_NPQS_CLIENT_SECRET|$OGA_APP_NPQS_PORT|$OGA_APP_NPQS_BRANDING_PATH|$NPQS_IDP_CLIENT_ID|National Plant Quarantine Service (NPQS)"
+  "fcau|$OGA_FCAU_PORT|$OGA_FCAU_DB_PATH|$OGA_NSW_FCAU_CLIENT_ID|$OGA_NSW_FCAU_CLIENT_SECRET|$OGA_APP_FCAU_PORT|$OGA_APP_FCAU_BRANDING_PATH|$FCAU_IDP_CLIENT_ID|Food Control Administration Unit (FCAU)"
+  "ird|$OGA_IRD_PORT|$OGA_IRD_DB_PATH|$OGA_NSW_IRD_CLIENT_ID|$OGA_NSW_IRD_CLIENT_SECRET|$OGA_APP_IRD_PORT|$OGA_APP_IRD_BRANDING_PATH|$IRD_IDP_CLIENT_ID|Inland Revenue Department (IRD)"
+  "cda|$OGA_CDA_PORT|$OGA_CDA_DB_PATH|$OGA_NSW_CDA_CLIENT_ID|$OGA_NSW_CDA_CLIENT_SECRET|$OGA_APP_CDA_PORT|$OGA_APP_CDA_BRANDING_PATH|$CDA_IDP_CLIENT_ID|Coconut Development Authority (CDA)"
+)
+
 ensure_branding_file() {
   local config_dir="$ROOT_DIR/portals/apps/oga-app/src/configs"
   local file_name="$1"
@@ -168,25 +155,112 @@ EOF
   fi
 }
 
-ensure_branding_file "npqs.yaml" "National Plant Quarantine Service (NPQS)"
-ensure_branding_file "fcau.yaml" "Food Control Administration Unit (FCAU)"
-ensure_branding_file "ird.yaml" "Inland Revenue Department (IRD)"
-ensure_branding_file "cda.yaml" "Coconut Development Authority (CDA)"
+# ---------------------------------------------------------------------------
+# wait_for_temporal: wait until Temporal's gRPC endpoint is fully ready
+# ---------------------------------------------------------------------------
+wait_for_temporal() {
+  local host="$TEMPORAL_HOST"
+  local port="$TEMPORAL_PORT"
+  local retries=30
+  local wait=2
+
+  echo "Waiting for Temporal at $host:$port..."
+
+  for ((i=1; i<=retries; i++)); do
+    if temporal operator cluster health \
+        --address "$host:$port" \
+        --namespace "$TEMPORAL_NAMESPACE" \
+        >/dev/null 2>&1; then
+      echo "Temporal is ready."
+      return 0
+    fi
+    echo "  Temporal not ready yet (attempt $i/$retries), retrying in ${wait}s..."
+    sleep "$wait"
+  done
+
+  echo "Temporal did not become ready in time. Aborting."
+  exit 1
+}
+
+# ---------------------------------------------------------------------------
+# clean_oga_databases: wipe OGA databases before starting backends.
+#   SQLite  -> delete the .db file
+#   Postgres -> drop and recreate the database
+# ---------------------------------------------------------------------------
+clean_oga_databases() {
+  echo "Cleaning OGA databases (driver: $OGA_DB_DRIVER)..."
+
+  if [[ "$OGA_DB_DRIVER" == "sqlite" ]]; then
+    for entry in "${OGA_INSTANCES[@]}"; do
+      IFS='|' read -r name _ db_path _ _ _ _ _ <<< "$entry"
+
+      local resolved_path
+      if [[ "$db_path" == /* ]]; then
+        resolved_path="$db_path"
+      else
+        resolved_path="$ROOT_DIR/oga/${db_path#./}"
+      fi
+
+      if [[ -f "$resolved_path" ]]; then
+        echo "  Deleting SQLite DB for $name: $resolved_path"
+        rm -f "$resolved_path"
+      else
+        echo "  SQLite DB for $name not found (nothing to delete): $resolved_path"
+      fi
+    done
+
+  elif [[ "$OGA_DB_DRIVER" == "postgres" ]]; then
+    if ! command -v psql >/dev/null 2>&1; then
+      echo "psql is required for Postgres DB cleaning but was not found in PATH"
+      exit 1
+    fi
+
+    local psql_opts=(-h "$OGA_DB_HOST" -p "$OGA_DB_PORT" -U "$OGA_DB_USER")
+
+    echo "  Dropping and recreating Postgres database: $OGA_DB_NAME"
+    PGPASSWORD="$OGA_DB_PASSWORD" psql "${psql_opts[@]}" -d postgres -c \
+      "SELECT pg_terminate_backend(pid)
+         FROM pg_stat_activity
+        WHERE datname = '$OGA_DB_NAME'
+          AND pid <> pg_backend_pid();" \
+      >/dev/null
+    PGPASSWORD="$OGA_DB_PASSWORD" psql "${psql_opts[@]}" -d postgres -c "DROP DATABASE IF EXISTS \"$OGA_DB_NAME\";"
+    PGPASSWORD="$OGA_DB_PASSWORD" psql "${psql_opts[@]}" -d postgres -c "CREATE DATABASE \"$OGA_DB_NAME\";"
+
+  else
+    echo "Unknown OGA_DB_DRIVER '$OGA_DB_DRIVER'; skipping OGA DB clean."
+  fi
+}
+
+# ---------------------------------------------------------------------------
+# MAIN SCRIPT
+# ---------------------------------------------------------------------------
 
 pids=()
-names=()
 
 cleanup() {
-  local code=$?
+  # Ctrl+C: stop processes and containers, but destroy nothing
+  echo
+  echo "Stopping services..."
+
   if [[ ${#pids[@]} -gt 0 ]]; then
-    echo
-    echo "Stopping services..."
     for pid in "${pids[@]}"; do
       kill "$pid" >/dev/null 2>&1 || true
     done
     wait >/dev/null 2>&1 || true
   fi
-  exit "$code"
+
+  if [[ "$RUN_IDP" == "true" ]]; then
+    echo "Stopping IDP containers..."
+    docker compose -f "$ROOT_DIR/idp/docker-compose.yml" stop
+  fi
+
+  if [[ "$RUN_TEMPORAL" == "true" ]]; then
+    echo "Stopping Temporal containers..."
+    docker compose -f "$ROOT_DIR/temporal/docker-compose.yml" stop
+  fi
+
+  exit 0
 }
 
 trap cleanup INT TERM
@@ -202,10 +276,108 @@ start_service() {
   ) &
 
   pids+=("$!")
-  names+=("$name")
 }
 
-echo "Starting local development services (non-Docker)..."
+# ---------------------------------------------------------------------------
+# CLEAN RUN: wipe everything, recreate, migrate — then start services
+# ---------------------------------------------------------------------------
+if [[ "$CLEAN_RUN" == "true" ]]; then
+  echo "Clean run: wiping Docker volumes and databases..."
+
+  if [[ "$RUN_IDP" == "true" ]]; then
+    echo "Removing IDP containers and volumes..."
+    docker compose -f "$ROOT_DIR/idp/docker-compose.yml" down --volumes
+  fi
+
+  if [[ "$RUN_TEMPORAL" == "true" ]]; then
+    echo "Removing Temporal containers and volumes..."
+    docker compose -f "$ROOT_DIR/temporal/docker-compose.yml" down --volumes
+  fi
+
+  clean_oga_databases
+
+  echo "Running backend migrations..."
+  (
+    cd "$ROOT_DIR/backend/internal/database/migrations"
+    ENV_FILE="$ENV_FILE" \
+    CLEAN_RUN="$CLEAN_RUN" \
+      bash ./run.sh
+  )
+fi
+
+# ---------------------------------------------------------------------------
+# START DOCKER SERVICES
+# ---------------------------------------------------------------------------
+if [[ "$RUN_IDP" == "true" ]]; then
+  echo "Starting IDP..."
+  docker compose -f "$ROOT_DIR/idp/docker-compose.yml" up -d
+fi
+
+if [[ "$RUN_TEMPORAL" == "true" ]]; then
+  echo "Starting Temporal..."
+  docker compose -f "$ROOT_DIR/temporal/docker-compose.yml" up -d
+fi
+
+# ---------------------------------------------------------------------------
+# START NON-DOCKER SERVICES
+# ---------------------------------------------------------------------------
+echo "Starting local development services..."
+
+# OGA backends and frontends can start immediately — no Temporal dependency
+for entry in "${OGA_INSTANCES[@]}"; do
+  IFS='|' read -r name port db_path nsw_client_id nsw_client_secret app_port branding_path idp_client_id app_name<<< "$entry"
+
+  start_service "oga-${name}" "$ROOT_DIR/oga" env \
+    OGA_PORT="$port" \
+    OGA_DB_DRIVER="$OGA_DB_DRIVER" \
+    OGA_DB_PATH="$db_path" \
+    OGA_DB_HOST="$OGA_DB_HOST" \
+    OGA_DB_PORT="$OGA_DB_PORT" \
+    OGA_DB_USER="$OGA_DB_USER" \
+    OGA_DB_PASSWORD="$OGA_DB_PASSWORD" \
+    OGA_DB_NAME="$OGA_DB_NAME" \
+    OGA_DB_SSLMODE="$OGA_DB_SSLMODE" \
+    OGA_FORMS_PATH="$OGA_FORMS_PATH" \
+    OGA_DEFAULT_FORM_ID="$OGA_DEFAULT_FORM_ID" \
+    OGA_ALLOWED_ORIGINS="$OGA_ALLOWED_ORIGINS" \
+    OGA_NSW_API_BASE_URL="http://localhost:${BACKEND_PORT}/api/v1" \
+    OGA_NSW_CLIENT_ID="$nsw_client_id" \
+    OGA_NSW_CLIENT_SECRET="$nsw_client_secret" \
+    OGA_NSW_TOKEN_URL="$OGA_NSW_TOKEN_URL" \
+    OGA_NSW_SCOPES="$OGA_NSW_SCOPES" \
+    OGA_NSW_TOKEN_INSECURE_SKIP_VERIFY="$OGA_NSW_TOKEN_INSECURE_SKIP_VERIFY" \
+    go run ./cmd/server
+
+  ensure_branding_file "$name.yaml" "${app_name}"
+
+  start_service "oga-app-${name}" "$ROOT_DIR/portals/apps/oga-app" env \
+    VITE_PORT="$app_port" \
+    VITE_BRANDING_PATH="$branding_path" \
+    VITE_API_BASE_URL="http://localhost:${port}" \
+    VITE_IDP_BASE_URL="$IDP_PUBLIC_URL" \
+    VITE_IDP_CLIENT_ID="$idp_client_id" \
+    VITE_APP_URL="http://localhost:${app_port}" \
+    VITE_IDP_SCOPES="$IDP_SCOPES" \
+    VITE_IDP_PLATFORM="$IDP_PLATFORM" \
+    pnpm run dev
+done
+
+start_service "trader-app" "$ROOT_DIR/portals/apps/trader-app" env \
+  VITE_API_BASE_URL="http://localhost:${BACKEND_PORT}/api/v1" \
+  VITE_IDP_BASE_URL="$IDP_PUBLIC_URL" \
+  VITE_IDP_CLIENT_ID="$TRADER_IDP_CLIENT_ID" \
+  VITE_APP_URL="http://localhost:${TRADER_APP_PORT}" \
+  VITE_IDP_SCOPES="$IDP_SCOPES" \
+  VITE_IDP_PLATFORM="$IDP_PLATFORM" \
+  VITE_IDP_TRADER_GROUP_NAME="$TRADER_IDP_TRADER_GROUP_NAME" \
+  VITE_IDP_CHA_GROUP_NAME="$TRADER_IDP_CHA_GROUP_NAME" \
+  VITE_SHOW_AUTOFILL_BUTTON="$SHOW_AUTOFILL_BUTTON" \
+  pnpm run dev -- --port "$TRADER_APP_PORT"
+
+# Backend must wait for Temporal before starting
+if [[ "$RUN_TEMPORAL" == "true" ]]; then
+  wait_for_temporal
+fi
 
 start_service "backend" "$ROOT_DIR/backend" env \
   DB_HOST="$DB_HOST" \
@@ -228,71 +400,7 @@ start_service "backend" "$ROOT_DIR/backend" env \
   AUTH_JWKS_INSECURE_SKIP_VERIFY="$AUTH_JWKS_INSECURE_SKIP_VERIFY" \
   go run ./cmd/server/main.go
 
-# OGA instance registry
-# Each row: name | backend_port | db_path | nsw_client_id | nsw_client_secret | app_port | branding_path | idp_client_id
-OGA_INSTANCES=(
-  "npqs|$OGA_NPQS_PORT|$OGA_NPQS_DB_PATH|$OGA_NSW_NPQS_CLIENT_ID|$OGA_NSW_NPQS_CLIENT_SECRET|$OGA_APP_NPQS_PORT|$OGA_APP_NPQS_BRANDING_PATH|$NPQS_IDP_CLIENT_ID"
-  "fcau|$OGA_FCAU_PORT|$OGA_FCAU_DB_PATH|$OGA_NSW_FCAU_CLIENT_ID|$OGA_NSW_FCAU_CLIENT_SECRET|$OGA_APP_FCAU_PORT|$OGA_APP_FCAU_BRANDING_PATH|$FCAU_IDP_CLIENT_ID"
-  "ird|$OGA_IRD_PORT|$OGA_IRD_DB_PATH|$OGA_NSW_IRD_CLIENT_ID|$OGA_NSW_IRD_CLIENT_SECRET|$OGA_APP_IRD_PORT|$OGA_APP_IRD_BRANDING_PATH|$IRD_IDP_CLIENT_ID"
-  "cda|$OGA_CDA_PORT|$OGA_CDA_DB_PATH|$OGA_NSW_CDA_CLIENT_ID|$OGA_NSW_CDA_CLIENT_SECRET|$OGA_APP_CDA_PORT|$OGA_APP_CDA_BRANDING_PATH|$CDA_IDP_CLIENT_ID"
-)
-
-# Launch OGA backends
-for entry in "${OGA_INSTANCES[@]}"; do
-  IFS='|' read -r name port db_path nsw_client_id nsw_client_secret app_port branding_path idp_client_id <<< "$entry"
-
-  start_service "oga-${name}" "$ROOT_DIR/oga" env \
-    OGA_PORT="$port" \
-    OGA_DB_DRIVER="$OGA_DB_DRIVER" \
-    OGA_DB_PATH="$db_path" \
-    OGA_DB_HOST="$OGA_DB_HOST" \
-    OGA_DB_PORT="$OGA_DB_PORT" \
-    OGA_DB_USER="$OGA_DB_USER" \
-    OGA_DB_PASSWORD="$OGA_DB_PASSWORD" \
-    OGA_DB_NAME="$OGA_DB_NAME" \
-    OGA_DB_SSLMODE="$OGA_DB_SSLMODE" \
-    OGA_FORMS_PATH="$OGA_FORMS_PATH" \
-    OGA_DEFAULT_FORM_ID="$OGA_DEFAULT_FORM_ID" \
-    OGA_ALLOWED_ORIGINS="$OGA_ALLOWED_ORIGINS" \
-    OGA_NSW_API_BASE_URL="http://localhost:${BACKEND_PORT}/api/v1" \
-    OGA_NSW_CLIENT_ID="$nsw_client_id" \
-    OGA_NSW_CLIENT_SECRET="$nsw_client_secret" \
-    OGA_NSW_TOKEN_URL="$OGA_NSW_TOKEN_URL" \
-    OGA_NSW_SCOPES="$OGA_NSW_SCOPES" \
-    OGA_NSW_TOKEN_INSECURE_SKIP_VERIFY="$OGA_NSW_TOKEN_INSECURE_SKIP_VERIFY" \
-    go run ./cmd/server
-done
-
-# Trader portal
-start_service "trader-app" "$ROOT_DIR/portals/apps/trader-app" env \
-  VITE_API_BASE_URL="http://localhost:${BACKEND_PORT}/api/v1" \
-  VITE_IDP_BASE_URL="$IDP_PUBLIC_URL" \
-  VITE_IDP_CLIENT_ID="$TRADER_IDP_CLIENT_ID" \
-  VITE_APP_URL="http://localhost:${TRADER_APP_PORT}" \
-  VITE_IDP_SCOPES="$IDP_SCOPES" \
-  VITE_IDP_PLATFORM="$IDP_PLATFORM" \
-  VITE_IDP_TRADER_GROUP_NAME="$TRADER_IDP_TRADER_GROUP_NAME" \
-  VITE_IDP_CHA_GROUP_NAME="$TRADER_IDP_CHA_GROUP_NAME" \
-  VITE_SHOW_AUTOFILL_BUTTON="$SHOW_AUTOFILL_BUTTON" \
-  pnpm run dev -- --port "$TRADER_APP_PORT"
-
-# Launch OGA portals
-for entry in "${OGA_INSTANCES[@]}"; do
-  IFS='|' read -r name port db_path nsw_client_id nsw_client_secret app_port branding_path idp_client_id <<< "$entry"
-
-  start_service "oga-app-${name}" "$ROOT_DIR/portals/apps/oga-app" env \
-    VITE_PORT="$app_port" \
-    VITE_BRANDING_PATH="$branding_path" \
-    VITE_API_BASE_URL="http://localhost:${port}" \
-    VITE_IDP_BASE_URL="$IDP_PUBLIC_URL" \
-    VITE_IDP_CLIENT_ID="$idp_client_id" \
-    VITE_APP_URL="http://localhost:${app_port}" \
-    VITE_IDP_SCOPES="$IDP_SCOPES" \
-    VITE_IDP_PLATFORM="$IDP_PLATFORM" \
-    pnpm run dev
-done
-
-# Status banner (generated from registry)
+# Status banner
 {
   echo
   echo "Started local services:"
@@ -304,10 +412,11 @@ done
     printf "  - oga-app-%-5s -> http://localhost:%s\n" "$name" "$app_port"
   done
   echo
-  echo "IDP start: $RUN_IDP"
-  echo "Migrations run: $RUN_MIGRATIONS"
+  echo "IDP running:      $RUN_IDP"
+  echo "Temporal running: $RUN_TEMPORAL"
+  echo "Clean run:        $CLEAN_RUN"
   echo
-  echo "Press Ctrl+C to stop all services started by this script."
+  echo "Press Ctrl+C to stop all services."
 }
 
 wait


### PR DESCRIPTION
## Summary

Refactors the local development startup script (`start-dev.sh`) and backend migration script (`run.sh`) to be safer, more predictable, and easier to use. The key philosophy change is **conservative by default** — running `./start-dev.sh` without any flags now preserves all existing data and simply starts services. A new `--clean-run` flag provides an explicit opt-in for a full environment reset.

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [x] Refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Other (please describe):

## Changes Made

**`start-dev.sh`**
- Replaced `--skip-clean-db`, `--skip-migrations`, and related destructive-by-default flags with a single `--clean-run` opt-in flag
- `--clean-run` performs a full reset in strict order: remove Docker volumes/containers → drop and recreate databases → run migrations → start services
- Default run (no flags) starts all services without touching any data
- `Ctrl+C` now correctly stops Docker containers (`docker compose stop`) without removing them or their volumes — previously containers were not stopped at all since they ran detached
- NSW backend now waits for Temporal to be fully ready (via `temporal operator cluster health`) before starting, preventing gRPC connection errors on startup
- OGA backends, OGA portals, and the trader portal start in parallel while the backend waits for Temporal
- Docker Compose commands use explicit `-f` paths in `cleanup()` to avoid working-directory issues during signal handling
- Added `temporal` to the required-command pre-flight check
- Moved `OGA_INSTANCES` registry definition earlier in the file so it is available to all functions

**`run.sh`**
- Migrations and DB drop/recreate are now gated on `CLEAN_RUN=true`, passed in as an environment variable from `start-dev.sh`
- When `CLEAN_RUN=false` (default), `run.sh` exits early without touching the database
- Removed redundant `$? -ne 0` error check — already covered by `set -euo pipefail`
- Script remains fully usable standalone; defaults to `CLEAN_RUN=false` when called directly

## Behaviour Summary

| **Action** | `./start-dev.sh` | `./start-dev.sh --clean-run` | `Ctrl+C` |
|---|---|---|---|
| Docker volumes | Preserved | Wiped + Recreated | Preserved |
| Backend DB | Preserved | Dropped + Recreated | Preserved |
| OGA DBs (SQLite/Postgres) | Preserved | Wiped + Recreated | Preserved |
| DB Migrations | Skipped | Run | — |
| Docker Containers (Temporal + IdP) | Started | Started | Stopped |
| NSW Backend | Started After Temporal Ready | Started After Temporal Ready | Stopped |
| Other Services + Frontend | Started | Started | Stopped |

## Testing

- [x] I have tested this change locally
- [ ] I have added unit tests for new functionality
- [x] I have tested edge cases
- [x] All existing tests pass

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have checked that there are no merge conflicts

## Additional Notes

- The `temporal` CLI is now a required dev dependency for the health check. Install via `brew install temporal` (macOS) or from the [Temporal CLI releases page](https://github.com/temporalio/cli/releases).
- For Postgres OGA driver, `psql` must be available in PATH when running `--clean-run`.
- `--skip-idp` and `--skip-temporal` flags are retained for day-to-day use when Docker services are already running.