### PR TITLE
[FEAT]: Add native PowerShell support for Windows development environment

### DIFF
--- a/backend/internal/database/migrations/run.ps1
+++ b/backend/internal/database/migrations/run.ps1
@@ -40,31 +40,22 @@ if ($CLEAN_RUN -eq "true") {
     $env:PGPASSWORD = $env:DB_PASSWORD
 
     # Force disconnect other users and drop the database
-    Write-Host "Dropping database $($env:DB_NAME)..."
-    & psql -h "$MigrationDbHost" -p "$($env:DB_PORT)" -U "$($env:DB_USERNAME)" -d postgres -c "DROP DATABASE IF EXISTS $($env:DB_NAME) WITH (FORCE);"
+    Write-Host "Dropping database `"$($env:DB_NAME)`"..."
+    & psql -h "$MigrationDbHost" -p "$($env:DB_PORT)" -U "$($env:DB_USERNAME)" -d postgres -c "DROP DATABASE IF EXISTS `"$($env:DB_NAME)`" WITH (FORCE);"
 
     # Recreate the database
-    Write-Host "Creating database $($env:DB_NAME)..."
-    & psql -h "$MigrationDbHost" -p "$($env:DB_PORT)" -U "$($env:DB_USERNAME)" -d postgres -c "CREATE DATABASE $($env:DB_NAME);"
+    Write-Host "Creating database `"$($env:DB_NAME)`"..."
+    & psql -h "$MigrationDbHost" -p "$($env:DB_PORT)" -U "$($env:DB_USERNAME)" -d postgres -c "CREATE DATABASE `"$($env:DB_NAME)`";"
 } else {
-    Write-Host "Skipping database drop/recreate. Run with --clean-run to wipe."
-    exit 0
+    Write-Host "Skipping database drop/recreate (Incremental Migration mode)."
 }
 
-# Define the file paths
-$Migrations = @(
-    "001_initial_schema.up.sql",
-    "002_insert_seed_hscodes.up.sql",
-    "003_insert_seed_form_templates.up.sql",
-    "004_insert_seed_workflow_node_templates.up.sql",
-    "005_insert_seed_workflow_templates.up.sql",
-    "006_insert_seed_workflow_hscode_map.up.sql",
-    "007_insert_seed_pre_consignment_template.up.sql",
-    "008_insert_payment_transactions.up.sql",
-    "009_insert_cha_entity.up.sql",
-    "010_workflow_table.up.sql",
-    "011_workflow_tem_v2.up.sql"
-)
+# Dynamically discover migration files
+$Migrations = Get-ChildItem -Path $PSScriptRoot -Filter "*.up.sql" | Sort-Object Name | Select-Object -ExpandProperty Name
+
+if ($null -eq $Migrations -or $Migrations.Count -eq 0) {
+    Write-Warning "No migration files (*.up.sql) found in $PSScriptRoot"
+}
 
 Write-Host "Starting database migrations..."
 

--- a/backend/internal/database/migrations/run.ps1
+++ b/backend/internal/database/migrations/run.ps1
@@ -1,0 +1,93 @@
+# Load environment variables from env file
+# Default: backend/.env
+$EnvFilePath = if ($env:ENV_FILE) { $env:ENV_FILE } else { Join-Path $PSScriptRoot "../../../.env" }
+
+if (Test-Path $EnvFilePath) {
+    Write-Host "Loading environment variables from $EnvFilePath"
+    Get-Content $EnvFilePath | ForEach-Object {
+        if ($_ -match '^([^#\s][^=]+)=(.*)$') {
+            $name = $matches[1].Trim()
+            $value = $matches[2].Trim().Trim('"').Trim("'")
+            Set-Item "env:$name" $value
+        }
+    }
+} else {
+    Write-Error "Error: env file not found: $EnvFilePath"
+    exit 1
+}
+
+$CLEAN_RUN = if ($env:CLEAN_RUN) { $env:CLEAN_RUN } else { "false" }
+
+# Ensure environment variables are set
+$RequiredVars = @("DB_HOST", "DB_PORT", "DB_USERNAME", "DB_PASSWORD", "DB_NAME")
+foreach ($Var in $RequiredVars) {
+    if (-not (Get-ChildItem Env:$Var -ErrorAction SilentlyContinue)) {
+        Write-Error "Error: Required environment variable $Var is not set."
+        exit 1
+    }
+}
+
+$MigrationDbHost = if ($env:MIGRATION_DB_HOST) { $env:MIGRATION_DB_HOST } else { $env:DB_HOST }
+$MigrationDbHost = $MigrationDbHost -replace "host.docker.internal", "localhost"
+
+$NpqsOgaSubmissionUrl = if ($env:NPQS_OGA_SUBMISSION_URL) { $env:NPQS_OGA_SUBMISSION_URL } else { "http://localhost:8081/api/oga/inject" }
+$FcauOgaSubmissionUrl = if ($env:FCAU_OGA_SUBMISSION_URL) { $env:FCAU_OGA_SUBMISSION_URL } else { "http://localhost:8082/api/oga/inject" }
+$PreconsignmentOgaSubmissionUrl = if ($env:PRECONSIGNMENT_OGA_SUBMISSION_URL) { $env:PRECONSIGNMENT_OGA_SUBMISSION_URL } else { "http://localhost:8083/api/oga/inject" }
+$CdaOgaSubmissionUrl = if ($env:CDA_OGA_SUBMISSION_URL) { $env:CDA_OGA_SUBMISSION_URL } else { "http://localhost:8084/api/oga/inject" }
+
+if ($CLEAN_RUN -eq "true") {
+    # Set PGPASSWORD for psql
+    $env:PGPASSWORD = $env:DB_PASSWORD
+
+    # Force disconnect other users and drop the database
+    Write-Host "Dropping database $($env:DB_NAME)..."
+    & psql -h "$MigrationDbHost" -p "$($env:DB_PORT)" -U "$($env:DB_USERNAME)" -d postgres -c "DROP DATABASE IF EXISTS $($env:DB_NAME) WITH (FORCE);"
+
+    # Recreate the database
+    Write-Host "Creating database $($env:DB_NAME)..."
+    & psql -h "$MigrationDbHost" -p "$($env:DB_PORT)" -U "$($env:DB_USERNAME)" -d postgres -c "CREATE DATABASE $($env:DB_NAME);"
+} else {
+    Write-Host "Skipping database drop/recreate. Run with --clean-run to wipe."
+    exit 0
+}
+
+# Define the file paths
+$Migrations = @(
+    "001_initial_schema.up.sql",
+    "002_insert_seed_hscodes.up.sql",
+    "003_insert_seed_form_templates.up.sql",
+    "004_insert_seed_workflow_node_templates.up.sql",
+    "005_insert_seed_workflow_templates.up.sql",
+    "006_insert_seed_workflow_hscode_map.up.sql",
+    "007_insert_seed_pre_consignment_template.up.sql",
+    "008_insert_payment_transactions.up.sql",
+    "009_insert_cha_entity.up.sql",
+    "010_workflow_table.up.sql",
+    "011_workflow_tem_v2.up.sql"
+)
+
+Write-Host "Starting database migrations..."
+
+# Loop through and execute each file
+foreach ($File in $Migrations) {
+    $FilePath = Join-Path $PSScriptRoot $File
+    if (Test-Path $FilePath) {
+        Write-Host "Executing: $File"
+        & psql `
+            -v ON_ERROR_STOP=1 `
+            -v NPQS_OGA_SUBMISSION_URL="$NpqsOgaSubmissionUrl" `
+            -v FCAU_OGA_SUBMISSION_URL="$FcauOgaSubmissionUrl" `
+            -v PRECONSIGNMENT_OGA_SUBMISSION_URL="$PreconsignmentOgaSubmissionUrl" `
+            -v CDA_OGA_SUBMISSION_URL="$CdaOgaSubmissionUrl" `
+            -h "$MigrationDbHost" -p "$($env:DB_PORT)" -U "$($env:DB_USERNAME)" -d "$($env:DB_NAME)" -f "$FilePath"
+        
+        if ($LASTEXITCODE -ne 0) {
+            Write-Error "Error executing $File. Aborting."
+            exit 1
+        }
+    } else {
+        Write-Warning "Warning: File $File not found, skipping."
+    }
+}
+
+Write-Host "Migrations completed successfully."

