### PR TITLE
[FIX][TraderApp][Frontend]: Resolve double-click requirement for CHA and HS code selection

### DIFF
--- a/portals/apps/trader-app/src/components/CHAPicker/CHASearch.tsx
+++ b/portals/apps/trader-app/src/components/CHAPicker/CHASearch.tsx
@@ -46,6 +46,7 @@ export function CHASearch({ value, onChange, options }: CHASearchProps) {
         onChange={(e) => setSearchQuery(e.target.value)}
         onFocus={() => setIsFocused(true)}
         onBlur={() => setTimeout(() => setIsFocused(false), 150)}
+        onMouseDown={() => setIsFocused(true)}
       >
         <TextField.Slot>
           <MagnifyingGlassIcon height="16" width="16" />
@@ -92,7 +93,10 @@ export function CHASearch({ value, onChange, options }: CHASearchProps) {
                       className={`cursor-pointer transition-colors ${
                         isSelected ? 'bg-blue-50 hover:bg-blue-100' : 'hover:bg-gray-50'
                       }`}
-                      onClick={() => handleSelect(cha)}
+                      onMouseDown={(e) => {
+                        e.preventDefault()
+                        handleSelect(cha)
+                      }}
                     >
                       <Box pt="1">
                         <MagnifyingGlassIcon height="14" width="14" className="text-gray-400" />

--- a/portals/apps/trader-app/src/components/HSCodePicker/HSCodeSearch.tsx
+++ b/portals/apps/trader-app/src/components/HSCodePicker/HSCodeSearch.tsx
@@ -87,6 +87,7 @@ export function HSCodeSearch({ value, onChange }: HSCodeSearchProps) {
         onChange={(e) => setSearchQuery(e.target.value)}
         onFocus={() => setIsFocused(true)}
         onBlur={() => setTimeout(() => setIsFocused(false), 150)}
+        onMouseDown={() => setIsFocused(true)}
       >
         <TextField.Slot>
           <MagnifyingGlassIcon height="16" width="16" />
@@ -141,7 +142,10 @@ export function HSCodeSearch({ value, onChange }: HSCodeSearchProps) {
                       className={`cursor-pointer transition-colors ${
                         isSelected ? 'bg-blue-50 hover:bg-blue-100' : 'hover:bg-gray-50'
                       }`}
-                      onClick={() => handleSelect(hsCode)}
+                      onMouseDown={(e) => {
+                        e.preventDefault()
+                        handleSelect(hsCode)
+                      }}
                     >
                       <Box pt="1">
                         <MagnifyingGlassIcon height="14" width="14" className="text-gray-400" />


### PR DESCRIPTION
## Summary

This PR addresses a race condition in the search components that required users to double-click an item to select it. By utilizing `onMouseDown`, we ensure the selection is captured before the input's focus is lost, enabling reliable single-click selection.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Changes Made

- **Selection Race Condition Fix**: Migrated from `onClick` to `onMouseDown` for search results in `CHASearch.tsx` and `HSCodeSearch.tsx`. This ensures the selection event fires before the input field's `onBlur` event can unmount the results list.
- **Robust Focus Handling**: Added `onMouseDown` to search inputs to ensure consistent focus state management across different browsers (especially on Windows).

## Testing

- [x] I have tested this change locally
- [x] I have tested edge cases
- [x] All existing tests pass

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings
- [x] I have checked that there are no merge conflicts

## Related Issues

Closes #460 

## Additional Notes

I have reverted the initial UI/UX enhancements included in this PR to keep the focus strictly on resolving the double-click selection bug. A separate redesign of the consignment creation screen is planned, and those interface changes will be re-introduced in a separate PR.
