### PR TITLE
feat(profile): Add Company Profile Service

### DIFF
--- a/backend/internal/database/migrations/016_create_company_records.down.sql
+++ b/backend/internal/database/migrations/016_create_company_records.down.sql
@@ -1,0 +1,3 @@
+DROP INDEX IF EXISTS idx_company_records_ou_handle;
+DROP INDEX IF EXISTS idx_company_records_ou_id;
+DROP TABLE IF EXISTS company_records;

--- a/backend/internal/database/migrations/016_create_company_records.up.sql
+++ b/backend/internal/database/migrations/016_create_company_records.up.sql
@@ -1,0 +1,15 @@
+CREATE TABLE IF NOT EXISTS company_records (
+    id          varchar(100)             NOT NULL PRIMARY KEY,
+    name        varchar(255)             NOT NULL,
+    ou_id       varchar(255)             NOT NULL UNIQUE,
+    ou_handle   varchar(255)             NOT NULL UNIQUE,
+    data        jsonb                    NOT NULL DEFAULT '{}',
+    created_at  timestamp with time zone DEFAULT CURRENT_TIMESTAMP,
+    updated_at  timestamp with time zone DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE INDEX idx_company_records_ou_id ON company_records (ou_id);
+CREATE INDEX idx_company_records_ou_handle ON company_records (ou_handle);
+
+INSERT INTO company_records (id, name, ou_id, ou_handle, data) VALUES
+    ('abcd-traders', 'ABCD Traders', 'abcd-traders-id', 'abcd-traders', '{}');

--- a/backend/internal/database/migrations/down.sh
+++ b/backend/internal/database/migrations/down.sh
@@ -11,6 +11,7 @@ MIGRATION_DB_HOST="${MIGRATION_DB_HOST:-$DB_HOST}"
 MIGRATION_DB_HOST="${MIGRATION_DB_HOST//host.docker.internal/localhost}"
 
 DOWNS=(
+  "016_create_company_records.down.sql"
   "015_fcau_workflow_seed.down.sql"
   "014_fcau_workflow_nodes_seed.down.sql"
   "013_fcau_forms_seed.down.sql"

--- a/backend/internal/database/migrations/run.sh
+++ b/backend/internal/database/migrations/run.sh
@@ -61,6 +61,7 @@ MIGRATIONS=(
     "013_fcau_forms_seed.up.sql"
     "014_fcau_workflow_nodes_seed.up.sql"
     "015_fcau_workflow_seed.up.sql"
+    "016_create_company_records.up.sql"
 )
 
 echo "Starting database migrations..."

--- a/backend/internal/profile/company/errors.go
+++ b/backend/internal/profile/company/errors.go
@@ -1,0 +1,7 @@
+package company
+
+import "errors"
+
+var ErrCompanyNotFound = errors.New("company not found")
+
+var ErrInvalidCompanyID = errors.New("invalid company ID")

--- a/backend/internal/profile/company/model.go
+++ b/backend/internal/profile/company/model.go
@@ -1,0 +1,21 @@
+package company
+
+import (
+	"encoding/json"
+	"time"
+)
+
+// Record represents a company's persisted profile in the database.
+type Record struct {
+	ID        string          `gorm:"type:varchar(100);column:id;primaryKey;not null" json:"id"`
+	Name      string          `gorm:"type:varchar(255);column:name;not null" json:"name"`
+	OUID      string          `gorm:"type:varchar(255);column:ou_id;unique;not null" json:"ouId"`
+	OUHandle  string          `gorm:"type:varchar(255);column:ou_handle;unique;not null" json:"ouHandle"`
+	Data      json.RawMessage `gorm:"type:jsonb;column:data;not null;default:'{}'" json:"data"`
+	CreatedAt time.Time       `gorm:"column:created_at;autoCreateTime" json:"createdAt"`
+	UpdatedAt time.Time       `gorm:"column:updated_at;autoUpdateTime" json:"updatedAt"`
+}
+
+func (r *Record) TableName() string {
+	return "company_records"
+}

--- a/backend/internal/profile/company/service.go
+++ b/backend/internal/profile/company/service.go
@@ -1,6 +1,7 @@
 package company
 
 import (
+	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -13,24 +14,24 @@ import (
 type Service interface {
 	// GetCompanyByID retrieves a company record by its ID.
 	// Returns ErrCompanyNotFound if no record exists.
-	GetCompanyByID(id string) (*Record, error)
+	GetCompanyByID(ctx context.Context, id string) (*Record, error)
 
 	// GetCompanyByOUHandle retrieves a company record by its IdP organisational unit handle.
 	// Returns ErrCompanyNotFound if no record exists.
-	GetCompanyByOUHandle(ouHandle string) (*Record, error)
+	GetCompanyByOUHandle(ctx context.Context, ouHandle string) (*Record, error)
 
 	// GetCompanyByOUId retrieves a company record by its IdP organisational unit ID.
 	// Returns ErrCompanyNotFound if no record exists.
-	GetCompanyByOUId(ouId string) (*Record, error)
+	GetCompanyByOUId(ctx context.Context, ouId string) (*Record, error)
 
 	// UpdateCompany performs an append-only merge of data into the company's Data field.
 	// New keys are added and existing keys are replaced only when explicitly provided.
 	// Keys absent from data are never removed.
 	// Returns ErrCompanyNotFound if the company does not exist.
-	UpdateCompany(id string, data map[string]any) error
+	UpdateCompany(ctx context.Context, id string, data map[string]any) error
 
 	// Health checks if the service can access the database.
-	Health() error
+	Health(ctx context.Context) error
 }
 
 type service struct {
@@ -42,56 +43,36 @@ func NewService(db *gorm.DB) Service {
 	return &service{db: db}
 }
 
-func (s *service) GetCompanyByID(id string) (*Record, error) {
+func (s *service) getByField(ctx context.Context, field, value string) (*Record, error) {
+	var record Record
+	result := s.db.WithContext(ctx).Where(fmt.Sprintf("%s = ?", field), value).First(&record)
+	if result.Error != nil {
+		if errors.Is(result.Error, gorm.ErrRecordNotFound) {
+			slog.Debug("company record not found", field, value)
+			return nil, ErrCompanyNotFound
+		}
+		slog.Error("failed to fetch company record", field, value, "error", result.Error)
+		return nil, fmt.Errorf("database query failed: %w", result.Error)
+	}
+	return &record, nil
+}
+
+func (s *service) GetCompanyByID(ctx context.Context, id string) (*Record, error) {
 	if id == "" {
 		return nil, ErrInvalidCompanyID
 	}
-
-	var record Record
-	result := s.db.Where("id = ?", id).First(&record)
-	if result.Error != nil {
-		if errors.Is(result.Error, gorm.ErrRecordNotFound) {
-			slog.Debug("company record not found", "id", id)
-			return nil, ErrCompanyNotFound
-		}
-		slog.Error("failed to fetch company record", "id", id, "error", result.Error)
-		return nil, fmt.Errorf("database query failed: %w", result.Error)
-	}
-
-	return &record, nil
+	return s.getByField(ctx, "id", id)
 }
 
-func (s *service) GetCompanyByOUHandle(ouHandle string) (*Record, error) {
-	var record Record
-	result := s.db.Where("ou_handle = ?", ouHandle).First(&record)
-	if result.Error != nil {
-		if errors.Is(result.Error, gorm.ErrRecordNotFound) {
-			slog.Debug("company record not found", "ou_handle", ouHandle)
-			return nil, ErrCompanyNotFound
-		}
-		slog.Error("failed to fetch company record", "ou_handle", ouHandle, "error", result.Error)
-		return nil, fmt.Errorf("database query failed: %w", result.Error)
-	}
-
-	return &record, nil
+func (s *service) GetCompanyByOUHandle(ctx context.Context, ouHandle string) (*Record, error) {
+	return s.getByField(ctx, "ou_handle", ouHandle)
 }
 
-func (s *service) GetCompanyByOUId(ouId string) (*Record, error) {
-	var record Record
-	result := s.db.Where("ou_id = ?", ouId).First(&record)
-	if result.Error != nil {
-		if errors.Is(result.Error, gorm.ErrRecordNotFound) {
-			slog.Debug("company record not found", "ou_id", ouId)
-			return nil, ErrCompanyNotFound
-		}
-		slog.Error("failed to fetch company record", "ou_id", ouId, "error", result.Error)
-		return nil, fmt.Errorf("database query failed: %w", result.Error)
-	}
-
-	return &record, nil
+func (s *service) GetCompanyByOUId(ctx context.Context, ouId string) (*Record, error) {
+	return s.getByField(ctx, "ou_id", ouId)
 }
 
-func (s *service) UpdateCompany(id string, data map[string]any) error {
+func (s *service) UpdateCompany(ctx context.Context, id string, data map[string]any) error {
 	if id == "" {
 		return ErrInvalidCompanyID
 	}
@@ -107,9 +88,9 @@ func (s *service) UpdateCompany(id string, data map[string]any) error {
 
 	// Use PostgreSQL's JSONB concatenation operator (||) for an atomic merge.
 	// This avoids race conditions inherent in a read-modify-write cycle.
-	result := s.db.Model(&Record{}).
+	result := s.db.WithContext(ctx).Model(&Record{}).
 		Where("id = ?", id).
-		Update("data", gorm.Expr("data || ?", string(jsonBytes)))
+		Update("data", gorm.Expr("data || ?::jsonb", string(jsonBytes)))
 
 	if result.Error != nil {
 		slog.Error("failed to update company data", "id", id, "error", result.Error)
@@ -123,8 +104,14 @@ func (s *service) UpdateCompany(id string, data map[string]any) error {
 	return nil
 }
 
-func (s *service) Health() error {
-	if err := s.db.Exec("SELECT 1").Error; err != nil {
+func (s *service) Health(ctx context.Context) error {
+	sqlDB, err := s.db.DB()
+	if err != nil {
+		slog.Error("failed to retrieve underlying sql db", "error", err)
+		return fmt.Errorf("failed to retrieve database: %w", err)
+	}
+
+	if err := sqlDB.PingContext(ctx); err != nil {
 		slog.Error("company service health check failed", "error", err)
 		return fmt.Errorf("company service health check failed: %w", err)
 	}

--- a/backend/internal/profile/company/service.go
+++ b/backend/internal/profile/company/service.go
@@ -1,0 +1,132 @@
+package company
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"log/slog"
+
+	"gorm.io/gorm"
+)
+
+// Service defines operations for company profile management.
+type Service interface {
+	// GetCompanyByID retrieves a company record by its ID.
+	// Returns ErrCompanyNotFound if no record exists.
+	GetCompanyByID(id string) (*Record, error)
+
+	// GetCompanyByOUHandle retrieves a company record by its IdP organisational unit handle.
+	// Returns ErrCompanyNotFound if no record exists.
+	GetCompanyByOUHandle(ouHandle string) (*Record, error)
+
+	// GetCompanyByOUId retrieves a company record by its IdP organisational unit ID.
+	// Returns ErrCompanyNotFound if no record exists.
+	GetCompanyByOUId(ouId string) (*Record, error)
+
+	// UpdateCompany performs an append-only merge of data into the company's Data field.
+	// New keys are added and existing keys are replaced only when explicitly provided.
+	// Keys absent from data are never removed.
+	// Returns ErrCompanyNotFound if the company does not exist.
+	UpdateCompany(id string, data map[string]any) error
+
+	// Health checks if the service can access the database.
+	Health() error
+}
+
+type service struct {
+	db *gorm.DB
+}
+
+// NewService creates a new company service instance.
+func NewService(db *gorm.DB) Service {
+	return &service{db: db}
+}
+
+func (s *service) GetCompanyByID(id string) (*Record, error) {
+	if id == "" {
+		return nil, ErrInvalidCompanyID
+	}
+
+	var record Record
+	result := s.db.Where("id = ?", id).First(&record)
+	if result.Error != nil {
+		if errors.Is(result.Error, gorm.ErrRecordNotFound) {
+			slog.Debug("company record not found", "id", id)
+			return nil, ErrCompanyNotFound
+		}
+		slog.Error("failed to fetch company record", "id", id, "error", result.Error)
+		return nil, fmt.Errorf("database query failed: %w", result.Error)
+	}
+
+	return &record, nil
+}
+
+func (s *service) GetCompanyByOUHandle(ouHandle string) (*Record, error) {
+	var record Record
+	result := s.db.Where("ou_handle = ?", ouHandle).First(&record)
+	if result.Error != nil {
+		if errors.Is(result.Error, gorm.ErrRecordNotFound) {
+			slog.Debug("company record not found", "ou_handle", ouHandle)
+			return nil, ErrCompanyNotFound
+		}
+		slog.Error("failed to fetch company record", "ou_handle", ouHandle, "error", result.Error)
+		return nil, fmt.Errorf("database query failed: %w", result.Error)
+	}
+
+	return &record, nil
+}
+
+func (s *service) GetCompanyByOUId(ouId string) (*Record, error) {
+	var record Record
+	result := s.db.Where("ou_id = ?", ouId).First(&record)
+	if result.Error != nil {
+		if errors.Is(result.Error, gorm.ErrRecordNotFound) {
+			slog.Debug("company record not found", "ou_id", ouId)
+			return nil, ErrCompanyNotFound
+		}
+		slog.Error("failed to fetch company record", "ou_id", ouId, "error", result.Error)
+		return nil, fmt.Errorf("database query failed: %w", result.Error)
+	}
+
+	return &record, nil
+}
+
+func (s *service) UpdateCompany(id string, data map[string]any) error {
+	if id == "" {
+		return ErrInvalidCompanyID
+	}
+
+	if len(data) == 0 {
+		return nil
+	}
+
+	jsonBytes, err := json.Marshal(data)
+	if err != nil {
+		return fmt.Errorf("failed to marshal company data: %w", err)
+	}
+
+	// Use PostgreSQL's JSONB concatenation operator (||) for an atomic merge.
+	// This avoids race conditions inherent in a read-modify-write cycle.
+	result := s.db.Model(&Record{}).
+		Where("id = ?", id).
+		Update("data", gorm.Expr("data || ?", string(jsonBytes)))
+
+	if result.Error != nil {
+		slog.Error("failed to update company data", "id", id, "error", result.Error)
+		return fmt.Errorf("failed to update company data: %w", result.Error)
+	}
+
+	if result.RowsAffected == 0 {
+		return ErrCompanyNotFound
+	}
+
+	return nil
+}
+
+func (s *service) Health() error {
+	if err := s.db.Exec("SELECT 1").Error; err != nil {
+		slog.Error("company service health check failed", "error", err)
+		return fmt.Errorf("company service health check failed: %w", err)
+	}
+	return nil
+}

--- a/backend/internal/profile/company/service_test.go
+++ b/backend/internal/profile/company/service_test.go
@@ -1,6 +1,7 @@
 package company
 
 import (
+	"context"
 	"errors"
 	"testing"
 	"time"
@@ -29,6 +30,24 @@ func setupTestDB(t *testing.T) (*gorm.DB, sqlmock.Sqlmock) {
 	return gormDB, mock
 }
 
+func setupPingTestDB(t *testing.T) (*gorm.DB, sqlmock.Sqlmock) {
+	t.Helper()
+	db, mock, err := sqlmock.New(sqlmock.MonitorPingsOption(true))
+	if err != nil {
+		t.Fatalf("failed to open sqlmock: %v", err)
+	}
+	t.Cleanup(func() { db.Close() })
+
+	mock.ExpectPing() // consumed by gorm.Open's connectivity check
+	dialector := postgres.New(postgres.Config{Conn: db})
+	gormDB, err := gorm.Open(dialector, &gorm.Config{})
+	if err != nil {
+		t.Fatalf("failed to open gorm: %v", err)
+	}
+
+	return gormDB, mock
+}
+
 var companyColumns = []string{"id", "name", "ou_id", "ou_handle", "data", "created_at", "updated_at"}
 
 func companyRow(id, name, ouId, ouHandle string, data []byte) *sqlmock.Rows {
@@ -40,7 +59,7 @@ func companyRow(id, name, ouId, ouHandle string, data []byte) *sqlmock.Rows {
 
 func TestService_GetCompanyByID_InvalidID(t *testing.T) {
 	svc := NewService(nil)
-	if _, err := svc.GetCompanyByID(""); !errors.Is(err, ErrInvalidCompanyID) {
+	if _, err := svc.GetCompanyByID(context.Background(), ""); !errors.Is(err, ErrInvalidCompanyID) {
 		t.Fatalf("expected ErrInvalidCompanyID, got %v", err)
 	}
 }
@@ -53,7 +72,7 @@ func TestService_GetCompanyByID_NotFound(t *testing.T) {
 		WithArgs("missing-id", 1).
 		WillReturnError(gorm.ErrRecordNotFound)
 
-	if _, err := svc.GetCompanyByID("missing-id"); !errors.Is(err, ErrCompanyNotFound) {
+	if _, err := svc.GetCompanyByID(context.Background(), "missing-id"); !errors.Is(err, ErrCompanyNotFound) {
 		t.Fatalf("expected ErrCompanyNotFound, got %v", err)
 	}
 	if err := mock.ExpectationsWereMet(); err != nil {
@@ -69,7 +88,7 @@ func TestService_GetCompanyByID_DBError(t *testing.T) {
 		WithArgs("co-1", 1).
 		WillReturnError(errors.New("query failed"))
 
-	if _, err := svc.GetCompanyByID("co-1"); err == nil {
+	if _, err := svc.GetCompanyByID(context.Background(), "co-1"); err == nil {
 		t.Fatal("expected error, got nil")
 	}
 	if err := mock.ExpectationsWereMet(); err != nil {
@@ -85,7 +104,7 @@ func TestService_GetCompanyByID_Success(t *testing.T) {
 		WithArgs("co-1", 1).
 		WillReturnRows(companyRow("co-1", "Acme", "acme-id", "acme-handle", []byte(`{}`)))
 
-	record, err := svc.GetCompanyByID("co-1")
+	record, err := svc.GetCompanyByID(context.Background(), "co-1")
 	if err != nil {
 		t.Fatalf("expected no error, got %v", err)
 	}
@@ -107,7 +126,7 @@ func TestService_GetCompanyByOUId_NotFound(t *testing.T) {
 		WithArgs("missing-ouid", 1).
 		WillReturnError(gorm.ErrRecordNotFound)
 
-	if _, err := svc.GetCompanyByOUId("missing-ouid"); !errors.Is(err, ErrCompanyNotFound) {
+	if _, err := svc.GetCompanyByOUId(context.Background(), "missing-ouid"); !errors.Is(err, ErrCompanyNotFound) {
 		t.Fatalf("expected ErrCompanyNotFound, got %v", err)
 	}
 	if err := mock.ExpectationsWereMet(); err != nil {
@@ -123,7 +142,7 @@ func TestService_GetCompanyByOUId_DBError(t *testing.T) {
 		WithArgs("acme-id", 1).
 		WillReturnError(errors.New("query failed"))
 
-	if _, err := svc.GetCompanyByOUId("acme-id"); err == nil {
+	if _, err := svc.GetCompanyByOUId(context.Background(), "acme-id"); err == nil {
 		t.Fatal("expected error, got nil")
 	}
 	if err := mock.ExpectationsWereMet(); err != nil {
@@ -139,7 +158,7 @@ func TestService_GetCompanyByOUId_Success(t *testing.T) {
 		WithArgs("acme-id", 1).
 		WillReturnRows(companyRow("co-1", "Acme", "acme-id", "acme-handle", []byte(`{}`)))
 
-	record, err := svc.GetCompanyByOUId("acme-id")
+	record, err := svc.GetCompanyByOUId(context.Background(), "acme-id")
 	if err != nil {
 		t.Fatalf("expected no error, got %v", err)
 	}
@@ -161,7 +180,7 @@ func TestService_GetCompanyByOUHandle_NotFound(t *testing.T) {
 		WithArgs("missing-handle", 1).
 		WillReturnError(gorm.ErrRecordNotFound)
 
-	if _, err := svc.GetCompanyByOUHandle("missing-handle"); !errors.Is(err, ErrCompanyNotFound) {
+	if _, err := svc.GetCompanyByOUHandle(context.Background(), "missing-handle"); !errors.Is(err, ErrCompanyNotFound) {
 		t.Fatalf("expected ErrCompanyNotFound, got %v", err)
 	}
 	if err := mock.ExpectationsWereMet(); err != nil {
@@ -177,7 +196,7 @@ func TestService_GetCompanyByOUHandle_DBError(t *testing.T) {
 		WithArgs("acme", 1).
 		WillReturnError(errors.New("query failed"))
 
-	if _, err := svc.GetCompanyByOUHandle("acme"); err == nil {
+	if _, err := svc.GetCompanyByOUHandle(context.Background(), "acme"); err == nil {
 		t.Fatal("expected error, got nil")
 	}
 	if err := mock.ExpectationsWereMet(); err != nil {
@@ -193,7 +212,7 @@ func TestService_GetCompanyByOUHandle_Success(t *testing.T) {
 		WithArgs("acme-handle", 1).
 		WillReturnRows(companyRow("co-1", "Acme", "acme-id", "acme-handle", []byte(`{}`)))
 
-	record, err := svc.GetCompanyByOUHandle("acme-handle")
+	record, err := svc.GetCompanyByOUHandle(context.Background(), "acme-handle")
 	if err != nil {
 		t.Fatalf("expected no error, got %v", err)
 	}
@@ -209,7 +228,7 @@ func TestService_GetCompanyByOUHandle_Success(t *testing.T) {
 
 func TestService_UpdateCompany_InvalidID(t *testing.T) {
 	svc := NewService(nil)
-	if err := svc.UpdateCompany("", map[string]any{"k": "v"}); !errors.Is(err, ErrInvalidCompanyID) {
+	if err := svc.UpdateCompany(context.Background(), "", map[string]any{"k": "v"}); !errors.Is(err, ErrInvalidCompanyID) {
 		t.Fatalf("expected ErrInvalidCompanyID, got %v", err)
 	}
 }
@@ -217,7 +236,7 @@ func TestService_UpdateCompany_InvalidID(t *testing.T) {
 func TestService_UpdateCompany_EmptyData(t *testing.T) {
 	svc := NewService(nil)
 	// Empty data is a no-op — no DB call should be made.
-	if err := svc.UpdateCompany("co-1", map[string]any{}); err != nil {
+	if err := svc.UpdateCompany(context.Background(), "co-1", map[string]any{}); err != nil {
 		t.Fatalf("expected no error for empty data, got %v", err)
 	}
 }
@@ -233,7 +252,7 @@ func TestService_UpdateCompany_NotFound(t *testing.T) {
 		WillReturnResult(sqlmock.NewResult(0, 0))
 	mock.ExpectCommit()
 
-	if err := svc.UpdateCompany("missing-id", map[string]any{"k": "v"}); !errors.Is(err, ErrCompanyNotFound) {
+	if err := svc.UpdateCompany(context.Background(), "missing-id", map[string]any{"k": "v"}); !errors.Is(err, ErrCompanyNotFound) {
 		t.Fatalf("expected ErrCompanyNotFound, got %v", err)
 	}
 	if err := mock.ExpectationsWereMet(); err != nil {
@@ -251,7 +270,7 @@ func TestService_UpdateCompany_DBError(t *testing.T) {
 		WillReturnError(errors.New("update failed"))
 	mock.ExpectRollback()
 
-	if err := svc.UpdateCompany("co-1", map[string]any{"new": "key"}); err == nil {
+	if err := svc.UpdateCompany(context.Background(), "co-1", map[string]any{"new": "key"}); err == nil {
 		t.Fatal("expected error, got nil")
 	}
 	if err := mock.ExpectationsWereMet(); err != nil {
@@ -269,7 +288,7 @@ func TestService_UpdateCompany_Success(t *testing.T) {
 		WillReturnResult(sqlmock.NewResult(1, 1))
 	mock.ExpectCommit()
 
-	if err := svc.UpdateCompany("co-1", map[string]any{"new": "key"}); err != nil {
+	if err := svc.UpdateCompany(context.Background(), "co-1", map[string]any{"new": "key"}); err != nil {
 		t.Fatalf("expected no error, got %v", err)
 	}
 	if err := mock.ExpectationsWereMet(); err != nil {
@@ -280,13 +299,12 @@ func TestService_UpdateCompany_Success(t *testing.T) {
 // --- Health ---
 
 func TestService_Health_Success(t *testing.T) {
-	db, mock := setupTestDB(t)
+	db, mock := setupPingTestDB(t)
 	svc := NewService(db)
 
-	mock.ExpectExec("SELECT 1").
-		WillReturnResult(sqlmock.NewResult(0, 0))
+	mock.ExpectPing()
 
-	if err := svc.Health(); err != nil {
+	if err := svc.Health(context.Background()); err != nil {
 		t.Fatalf("expected no error, got %v", err)
 	}
 	if err := mock.ExpectationsWereMet(); err != nil {
@@ -295,13 +313,12 @@ func TestService_Health_Success(t *testing.T) {
 }
 
 func TestService_Health_DBError(t *testing.T) {
-	db, mock := setupTestDB(t)
+	db, mock := setupPingTestDB(t)
 	svc := NewService(db)
 
-	mock.ExpectExec("SELECT 1").
-		WillReturnError(errors.New("health failed"))
+	mock.ExpectPing().WillReturnError(errors.New("health failed"))
 
-	if err := svc.Health(); err == nil {
+	if err := svc.Health(context.Background()); err == nil {
 		t.Fatal("expected error, got nil")
 	}
 	if err := mock.ExpectationsWereMet(); err != nil {

--- a/backend/internal/profile/company/service_test.go
+++ b/backend/internal/profile/company/service_test.go
@@ -1,0 +1,310 @@
+package company
+
+import (
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/DATA-DOG/go-sqlmock"
+	"gorm.io/driver/postgres"
+	"gorm.io/gorm"
+)
+
+var now = time.Now()
+
+func setupTestDB(t *testing.T) (*gorm.DB, sqlmock.Sqlmock) {
+	t.Helper()
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("failed to open sqlmock: %v", err)
+	}
+	t.Cleanup(func() { db.Close() })
+
+	dialector := postgres.New(postgres.Config{Conn: db})
+	gormDB, err := gorm.Open(dialector, &gorm.Config{})
+	if err != nil {
+		t.Fatalf("failed to open gorm: %v", err)
+	}
+
+	return gormDB, mock
+}
+
+var companyColumns = []string{"id", "name", "ou_id", "ou_handle", "data", "created_at", "updated_at"}
+
+func companyRow(id, name, ouId, ouHandle string, data []byte) *sqlmock.Rows {
+	return sqlmock.NewRows(companyColumns).
+		AddRow(id, name, ouId, ouHandle, data, now, now)
+}
+
+// --- GetCompanyByID ---
+
+func TestService_GetCompanyByID_InvalidID(t *testing.T) {
+	svc := NewService(nil)
+	if _, err := svc.GetCompanyByID(""); !errors.Is(err, ErrInvalidCompanyID) {
+		t.Fatalf("expected ErrInvalidCompanyID, got %v", err)
+	}
+}
+
+func TestService_GetCompanyByID_NotFound(t *testing.T) {
+	db, mock := setupTestDB(t)
+	svc := NewService(db)
+
+	mock.ExpectQuery(`SELECT .* FROM "company_records" WHERE id = \$1`).
+		WithArgs("missing-id", 1).
+		WillReturnError(gorm.ErrRecordNotFound)
+
+	if _, err := svc.GetCompanyByID("missing-id"); !errors.Is(err, ErrCompanyNotFound) {
+		t.Fatalf("expected ErrCompanyNotFound, got %v", err)
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("unmet expectations: %v", err)
+	}
+}
+
+func TestService_GetCompanyByID_DBError(t *testing.T) {
+	db, mock := setupTestDB(t)
+	svc := NewService(db)
+
+	mock.ExpectQuery(`SELECT .* FROM "company_records" WHERE id = \$1`).
+		WithArgs("co-1", 1).
+		WillReturnError(errors.New("query failed"))
+
+	if _, err := svc.GetCompanyByID("co-1"); err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("unmet expectations: %v", err)
+	}
+}
+
+func TestService_GetCompanyByID_Success(t *testing.T) {
+	db, mock := setupTestDB(t)
+	svc := NewService(db)
+
+	mock.ExpectQuery(`SELECT .* FROM "company_records" WHERE id = \$1`).
+		WithArgs("co-1", 1).
+		WillReturnRows(companyRow("co-1", "Acme", "acme-id", "acme-handle", []byte(`{}`)))
+
+	record, err := svc.GetCompanyByID("co-1")
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	if record == nil || record.ID != "co-1" || record.Name != "Acme" {
+		t.Fatalf("unexpected record: %#v", record)
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("unmet expectations: %v", err)
+	}
+}
+
+// --- GetCompanyByOUId ---
+
+func TestService_GetCompanyByOUId_NotFound(t *testing.T) {
+	db, mock := setupTestDB(t)
+	svc := NewService(db)
+
+	mock.ExpectQuery(`SELECT .* FROM "company_records" WHERE ou_id = \$1`).
+		WithArgs("missing-ouid", 1).
+		WillReturnError(gorm.ErrRecordNotFound)
+
+	if _, err := svc.GetCompanyByOUId("missing-ouid"); !errors.Is(err, ErrCompanyNotFound) {
+		t.Fatalf("expected ErrCompanyNotFound, got %v", err)
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("unmet expectations: %v", err)
+	}
+}
+
+func TestService_GetCompanyByOUId_DBError(t *testing.T) {
+	db, mock := setupTestDB(t)
+	svc := NewService(db)
+
+	mock.ExpectQuery(`SELECT .* FROM "company_records" WHERE ou_id = \$1`).
+		WithArgs("acme-id", 1).
+		WillReturnError(errors.New("query failed"))
+
+	if _, err := svc.GetCompanyByOUId("acme-id"); err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("unmet expectations: %v", err)
+	}
+}
+
+func TestService_GetCompanyByOUId_Success(t *testing.T) {
+	db, mock := setupTestDB(t)
+	svc := NewService(db)
+
+	mock.ExpectQuery(`SELECT .* FROM "company_records" WHERE ou_id = \$1`).
+		WithArgs("acme-id", 1).
+		WillReturnRows(companyRow("co-1", "Acme", "acme-id", "acme-handle", []byte(`{}`)))
+
+	record, err := svc.GetCompanyByOUId("acme-id")
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	if record == nil || record.OUID != "acme-id" || record.Name != "Acme" {
+		t.Fatalf("unexpected record: %#v", record)
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("unmet expectations: %v", err)
+	}
+}
+
+// --- GetCompanyByOUHandle ---
+
+func TestService_GetCompanyByOUHandle_NotFound(t *testing.T) {
+	db, mock := setupTestDB(t)
+	svc := NewService(db)
+
+	mock.ExpectQuery(`SELECT .* FROM "company_records" WHERE ou_handle = \$1`).
+		WithArgs("missing-handle", 1).
+		WillReturnError(gorm.ErrRecordNotFound)
+
+	if _, err := svc.GetCompanyByOUHandle("missing-handle"); !errors.Is(err, ErrCompanyNotFound) {
+		t.Fatalf("expected ErrCompanyNotFound, got %v", err)
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("unmet expectations: %v", err)
+	}
+}
+
+func TestService_GetCompanyByOUHandle_DBError(t *testing.T) {
+	db, mock := setupTestDB(t)
+	svc := NewService(db)
+
+	mock.ExpectQuery(`SELECT .* FROM "company_records" WHERE ou_handle = \$1`).
+		WithArgs("acme", 1).
+		WillReturnError(errors.New("query failed"))
+
+	if _, err := svc.GetCompanyByOUHandle("acme"); err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("unmet expectations: %v", err)
+	}
+}
+
+func TestService_GetCompanyByOUHandle_Success(t *testing.T) {
+	db, mock := setupTestDB(t)
+	svc := NewService(db)
+
+	mock.ExpectQuery(`SELECT .* FROM "company_records" WHERE ou_handle = \$1`).
+		WithArgs("acme-handle", 1).
+		WillReturnRows(companyRow("co-1", "Acme", "acme-id", "acme-handle", []byte(`{}`)))
+
+	record, err := svc.GetCompanyByOUHandle("acme-handle")
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	if record == nil || record.OUHandle != "acme-handle" {
+		t.Fatalf("unexpected record: %#v", record)
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("unmet expectations: %v", err)
+	}
+}
+
+// --- UpdateCompany ---
+
+func TestService_UpdateCompany_InvalidID(t *testing.T) {
+	svc := NewService(nil)
+	if err := svc.UpdateCompany("", map[string]any{"k": "v"}); !errors.Is(err, ErrInvalidCompanyID) {
+		t.Fatalf("expected ErrInvalidCompanyID, got %v", err)
+	}
+}
+
+func TestService_UpdateCompany_EmptyData(t *testing.T) {
+	svc := NewService(nil)
+	// Empty data is a no-op — no DB call should be made.
+	if err := svc.UpdateCompany("co-1", map[string]any{}); err != nil {
+		t.Fatalf("expected no error for empty data, got %v", err)
+	}
+}
+
+func TestService_UpdateCompany_NotFound(t *testing.T) {
+	db, mock := setupTestDB(t)
+	svc := NewService(db)
+
+	// Atomic JSONB merge: no prior SELECT, UPDATE returns 0 rows when id is missing.
+	mock.ExpectBegin()
+	mock.ExpectExec(`UPDATE "company_records" SET`).
+		WithArgs(sqlmock.AnyArg(), sqlmock.AnyArg(), "missing-id").
+		WillReturnResult(sqlmock.NewResult(0, 0))
+	mock.ExpectCommit()
+
+	if err := svc.UpdateCompany("missing-id", map[string]any{"k": "v"}); !errors.Is(err, ErrCompanyNotFound) {
+		t.Fatalf("expected ErrCompanyNotFound, got %v", err)
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("unmet expectations: %v", err)
+	}
+}
+
+func TestService_UpdateCompany_DBError(t *testing.T) {
+	db, mock := setupTestDB(t)
+	svc := NewService(db)
+
+	mock.ExpectBegin()
+	mock.ExpectExec(`UPDATE "company_records" SET`).
+		WithArgs(sqlmock.AnyArg(), sqlmock.AnyArg(), "co-1").
+		WillReturnError(errors.New("update failed"))
+	mock.ExpectRollback()
+
+	if err := svc.UpdateCompany("co-1", map[string]any{"new": "key"}); err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("unmet expectations: %v", err)
+	}
+}
+
+func TestService_UpdateCompany_Success(t *testing.T) {
+	db, mock := setupTestDB(t)
+	svc := NewService(db)
+
+	mock.ExpectBegin()
+	mock.ExpectExec(`UPDATE "company_records" SET`).
+		WithArgs(sqlmock.AnyArg(), sqlmock.AnyArg(), "co-1").
+		WillReturnResult(sqlmock.NewResult(1, 1))
+	mock.ExpectCommit()
+
+	if err := svc.UpdateCompany("co-1", map[string]any{"new": "key"}); err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("unmet expectations: %v", err)
+	}
+}
+
+// --- Health ---
+
+func TestService_Health_Success(t *testing.T) {
+	db, mock := setupTestDB(t)
+	svc := NewService(db)
+
+	mock.ExpectExec("SELECT 1").
+		WillReturnResult(sqlmock.NewResult(0, 0))
+
+	if err := svc.Health(); err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("unmet expectations: %v", err)
+	}
+}
+
+func TestService_Health_DBError(t *testing.T) {
+	db, mock := setupTestDB(t)
+	svc := NewService(db)
+
+	mock.ExpectExec("SELECT 1").
+		WillReturnError(errors.New("health failed"))
+
+	if err := svc.Health(); err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("unmet expectations: %v", err)
+	}
+}


### PR DESCRIPTION
## Summary

Implements a new `internal/profile/company` package as a first-class profile service for managing company records. This follows the same conventions as the existing `internal/profile/user` package and lays the foundation for company-scoped data across services such as `consignment_service` and `pre_consignment_service`.

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Other (please describe):

## Changes Made

**Database migration:**
- `016_create_company_records.up.sql` — creates the `company_records` table (`id`, `name`, `idp_ou_id` UNIQUE, `data` JSONB) with an index on `idp_ou_id`
- `016_create_company_records.down.sql` — drops the table and index
- `migrations/run.sh` and `down.sh` updated to include the new migration

**New package — `internal/profile/company/`:**
- `model.go` — `Record` struct with GORM and JSON tags; `TableName()` returns `"company_records"`
- `errors.go` — `ErrCompanyNotFound`, `ErrInvalidCompanyID`
- `service.go` — `Service` interface with four methods:
  - `GetCompanyByID(id string) (*Record, error)`
  - `GetCompanyByIDPOUID(idpOUID string) (*Record, error)`
  - `UpdateCompany(id string, data map[string]any) error` — append-only: fetches the existing record, merges new keys in Go, and writes back; keys absent from the update are never removed
  - `Health() error`
- `service_test.go` — 11 unit tests covering all methods and error paths (invalid ID, not found, DB error, success)

HTTP handlers are out of scope and will be added in a future issue when the IdP Management Portal is built.

## Testing

- [x] I have tested this change locally
- [x] I have added unit tests for new functionality
- [x] I have tested edge cases
- [x] All existing tests pass

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have checked that there are no merge conflicts

## Related Issues

Closes #455

## Deployment Notes

A new database migration (`016_create_company_records`) must be run before deploying. Run `migrations/run.sh` as part of the standard deployment process — no manual steps required.