--- a/backend/internal/database/migrations/run.ps1
+++ b/backend/internal/database/migrations/run.ps1
@@ -1,3 +1,8 @@
+param(
+    [switch]${clean-run},
+    [switch]${migrations}
+)
+
 # Load environment variables from env file
 # Default: backend/.env
 $EnvFilePath = if ($env:ENV_FILE) { $env:ENV_FILE } else { Join-Path $PSScriptRoot "../../../.env" }
@@ -16,8 +21,6 @@ if (Test-Path $EnvFilePath) {
     exit 1
 }
 
-$CLEAN_RUN = if ($env:CLEAN_RUN) { $env:CLEAN_RUN } else { "false" }
-
 # Ensure environment variables are set
 $RequiredVars = @("DB_HOST", "DB_PORT", "DB_USERNAME", "DB_PASSWORD", "DB_NAME")
 foreach ($Var in $RequiredVars) {
@@ -35,7 +38,8 @@ $FcauOgaSubmissionUrl = if ($env:FCAU_OGA_SUBMISSION_URL) { $env:FCAU_OGA_SUBMIS
 $PreconsignmentOgaSubmissionUrl = if ($env:PRECONSIGNMENT_OGA_SUBMISSION_URL) { $env:PRECONSIGNMENT_OGA_SUBMISSION_URL } else { "http://localhost:8083/api/oga/inject" }
 $CdaOgaSubmissionUrl = if ($env:CDA_OGA_SUBMISSION_URL) { $env:CDA_OGA_SUBMISSION_URL } else { "http://localhost:8084/api/oga/inject" }
 
-if ($CLEAN_RUN -eq "true") {
+# Handle Clean Run
+if (${clean-run}) {
     # Set PGPASSWORD for psql
     $env:PGPASSWORD = $env:DB_PASSWORD
 
@@ -46,39 +50,49 @@ if ($CLEAN_RUN -eq "true") {
     # Recreate the database
     Write-Host "Creating database `"$($env:DB_NAME)`"..."
     & psql -h "$MigrationDbHost" -p "$($env:DB_PORT)" -U "$($env:DB_USERNAME)" -d postgres -c "CREATE DATABASE `"$($env:DB_NAME)`";"
-} else {
-    Write-Host "Skipping database drop/recreate. Run with -clean-run to wipe."
-    exit 0
 }
 
 # Dynamically discover migration files
-$Migrations = Get-ChildItem -Path $PSScriptRoot -Filter "*.up.sql" | Sort-Object Name | Select-Object -ExpandProperty Name
+$AllMigrations = Get-ChildItem -Path $PSScriptRoot -Filter "*.up.sql" | Sort-Object Name
 
-if ($null -eq $Migrations -or $Migrations.Count -eq 0) {
-    Write-Warning "No migration files (*.up.sql) found in $PSScriptRoot"
+$MigrationsToRun = @()
+if (${clean-run}) {
+    $MigrationsToRun = $AllMigrations
+} elseif (${migrations}) {
+    $Prefix = Read-Host "Enter the migration prefix to start from (e.g., 013)"
+    if ([string]::IsNullOrWhiteSpace($Prefix)) {
+        Write-Error "Migration prefix is required when using -migrations."
+        exit 1
+    }
+    
+    # Filter files starting from the prefix
+    $MigrationsToRun = $AllMigrations | Where-Object { $_.Name -ge $Prefix }
+    
+    if ($null -eq $MigrationsToRun -or $MigrationsToRun.Count -eq 0) {
+        Write-Warning "No migration files found matching or following prefix: $Prefix"
+        exit 0
+    }
 }
+
+Write-Host "Selected $($MigrationsToRun.Count) migration(s) to execute."
 
 Write-Host "Starting database migrations..."
 
 # Loop through and execute each file
-foreach ($File in $Migrations) {
-    $FilePath = Join-Path $PSScriptRoot $File
-    if (Test-Path $FilePath) {
-        Write-Host "Executing: $File"
-        & psql `
-            -v ON_ERROR_STOP=1 `
-            -v NPQS_OGA_SUBMISSION_URL="$NpqsOgaSubmissionUrl" `
-            -v FCAU_OGA_SUBMISSION_URL="$FcauOgaSubmissionUrl" `
-            -v PRECONSIGNMENT_OGA_SUBMISSION_URL="$PreconsignmentOgaSubmissionUrl" `
-            -v CDA_OGA_SUBMISSION_URL="$CdaOgaSubmissionUrl" `
-            -h "$MigrationDbHost" -p "$($env:DB_PORT)" -U "$($env:DB_USERNAME)" -d "$($env:DB_NAME)" -f "$FilePath"
-        
-        if ($LASTEXITCODE -ne 0) {
-            Write-Error "Error executing $File. Aborting."
-            exit 1
-        }
-    } else {
-        Write-Warning "Warning: File $File not found, skipping."
+foreach ($File in $MigrationsToRun) {
+    $FilePath = $File.FullName
+    Write-Host "Executing: $($File.Name)"
+    & psql `
+        -v ON_ERROR_STOP=1 `
+        -v NPQS_OGA_SUBMISSION_URL="$NpqsOgaSubmissionUrl" `
+        -v FCAU_OGA_SUBMISSION_URL="$FcauOgaSubmissionUrl" `
+        -v PRECONSIGNMENT_OGA_SUBMISSION_URL="$PreconsignmentOgaSubmissionUrl" `
+        -v CDA_OGA_SUBMISSION_URL="$CdaOgaSubmissionUrl" `
+        -h "$MigrationDbHost" -p "$($env:DB_PORT)" -U "$($env:DB_USERNAME)" -d "$($env:DB_NAME)" -f "$FilePath"
+    
+    if ($LASTEXITCODE -ne 0) {
+        Write-Error "Error executing $($File.Name). Aborting."
+        exit 1
     }
 }
 

--- a/backend/internal/database/migrations/run.ps1
+++ b/backend/internal/database/migrations/run.ps1
@@ -47,7 +47,8 @@ if ($CLEAN_RUN -eq "true") {
     Write-Host "Creating database `"$($env:DB_NAME)`"..."
     & psql -h "$MigrationDbHost" -p "$($env:DB_PORT)" -U "$($env:DB_USERNAME)" -d postgres -c "CREATE DATABASE `"$($env:DB_NAME)`";"
 } else {
-    Write-Host "Skipping database drop/recreate (Incremental Migration mode)."
+    Write-Host "Skipping database drop/recreate. Run with -clean-run to wipe."
+    exit 0
 }
 
 # Dynamically discover migration files

--- a/idp/01-default-resources.sh
+++ b/idp/01-default-resources.sh
@@ -1,3 +1,5 @@
+#!/bin/bash
+
 set -e
 
 # Parse command line arguments for custom redirect URIs

--- a/idp/02-sample-resources.sh
+++ b/idp/02-sample-resources.sh
@@ -1,3 +1,5 @@
+#!/bin/bash
+
 set -e
 
 # Source common functions from the same directory as this script

--- a/start-dev.ps1
+++ b/start-dev.ps1
@@ -1,0 +1,386 @@
+param(
+    [string]$EnvFile = "",
+    [switch]$SkipIdp,
+    [switch]$SkipTemporal,
+    [switch]$CleanRun
+)
+
+$ROOT_DIR = $PSScriptRoot
+if (-not $EnvFile) {
+    $EnvFile = Join-Path $ROOT_DIR ".env"
+}
+
+$RUN_IDP = -not $SkipIdp
+$RUN_TEMPORAL = -not $SkipTemporal
+$CLEAN_RUN = if ($CleanRun) { "true" } else { "false" }
+
+if (-not (Test-Path $EnvFile)) {
+    Write-Host "Env file not found: $EnvFile"
+    Write-Host "Create one from: cp $ROOT_DIR\.env.example $ROOT_DIR\.env"
+    exit 1
+}
+
+# Load environment variables
+Write-Host "Loading environment variables from $EnvFile..."
+Get-Content $EnvFile | ForEach-Object {
+    if ($_ -match '^([^#\s][^=]+)=(.*)$') {
+        $name = $matches[1].Trim()
+        $value = $matches[2].Trim().Trim('"').Trim("'")
+        Set-Item "env:$name" $value
+    }
+}
+
+# Check dependencies
+$Dependencies = @("go", "pnpm", "docker", "temporal")
+foreach ($cmd in $Dependencies) {
+    if (-not (Get-Command $cmd -ErrorAction SilentlyContinue)) {
+        Write-Error "$cmd is required but was not found in PATH"
+        exit 1
+    }
+}
+
+# Port Definitions (with defaults)
+$IDP_PORT = if ($env:IDP_PORT) { $env:IDP_PORT } else { "8090" }
+$BACKEND_PORT = if ($env:BACKEND_PORT) { $env:BACKEND_PORT } else { "8080" }
+$TRADER_APP_PORT = if ($env:TRADER_APP_PORT) { $env:TRADER_APP_PORT } else { "5173" }
+$OGA_APP_NPQS_PORT = if ($env:OGA_APP_NPQS_PORT) { $env:OGA_APP_NPQS_PORT } else { "5174" }
+$OGA_APP_FCAU_PORT = if ($env:OGA_APP_FCAU_PORT) { $env:OGA_APP_FCAU_PORT } else { "5175" }
+$OGA_APP_IRD_PORT = if ($env:OGA_APP_IRD_PORT) { $env:OGA_APP_IRD_PORT } else { "5176" }
+$OGA_APP_CDA_PORT = if ($env:OGA_APP_CDA_PORT) { $env:OGA_APP_CDA_PORT } else { "5177" }
+$OGA_NPQS_PORT = if ($env:OGA_NPQS_PORT) { $env:OGA_NPQS_PORT } else { "8081" }
+$OGA_FCAU_PORT = if ($env:OGA_FCAU_PORT) { $env:OGA_FCAU_PORT } else { "8082" }
+$OGA_IRD_PORT = if ($env:OGA_IRD_PORT) { $env:OGA_IRD_PORT } else { "8083" }
+$OGA_CDA_PORT = if ($env:OGA_CDA_PORT) { $env:OGA_CDA_PORT } else { "8084" }
+
+# Temporal settings
+$TEMPORAL_HOST = if ($env:TEMPORAL_HOST) { $env:TEMPORAL_HOST } else { "localhost" }
+$TEMPORAL_PORT = if ($env:TEMPORAL_PORT) { $env:TEMPORAL_PORT } else { "7233" }
+$TEMPORAL_NAMESPACE = if ($env:TEMPORAL_NAMESPACE) { $env:TEMPORAL_NAMESPACE } else { "default" }
+
+# Service Environment Variables
+$DB_HOST = if ($env:DB_HOST) { $env:DB_HOST } else { "localhost" }
+$DB_PORT = if ($env:DB_PORT) { $env:DB_PORT } else { "5432" }
+$DB_NAME = if ($env:DB_NAME) { $env:DB_NAME } else { "nsw_db" }
+$DB_USERNAME = if ($env:DB_USERNAME) { $env:DB_USERNAME } else { "postgres" }
+$DB_PASSWORD = if ($env:DB_PASSWORD) { $env:DB_PASSWORD } else { "changeme" }
+$DB_SSLMODE = if ($env:DB_SSLMODE) { $env:DB_SSLMODE } else { "disable" }
+$SERVER_DEBUG = if ($env:SERVER_DEBUG) { $env:SERVER_DEBUG } else { "true" }
+$SERVER_LOG_LEVEL = if ($env:SERVER_LOG_LEVEL) { $env:SERVER_LOG_LEVEL } else { "info" }
+$CORS_ALLOWED_ORIGINS = if ($env:CORS_ALLOWED_ORIGINS) { $env:CORS_ALLOWED_ORIGINS } else { "http://localhost:3000,http://localhost:5173,http://localhost:5174,http://localhost:5175,http://localhost:5176,http://localhost:5177" }
+
+$AUTH_ISSUER = if ($env:AUTH_ISSUER) { $env:AUTH_ISSUER } else { "https://localhost:$IDP_PORT" }
+$AUTH_JWKS_URL = if ($env:AUTH_JWKS_URL) { $env:AUTH_JWKS_URL } else { "https://localhost:$IDP_PORT/oauth2/jwks" }
+$AUTH_CLIENT_IDS = if ($env:AUTH_CLIENT_IDS) { $env:AUTH_CLIENT_IDS } else { "TRADER_PORTAL_APP,FCAU_TO_NSW,NPQS_TO_NSW,IRD_TO_NSW,CDA_TO_NSW" }
+$AUTH_AUDIENCE = if ($env:AUTH_AUDIENCE) { $env:AUTH_AUDIENCE } else { "NSW_API" }
+$AUTH_JWKS_INSECURE_SKIP_VERIFY = if ($env:AUTH_JWKS_INSECURE_SKIP_VERIFY) { $env:AUTH_JWKS_INSECURE_SKIP_VERIFY } else { "true" }
+
+$IDP_PUBLIC_URL = if ($env:IDP_PUBLIC_URL) { $env:IDP_PUBLIC_URL } else { "https://localhost:$IDP_PORT" }
+$TRADER_IDP_CLIENT_ID = if ($env:TRADER_IDP_CLIENT_ID) { $env:TRADER_IDP_CLIENT_ID } else { "TRADER_PORTAL_APP" }
+$NPQS_IDP_CLIENT_ID = if ($env:NPQS_IDP_CLIENT_ID) { $env:NPQS_IDP_CLIENT_ID } else { "OGA_PORTAL_APP_NPQS" }
+$FCAU_IDP_CLIENT_ID = if ($env:FCAU_IDP_CLIENT_ID) { $env:FCAU_IDP_CLIENT_ID } else { "OGA_PORTAL_APP_FCAU" }
+$IRD_IDP_CLIENT_ID = if ($env:IRD_IDP_CLIENT_ID) { $env:IRD_IDP_CLIENT_ID } else { "OGA_PORTAL_APP_IRD" }
+$CDA_IDP_CLIENT_ID = if ($env:CDA_IDP_CLIENT_ID) { $env:CDA_IDP_CLIENT_ID } else { "OGA_PORTAL_APP_CDA" }
+$IDP_SCOPES = if ($env:IDP_SCOPES) { $env:IDP_SCOPES } else { "openid,profile,email,group,role" }
+$IDP_PLATFORM = if ($env:IDP_PLATFORM) { $env:IDP_PLATFORM } else { "AsgardeoV2" }
+$SHOW_AUTOFILL_BUTTON = if ($env:SHOW_AUTOFILL_BUTTON) { $env:SHOW_AUTOFILL_BUTTON } else { "true" }
+$TRADER_IDP_TRADER_GROUP_NAME = if ($env:TRADER_IDP_TRADER_GROUP_NAME) { $env:TRADER_IDP_TRADER_GROUP_NAME } else { "Traders" }
+$TRADER_IDP_CHA_GROUP_NAME = if ($env:TRADER_IDP_CHA_GROUP_NAME) { $env:TRADER_IDP_CHA_GROUP_NAME } else { "CHA" }
+
+$OGA_FORMS_PATH = if ($env:OGA_FORMS_PATH) { $env:OGA_FORMS_PATH } else { "./data/forms" }
+$OGA_DEFAULT_FORM_ID = if ($env:OGA_DEFAULT_FORM_ID) { $env:OGA_DEFAULT_FORM_ID } else { "default" }
+$OGA_ALLOWED_ORIGINS = if ($env:OGA_ALLOWED_ORIGINS) { $env:OGA_ALLOWED_ORIGINS } else { "*" }
+
+$OGA_DB_DRIVER = if ($env:OGA_DB_DRIVER) { $env:OGA_DB_DRIVER } else { "sqlite" }
+$OGA_DB_HOST = if ($env:OGA_DB_HOST) { $env:OGA_DB_HOST } else { "localhost" }
+$OGA_DB_PORT = if ($env:OGA_DB_PORT) { $env:OGA_DB_PORT } else { "5432" }
+$OGA_DB_USER = if ($env:OGA_DB_USER) { $env:OGA_DB_USER } else { "postgres" }
+$OGA_DB_PASSWORD = if ($env:OGA_DB_PASSWORD) { $env:OGA_DB_PASSWORD } else { "changeme" }
+$OGA_DB_NAME = if ($env:OGA_DB_NAME) { $env:OGA_DB_NAME } else { "oga_db" }
+$OGA_DB_SSLMODE = if ($env:OGA_DB_SSLMODE) { $env:OGA_DB_SSLMODE } else { "disable" }
+
+$OGA_NPQS_DB_PATH = if ($env:OGA_NPQS_DB_PATH) { $env:OGA_NPQS_DB_PATH } else { "./npqs.db" }
+$OGA_FCAU_DB_PATH = if ($env:OGA_FCAU_DB_PATH) { $env:OGA_FCAU_DB_PATH } else { "./fcau.db" }
+$OGA_IRD_DB_PATH = if ($env:OGA_IRD_DB_PATH) { $env:OGA_IRD_DB_PATH } else { "./ird.db" }
+$OGA_CDA_DB_PATH = if ($env:OGA_CDA_DB_PATH) { $env:OGA_CDA_DB_PATH } else { "./cda.db" }
+$OGA_APP_NPQS_BRANDING_PATH = if ($env:OGA_APP_NPQS_BRANDING_PATH) { $env:OGA_APP_NPQS_BRANDING_PATH } else { "./src/configs/npqs.yaml" }
+$OGA_APP_FCAU_BRANDING_PATH = if ($env:OGA_APP_FCAU_BRANDING_PATH) { $env:OGA_APP_FCAU_BRANDING_PATH } else { "./src/configs/fcau.yaml" }
+$OGA_APP_IRD_BRANDING_PATH = if ($env:OGA_APP_IRD_BRANDING_PATH) { $env:OGA_APP_IRD_BRANDING_PATH } else { "./src/configs/ird.yaml" }
+$OGA_APP_CDA_BRANDING_PATH = if ($env:OGA_APP_CDA_BRANDING_PATH) { $env:OGA_APP_CDA_BRANDING_PATH } else { "./src/configs/cda.yaml" }
+
+$OGA_NSW_NPQS_CLIENT_ID = if ($env:OGA_NSW_NPQS_CLIENT_ID) { $env:OGA_NSW_NPQS_CLIENT_ID } else { "NPQS_TO_NSW" }
+$OGA_NSW_FCAU_CLIENT_ID = if ($env:OGA_NSW_FCAU_CLIENT_ID) { $env:OGA_NSW_FCAU_CLIENT_ID } else { "FCAU_TO_NSW" }
+$OGA_NSW_IRD_CLIENT_ID = if ($env:OGA_NSW_IRD_CLIENT_ID) { $env:OGA_NSW_IRD_CLIENT_ID } else { "IRD_TO_NSW" }
+$OGA_NSW_CDA_CLIENT_ID = if ($env:OGA_NSW_CDA_CLIENT_ID) { $env:OGA_NSW_CDA_CLIENT_ID } else { "CDA_TO_NSW" }
+$OGA_NSW_NPQS_CLIENT_SECRET = if ($env:OGA_NSW_NPQS_CLIENT_SECRET) { $env:OGA_NSW_NPQS_CLIENT_SECRET } else { "1234" }
+$OGA_NSW_FCAU_CLIENT_SECRET = if ($env:OGA_NSW_FCAU_CLIENT_SECRET) { $env:OGA_NSW_FCAU_CLIENT_SECRET } else { "1234" }
+$OGA_NSW_IRD_CLIENT_SECRET = if ($env:OGA_NSW_IRD_CLIENT_SECRET) { $env:OGA_NSW_IRD_CLIENT_SECRET } else { "1234" }
+$OGA_NSW_CDA_CLIENT_SECRET = if ($env:OGA_NSW_CDA_CLIENT_SECRET) { $env:OGA_NSW_CDA_CLIENT_SECRET } else { "1234" }
+$OGA_NSW_TOKEN_URL = if ($env:OGA_NSW_TOKEN_URL) { $env:OGA_NSW_TOKEN_URL } else { "https://localhost:$IDP_PORT/oauth2/token" }
+$OGA_NSW_SCOPES = if ($env:OGA_NSW_SCOPES) { $env:OGA_NSW_SCOPES } else { "" }
+$OGA_NSW_TOKEN_INSECURE_SKIP_VERIFY = if ($env:OGA_NSW_TOKEN_INSECURE_SKIP_VERIFY) { $env:OGA_NSW_TOKEN_INSECURE_SKIP_VERIFY } else { "true" }
+
+# OGA Registry
+$OGA_INSTANCES = @(
+    @{ Name="npqs"; Port=$OGA_NPQS_PORT; DbPath=$OGA_NPQS_DB_PATH; NswClientId=$OGA_NSW_NPQS_CLIENT_ID; NswClientSecret=$OGA_NSW_NPQS_CLIENT_SECRET; AppPort=$OGA_APP_NPQS_PORT; BrandingPath=$OGA_APP_NPQS_BRANDING_PATH; IdpClientId=$NPQS_IDP_CLIENT_ID; AppName="National Plant Quarantine Service (NPQS)" },
+    @{ Name="fcau"; Port=$OGA_FCAU_PORT; DbPath=$OGA_FCAU_DB_PATH; NswClientId=$OGA_NSW_FCAU_CLIENT_ID; NswClientSecret=$OGA_NSW_FCAU_CLIENT_SECRET; AppPort=$OGA_APP_FCAU_PORT; BrandingPath=$OGA_APP_FCAU_BRANDING_PATH; IdpClientId=$FCAU_IDP_CLIENT_ID; AppName="Food Control Administration Unit (FCAU)" },
+    @{ Name="ird"; Port=$OGA_IRD_PORT; DbPath=$OGA_IRD_DB_PATH; NswClientId=$OGA_NSW_IRD_CLIENT_ID; NswClientSecret=$OGA_NSW_IRD_CLIENT_SECRET; AppPort=$OGA_APP_IRD_PORT; BrandingPath=$OGA_APP_IRD_BRANDING_PATH; IdpClientId=$IRD_IDP_CLIENT_ID; AppName="Inland Revenue Department (IRD)" },
+    @{ Name="cda"; Port=$OGA_CDA_PORT; DbPath=$OGA_CDA_DB_PATH; NswClientId=$OGA_NSW_CDA_CLIENT_ID; NswClientSecret=$OGA_NSW_CDA_CLIENT_SECRET; AppPort=$OGA_APP_CDA_PORT; BrandingPath=$OGA_APP_CDA_BRANDING_PATH; IdpClientId=$CDA_IDP_CLIENT_ID; AppName="Coconut Development Authority (CDA)" }
+)
+
+function ensure_branding_file($FileName, $AppName) {
+    $ConfigDir = Join-Path $ROOT_DIR "portals/apps/oga-app/src/configs"
+    $FilePath = Join-Path $ConfigDir $FileName
+    if (-not (Test-Path $FilePath)) {
+        New-Item -ItemType Directory -Path $ConfigDir -Force | Out-Null
+        $Content = @"
+branding:
+  appName: "$AppName"
+  logoUrl: ""
+  favicon: ""
+"@
+        Set-Content -Path $FilePath -Value $Content
+    }
+}
+
+function wait_for_temporal() {
+    $Retries = 30
+    $WaitSeconds = 2
+
+    Write-Host "Waiting for Temporal at ${TEMPORAL_HOST}:${TEMPORAL_PORT}..."
+    for ($i = 1; $i -le $Retries; $i++) {
+        temporal operator cluster health --address "${TEMPORAL_HOST}:${TEMPORAL_PORT}" --namespace $TEMPORAL_NAMESPACE 2>&1 | Out-Null
+        if ($LASTEXITCODE -eq 0) {
+            Write-Host "Temporal is ready."
+            return
+        }
+        Write-Host "  Temporal not ready yet (attempt $i/$Retries), retrying in ${WaitSeconds}s..."
+        Start-Sleep -Seconds $WaitSeconds
+    }
+    Write-Error "Temporal did not become ready in time. Aborting."
+    exit 1
+}
+
+function clean_oga_databases() {
+    Write-Host "Cleaning OGA databases (driver: $OGA_DB_DRIVER)..."
+    if ($OGA_DB_DRIVER -eq "sqlite") {
+        foreach ($Instance in $OGA_INSTANCES) {
+            $DbPath = $Instance.DbPath
+            $ResolvedPath = ""
+            if ([System.IO.Path]::IsPathRooted($DbPath)) {
+                $ResolvedPath = $DbPath
+            } else {
+                $RelativePath = $DbPath -replace '^\./', ''
+                $ResolvedPath = Join-Path $ROOT_DIR "oga/$RelativePath"
+            }
+
+            if (Test-Path $ResolvedPath) {
+                Write-Host "  Deleting SQLite DB for $($Instance.Name): $ResolvedPath"
+                Remove-Item -Path $ResolvedPath -Force
+            } else {
+                Write-Host "  SQLite DB for $($Instance.Name) not found (nothing to delete): $ResolvedPath"
+            }
+        }
+    } elseif ($OGA_DB_DRIVER -eq "postgres") {
+        if (-not (Get-Command psql -ErrorAction SilentlyContinue)) {
+            Write-Error "psql is required for Postgres DB cleaning but was not found in PATH"
+            exit 1
+        }
+        $env:PGPASSWORD = $OGA_DB_PASSWORD
+        Write-Host "  Dropping and recreating Postgres database: $OGA_DB_NAME"
+        $TermQuery = "SELECT pg_terminate_backend(pid) FROM pg_stat_activity WHERE datname = '$OGA_DB_NAME' AND pid <> pg_backend_pid();"
+        & psql -h $OGA_DB_HOST -p $OGA_DB_PORT -U $OGA_DB_USER -d postgres -c $TermQuery | Out-Null
+        & psql -h $OGA_DB_HOST -p $OGA_DB_PORT -U $OGA_DB_USER -d postgres -c "DROP DATABASE IF EXISTS `"$OGA_DB_NAME`";"
+        & psql -h $OGA_DB_HOST -p $OGA_DB_PORT -U $OGA_DB_USER -d postgres -c "CREATE DATABASE `"$OGA_DB_NAME`";"
+    }
+}
+
+$script:Jobs = @()
+
+function Start-ServiceJob {
+    param($Name, $Dir, $EnvVars, $ScriptBlock)
+    $Job = Start-Job -Name $Name -ScriptBlock $ScriptBlock -ArgumentList $Name, $Dir, $EnvVars
+    $script:Jobs += $Job
+    return $Job
+}
+
+# Clean Run Logic
+if ($CLEAN_RUN -eq "true") {
+    Write-Host "Clean run: wiping Docker volumes and databases..."
+    if ($RUN_IDP) {
+        Write-Host "Removing IDP containers and volumes..."
+        docker compose -f (Join-Path $ROOT_DIR "idp/docker-compose.yml") down --volumes
+    }
+    if ($RUN_TEMPORAL) {
+        Write-Host "Removing Temporal containers and volumes..."
+        docker compose -f (Join-Path $ROOT_DIR "temporal/docker-compose.yml") down --volumes
+    }
+    clean_oga_databases
+    
+    Write-Host "Running backend migrations..."
+    Push-Location (Join-Path $ROOT_DIR "backend/internal/database/migrations")
+    $env:ENV_FILE = $EnvFile
+    $env:CLEAN_RUN = $CLEAN_RUN
+    powershell.exe -File ./run.ps1
+    Pop-Location
+}
+
+# Start Docker Services
+if ($RUN_IDP) {
+    Write-Host "Starting IDP..."
+    docker compose -f (Join-Path $ROOT_DIR "idp/docker-compose.yml") up -d
+}
+if ($RUN_TEMPORAL) {
+    Write-Host "Starting Temporal..."
+    docker compose -f (Join-Path $ROOT_DIR "temporal/docker-compose.yml") up -d
+}
+
+Write-Host "Starting local development services..."
+
+# Start OGA Services
+foreach ($Instance in $OGA_INSTANCES) {
+    $OgaEnv = @{
+        OGA_PORT = $Instance.Port
+        OGA_DB_DRIVER = $OGA_DB_DRIVER
+        OGA_DB_PATH = $Instance.DbPath
+        OGA_DB_HOST = $OGA_DB_HOST
+        OGA_DB_PORT = $OGA_DB_PORT
+        OGA_DB_USER = $OGA_DB_USER
+        OGA_DB_PASSWORD = $OGA_DB_PASSWORD
+        OGA_DB_NAME = $OGA_DB_NAME
+        OGA_DB_SSLMODE = $OGA_DB_SSLMODE
+        OGA_FORMS_PATH = $OGA_FORMS_PATH
+        OGA_DEFAULT_FORM_ID = $OGA_DEFAULT_FORM_ID
+        OGA_ALLOWED_ORIGINS = $OGA_ALLOWED_ORIGINS
+        OGA_NSW_API_BASE_URL = "http://localhost:${BACKEND_PORT}/api/v1"
+        OGA_NSW_CLIENT_ID = $Instance.NswClientId
+        OGA_NSW_CLIENT_SECRET = $Instance.NswClientSecret
+        OGA_NSW_TOKEN_URL = $OGA_NSW_TOKEN_URL
+        OGA_NSW_SCOPES = $OGA_NSW_SCOPES
+        OGA_NSW_TOKEN_INSECURE_SKIP_VERIFY = $OGA_NSW_TOKEN_INSECURE_SKIP_VERIFY
+    }
+    Start-ServiceJob -Name "oga-$($Instance.Name)" -Dir (Join-Path $ROOT_DIR "oga") -EnvVars $OgaEnv -ScriptBlock {
+        param($Name, $Dir, $EnvVars)
+        foreach ($Key in $EnvVars.Keys) { Set-Item "env:$Key" $EnvVars[$Key] }
+        Set-Location $Dir
+        go run ./cmd/server 2>&1 | ForEach-Object { Write-Host "[$Name] $_" }
+    }
+    # Small delay to prevent resource contention during Go compilation
+    Start-Sleep -Seconds 2
+
+    ensure_branding_file "$($Instance.Name).yaml" "$($Instance.AppName)"
+
+    $OgaAppEnv = @{
+        VITE_PORT = $Instance.AppPort
+        VITE_BRANDING_PATH = $Instance.BrandingPath
+        VITE_API_BASE_URL = "http://localhost:$($Instance.Port)"
+        VITE_IDP_BASE_URL = $IDP_PUBLIC_URL
+        VITE_IDP_CLIENT_ID = $Instance.IdpClientId
+        VITE_APP_URL = "http://localhost:$($Instance.AppPort)"
+        VITE_IDP_SCOPES = $IDP_SCOPES
+        VITE_IDP_PLATFORM = $IDP_PLATFORM
+    }
+    Start-ServiceJob -Name "oga-app-$($Instance.Name)" -Dir (Join-Path $ROOT_DIR "portals/apps/oga-app") -EnvVars $OgaAppEnv -ScriptBlock {
+        param($Name, $Dir, $EnvVars)
+        foreach ($Key in $EnvVars.Keys) { Set-Item "env:$Key" $EnvVars[$Key] }
+        Set-Location $Dir
+        pnpm run dev 2>&1 | ForEach-Object { Write-Host "[$Name] $_" }
+    }
+    # Small delay to prevent Vite filesystem conflicts in the shared oga-app directory
+    Start-Sleep -Seconds 2
+}
+
+# Trader App
+$TraderEnv = @{
+    VITE_API_BASE_URL = "http://localhost:${BACKEND_PORT}/api/v1"
+    VITE_IDP_BASE_URL = $IDP_PUBLIC_URL
+    VITE_IDP_CLIENT_ID = $TRADER_IDP_CLIENT_ID
+    VITE_APP_URL = "http://localhost:${TRADER_APP_PORT}"
+    VITE_IDP_SCOPES = $IDP_SCOPES
+    VITE_IDP_PLATFORM = $IDP_PLATFORM
+    VITE_IDP_TRADER_GROUP_NAME = $TRADER_IDP_TRADER_GROUP_NAME
+    VITE_IDP_CHA_GROUP_NAME = $TRADER_IDP_CHA_GROUP_NAME
+    VITE_SHOW_AUTOFILL_BUTTON = $SHOW_AUTOFILL_BUTTON
+    TRADER_APP_PORT = $TRADER_APP_PORT
+}
+Start-ServiceJob -Name "trader-app" -Dir (Join-Path $ROOT_DIR "portals/apps/trader-app") -EnvVars $TraderEnv -ScriptBlock {
+    param($Name, $Dir, $EnvVars)
+    foreach ($Key in $EnvVars.Keys) { Set-Item "env:$Key" $EnvVars[$Key] }
+    Set-Location $Dir
+    pnpm run dev -- --port $env:TRADER_APP_PORT 2>&1 | ForEach-Object { Write-Host "[$Name] $_" }
+}
+
+# Backend (wait for Temporal)
+if ($RUN_TEMPORAL) {
+    wait_for_temporal
+}
+
+$BackendEnv = @{
+    DB_HOST = $DB_HOST
+    DB_PORT = $DB_PORT
+    DB_NAME = $DB_NAME
+    DB_USERNAME = $DB_USERNAME
+    DB_PASSWORD = $DB_PASSWORD
+    DB_SSLMODE = $DB_SSLMODE
+    TEMPORAL_HOST = $TEMPORAL_HOST
+    TEMPORAL_PORT = $TEMPORAL_PORT
+    TEMPORAL_NAMESPACE = $TEMPORAL_NAMESPACE
+    SERVER_PORT = $BACKEND_PORT
+    SERVER_DEBUG = $SERVER_DEBUG
+    SERVER_LOG_LEVEL = $SERVER_LOG_LEVEL
+    CORS_ALLOWED_ORIGINS = $CORS_ALLOWED_ORIGINS
+    AUTH_JWKS_URL = $AUTH_JWKS_URL
+    AUTH_ISSUER = $AUTH_ISSUER
+    AUTH_CLIENT_IDS = $AUTH_CLIENT_IDS
+    AUTH_AUDIENCE = $AUTH_AUDIENCE
+    AUTH_JWKS_INSECURE_SKIP_VERIFY = $AUTH_JWKS_INSECURE_SKIP_VERIFY
+}
+Start-ServiceJob -Name "backend" -Dir (Join-Path $ROOT_DIR "backend") -EnvVars $BackendEnv -ScriptBlock {
+    param($Name, $Dir, $EnvVars)
+    foreach ($Key in $EnvVars.Keys) { Set-Item "env:$Key" $EnvVars[$Key] }
+    Set-Location $Dir
+    go run ./cmd/server/main.go 2>&1 | ForEach-Object { Write-Host "[$Name] $_" }
+}
+
+# Status Banner
+Write-Host ""
+Write-Host "Started local services:"
+Write-Host "  - backend       -> http://localhost:$BACKEND_PORT"
+Write-Host "  - trader-app    -> http://localhost:$TRADER_APP_PORT"
+foreach ($Instance in $OGA_INSTANCES) {
+    Write-Host ("  - oga-{0,-9} -> http://localhost:{1}" -f $Instance.Name, $Instance.Port)
+    Write-Host ("  - oga-app-{0,-5} -> http://localhost:{1}" -f $Instance.Name, $Instance.AppPort)
+}
+Write-Host ""
+Write-Host "IDP running:      $RUN_IDP"
+Write-Host "Temporal running: $RUN_TEMPORAL"
+Write-Host "Clean run:        $CLEAN_RUN"
+Write-Host ""
+Write-Host "Press Ctrl+C to stop all services."
+
+# Main loop
+try {
+    while ($true) {
+        foreach ($Job in $script:Jobs) {
+            if ($Job.State -eq "Running") {
+                $Data = Receive-Job -Job $Job
+                if ($Data) { $Data | ForEach-Object { Write-Host $_ } }
+            }
+        }
+        Start-Sleep -Milliseconds 500
+    }
+} finally {
+    Write-Host ""
+    Write-Host "Stopping services..."
+    foreach ($Job in $script:Jobs) {
+        Stop-Job -Job $Job
+        Remove-Job -Job $Job
+    }
+    if ($RUN_IDP) {
+        Write-Host "Stopping IDP containers..."
+        docker compose -f (Join-Path $ROOT_DIR "idp/docker-compose.yml") stop
+    }
+    if ($RUN_TEMPORAL) {
+        Write-Host "Stopping Temporal containers..."
+        docker compose -f (Join-Path $ROOT_DIR "temporal/docker-compose.yml") stop
+    }
+}

--- a/start-dev.ps1
+++ b/start-dev.ps1
@@ -1,28 +1,28 @@
 param(
-    [string]$EnvFile = "",
-    [switch]$SkipIdp,
-    [switch]$SkipTemporal,
-    [switch]$CleanRun
+    [string]${env-file} = "",
+    [switch]${skip-idp},
+    [switch]${skip-temporal},
+    [switch]${clean-run}
 )
 
 $ROOT_DIR = $PSScriptRoot
-if (-not $EnvFile) {
-    $EnvFile = Join-Path $ROOT_DIR ".env"
+if (-not ${env-file}) {
+    ${env-file} = Join-Path $ROOT_DIR ".env"
 }
 
-$RUN_IDP = -not $SkipIdp
-$RUN_TEMPORAL = -not $SkipTemporal
-$CLEAN_RUN = if ($CleanRun) { "true" } else { "false" }
+$RUN_IDP = -not ${skip-idp}
+$RUN_TEMPORAL = -not ${skip-temporal}
+$CLEAN_RUN = if (${clean-run}) { "true" } else { "false" }
 
-if (-not (Test-Path $EnvFile)) {
-    Write-Host "Env file not found: $EnvFile"
+if (-not (Test-Path ${env-file})) {
+    Write-Host "Env file not found: ${env-file}"
     Write-Host "Create one from: cp $ROOT_DIR\.env.example $ROOT_DIR\.env"
     exit 1
 }
 
 # Load environment variables
-Write-Host "Loading environment variables from $EnvFile..."
-Get-Content $EnvFile | ForEach-Object {
+Write-Host "Loading environment variables from ${env-file}..."
+Get-Content ${env-file} | ForEach-Object {
     if ($_ -match '^([^#\s][^=]+)=(.*)$') {
         $name = $matches[1].Trim()
         $value = $matches[2].Trim().Trim('"').Trim("'")
@@ -219,7 +219,7 @@ if ($CLEAN_RUN -eq "true") {
 
 Write-Host "Running backend migrations..."
 Push-Location (Join-Path $ROOT_DIR "backend/internal/database/migrations")
-$env:ENV_FILE = $EnvFile
+$env:ENV_FILE = ${env-file}
 $env:CLEAN_RUN = $CLEAN_RUN
 powershell.exe -File ./run.ps1
 Pop-Location

--- a/start-dev.ps1
+++ b/start-dev.ps1
@@ -215,14 +215,14 @@ if ($CLEAN_RUN -eq "true") {
         docker compose -f (Join-Path $ROOT_DIR "temporal/docker-compose.yml") down --volumes
     }
     clean_oga_databases
-    
-    Write-Host "Running backend migrations..."
-    Push-Location (Join-Path $ROOT_DIR "backend/internal/database/migrations")
-    $env:ENV_FILE = $EnvFile
-    $env:CLEAN_RUN = $CLEAN_RUN
-    powershell.exe -File ./run.ps1
-    Pop-Location
 }
+
+Write-Host "Running backend migrations..."
+Push-Location (Join-Path $ROOT_DIR "backend/internal/database/migrations")
+$env:ENV_FILE = $EnvFile
+$env:CLEAN_RUN = $CLEAN_RUN
+powershell.exe -File ./run.ps1
+Pop-Location
 
 # Start Docker Services
 if ($RUN_IDP) {

--- a/start-dev.ps1
+++ b/start-dev.ps1
@@ -2,8 +2,15 @@ param(
     [string]${env-file} = "",
     [switch]${skip-idp},
     [switch]${skip-temporal},
-    [switch]${clean-run}
+    [switch]${clean-run},
+    [switch]${migrations}
 )
+
+# Mutual exclusivity check
+if (${clean-run} -and ${migrations}) {
+    Write-Error "Error: You cannot use -clean-run and -migrations at the same time."
+    exit 1
+}
 
 $ROOT_DIR = $PSScriptRoot
 if (-not ${env-file}) {
@@ -142,6 +149,19 @@ branding:
     }
 }
 
+function ensure_node_modules() {
+    $PortalsDir = Join-Path $ROOT_DIR "portals"
+    $OgaAppModules = Join-Path $PortalsDir "apps/oga-app/node_modules"
+    $TraderAppModules = Join-Path $PortalsDir "apps/trader-app/node_modules"
+
+    if ((-not (Test-Path $OgaAppModules)) -or (-not (Test-Path $TraderAppModules))) {
+        Write-Host "Missing node_modules in frontend apps. Running pnpm install in $PortalsDir..."
+        Push-Location $PortalsDir
+        pnpm install
+        Pop-Location
+    }
+}
+
 function wait_for_temporal() {
     $Retries = 30
     $WaitSeconds = 2
@@ -217,12 +237,16 @@ if ($CLEAN_RUN -eq "true") {
     clean_oga_databases
 }
 
-Write-Host "Running backend migrations..."
-Push-Location (Join-Path $ROOT_DIR "backend/internal/database/migrations")
-$env:ENV_FILE = ${env-file}
-$env:CLEAN_RUN = $CLEAN_RUN
-powershell.exe -File ./run.ps1
-Pop-Location
+if (${clean-run} -or ${migrations}) {
+    Write-Host "Running backend migrations..."
+    Push-Location (Join-Path $ROOT_DIR "backend/internal/database/migrations")
+    $env:ENV_FILE = ${env-file}
+    $MigrationParams = @()
+    if (${clean-run}) { $MigrationParams += "-clean-run" }
+    if (${migrations}) { $MigrationParams += "-migrations" }
+    powershell.exe -File ./run.ps1 @MigrationParams
+    Pop-Location
+}
 
 # Start Docker Services
 if ($RUN_IDP) {
@@ -237,6 +261,7 @@ if ($RUN_TEMPORAL) {
 Write-Host "Starting local development services..."
 
 # Start OGA Services
+ensure_node_modules
 foreach ($Instance in $OGA_INSTANCES) {
     $OgaEnv = @{
         OGA_PORT = $Instance.Port
@@ -268,6 +293,13 @@ foreach ($Instance in $OGA_INSTANCES) {
     Start-Sleep -Seconds 2
 
     ensure_branding_file "$($Instance.Name).yaml" "$($Instance.AppName)"
+
+    # For the first OGA instance, wait longer to allow database migrations to finish
+    # before starting other instances in parallel to avoid Postgres race conditions.
+    if ($Instance.Name -eq $OGA_INSTANCES[0].Name -and $OGA_DB_DRIVER -eq "postgres") {
+        Write-Host "Waiting for OGA database migrations to complete..."
+        Start-Sleep -Seconds 10
+    }
 
     $OgaAppEnv = @{
         VITE_PORT = $Instance.AppPort


### PR DESCRIPTION
## Summary
This PR adds native PowerShell (.ps1) orchestration scripts to allow developers to run the full stack directly from a standard Windows terminal without requiring WSL or Git Bash. It mirrors the exact logic of the existing Bash infrastructure while resolving Windows-specific stability issues.

## Type of Change
- [x] New feature (non-breaking change which adds functionality)

## Changes Made
- **New Scripts**: Added `start-dev.ps1` and `backend/internal/database/migrations/run.ps1` for native Windows execution.
- **Stability Fixes**: Implemented sequential startup delays in PowerShell to prevent EPERM (file locking) and Go compilation race conditions on Windows.
- **Infrastructure Compatibility**: Updated IDP bootstrap scripts (`01-default-resources.sh` and `02-sample-resources.sh`) with proper shebangs and LF line endings for Docker compatibility.
- **Environment Sync**: Synchronized root and app `.env` files to support the new YAML-based branding system and mandatory IDP environment variables.

## Testing
- [x] I have tested this change locally
- [x] I have tested edge cases (e.g. concurrent service startup)

## Checklist
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have checked that there are no merge conflicts

## Related Issues
Closes #411 

## Additional Notes
Developers running on Windows should ensure their terminal has execution permissions for local scripts (`Set-ExecutionPolicy -ExecutionPolicy RemoteSigned -Scope CurrentUser`).