### PR TITLE
feat(uiprojector): introduce reusable UI projection engine

### DIFF
--- a/backend/pkg/uiprojector/README.md
+++ b/backend/pkg/uiprojector/README.md
@@ -1,0 +1,77 @@
+# UI Projector
+
+`uiprojector` is a metadata-driven engine that transforms raw workflow state and business data into a structured UI payload. It uses a **Zone-Based Architecture** to map transformation logic (Projectors) and layout rules (Blueprints) into named UI slots.
+
+## Core Concepts
+
+### 1. Blueprint (The Layout)
+A `Blueprint` defines the structural rules for a view. It maps named **Zones** (e.g., "main", "sidebar") to specific components.
+- **TemplateID**: The identifier for the raw template content.
+- **Projector**: The strategy used to transform the data (e.g., `FORM`, `MARKDOWN`).
+- **VisibleWhen**: Declarative rules that hide/show zones based on current state or data presence.
+
+### 2. Facts (The Input)
+`Facts` represent the current context of the business entity being rendered.
+- **State**: The logical status (e.g., `PENDING`, `APPROVED`).
+- **Data**: A map of raw data plucked into sections via `DataKey`.
+
+### 3. Projector (The Strategy)
+Projectors are transformation strategies. Built-in projectors include:
+- **FORM**: Transforms JSON Schema templates into interactive forms.
+- **MARKDOWN**: Renders Go `text/template` markdown.
+- **RAW**: Returns data as-is.
+
+### 4. Assembler (The Engine)
+The `Assembler` orchestrates the lifecycle:
+1. Validates visibility rules via `ShouldRender`.
+2. Resolves and fetches templates via a `TemplateProvider`.
+3. Selects the appropriate `Projector`.
+4. Plucks specific data via `DataKey`.
+5. Projects the final content into the designated **Zone**.
+
+## Usage
+
+```go
+// 1. Setup dependencies
+tp := MyTemplateProvider{} 
+projectors := uiprojector.DefaultProjectors()
+
+// 2. Initialize Assembler
+asm := uiprojector.NewAssembler(tp, projectors)
+
+// 3. Assemble a view
+blueprint := &uiprojector.Blueprint{
+    Sections: map[string]uiprojector.SectionBlueprint{
+        "main": {
+            ID: "my-form",
+            Projector: "FORM",
+            TemplateID: "form-v1",
+        },
+    },
+}
+facts := uiprojector.Facts{State: "DRAFT", Data: map[string]any{}}
+
+zones, err := asm.Assemble(ctx, blueprint, facts)
+if err != nil {
+    // handle error
+}
+
+// Access rendered content by zone
+mainContent := zones["main"].Content
+```
+
+## Architecture Features
+
+- **Zone-Based**: Named slots instead of simple lists allow for complex, shell-driven layouts.
+- **Stateless Visibility**: Visibility logic is decoupled and testable through pure functions.
+- **Immutability**: The `Assembler` uses defensive copying for its projector registry to prevent external side effects.
+- **Storage Agnostic**: Templates can be fetched from S3, local disk, or databases via the `TemplateProvider` interface.
+
+## Extensibility
+You can register custom projectors by adding them to the map passed to `NewAssembler`:
+
+```go
+projectors := uiprojector.DefaultProjectors()
+projectors["CHARTS"] = &ChartProjector{}
+asm := uiprojector.NewAssembler(tp, projectors)
+```

--- a/backend/pkg/uiprojector/README.md
+++ b/backend/pkg/uiprojector/README.md
@@ -37,7 +37,10 @@ tp := MyTemplateProvider{}
 projectors := uiprojector.DefaultProjectors()
 
 // 2. Initialize Assembler
-asm := uiprojector.NewAssembler(tp, projectors)
+asm, err := uiprojector.NewAssembler(tp, projectors)
+if err != nil {
+    // handle error
+}
 
 // 3. Assemble a view
 blueprint := &uiprojector.Blueprint{
@@ -73,5 +76,5 @@ You can register custom projectors by adding them to the map passed to `NewAssem
 ```go
 projectors := uiprojector.DefaultProjectors()
 projectors["CHARTS"] = &ChartProjector{}
-asm := uiprojector.NewAssembler(tp, projectors)
+asm, err := uiprojector.NewAssembler(tp, projectors)
 ```

--- a/backend/pkg/uiprojector/assembler.go
+++ b/backend/pkg/uiprojector/assembler.go
@@ -17,34 +17,45 @@ type Assembler struct {
 }
 
 func NewAssembler(tp TemplateProvider, projectors map[string]Projector) *Assembler {
+	if tp == nil {
+		panic("uiprojector: template provider is nil")
+	}
+
+	p := make(map[string]Projector, len(projectors))
+	for k, v := range projectors {
+		p[k] = v
+	}
+
 	return &Assembler{
 		templateProvider: tp,
-		projectors:       projectors,
+		projectors:       p,
 	}
 }
 
 // Assemble is the "pure" transformation logic.
 func (a *Assembler) Assemble(ctx context.Context, blueprint *Blueprint, facts Facts) ([]Section, error) {
-	var sections []Section
+	if blueprint == nil {
+		return nil, fmt.Errorf("assembler: blueprint is nil")
+	}
 
-	evaluator := NewVisibilityEvaluator()
+	sections := make([]Section, 0, len(blueprint.Sections))
 
 	for _, sb := range blueprint.Sections {
 		// 1. Visibility Check
-		if !evaluator.ShouldRender(sb, facts) {
+		if !ShouldRender(sb, facts) {
 			continue
 		}
 
-		// 2. Fetch Template
-		templateContent, err := a.templateProvider.GetTemplate(ctx, sb.TemplateID)
-		if err != nil {
-			return nil, fmt.Errorf("assembler: failed to fetch template %s: %w", sb.TemplateID, err)
-		}
-
-		// 3. Resolve Projector
+		// 2. Resolve Projector (Fail fast)
 		proj, ok := a.projectors[sb.Projector]
 		if !ok {
 			return nil, fmt.Errorf("assembler: unknown projector %s", sb.Projector)
+		}
+
+		// 3. Fetch Template
+		templateContent, err := a.templateProvider.GetTemplate(ctx, sb.TemplateID)
+		if err != nil {
+			return nil, fmt.Errorf("assembler: failed to fetch template %s: %w", sb.TemplateID, err)
 		}
 
 		// 4. Pluck Data from Registry via DataKey

--- a/backend/pkg/uiprojector/assembler.go
+++ b/backend/pkg/uiprojector/assembler.go
@@ -33,14 +33,14 @@ func NewAssembler(tp TemplateProvider, projectors map[string]Projector) *Assembl
 }
 
 // Assemble is the "pure" transformation logic.
-func (a *Assembler) Assemble(ctx context.Context, blueprint *Blueprint, facts Facts) ([]Section, error) {
+func (a *Assembler) Assemble(ctx context.Context, blueprint *Blueprint, facts Facts) (map[string]Section, error) {
 	if blueprint == nil {
 		return nil, fmt.Errorf("assembler: blueprint is nil")
 	}
 
-	sections := make([]Section, 0, len(blueprint.Sections))
+	sections := make(map[string]Section, len(blueprint.Sections))
 
-	for _, sb := range blueprint.Sections {
+	for zone, sb := range blueprint.Sections {
 		// 1. Visibility Check
 		if !ShouldRender(sb, facts) {
 			continue
@@ -72,12 +72,12 @@ func (a *Assembler) Assemble(ctx context.Context, blueprint *Blueprint, facts Fa
 			return nil, fmt.Errorf("assembler: projection failed for section %s: %w", sb.ID, err)
 		}
 
-		sections = append(sections, Section{
+		sections[zone] = Section{
 			ID:      sb.ID,
 			Type:    SectionType(sb.Projector),
 			Title:   sb.Title,
 			Content: content,
-		})
+		}
 	}
 
 	return sections, nil

--- a/backend/pkg/uiprojector/assembler.go
+++ b/backend/pkg/uiprojector/assembler.go
@@ -3,6 +3,7 @@ package uiprojector
 import (
 	"context"
 	"fmt"
+	"maps"
 )
 
 // TemplateProvider abstracts the resolution of TemplateID to raw bytes.
@@ -16,20 +17,15 @@ type Assembler struct {
 	projectors       map[string]Projector
 }
 
-func NewAssembler(tp TemplateProvider, projectors map[string]Projector) *Assembler {
+func NewAssembler(tp TemplateProvider, projectors map[string]Projector) (*Assembler, error) {
 	if tp == nil {
-		panic("uiprojector: template provider is nil")
-	}
-
-	p := make(map[string]Projector, len(projectors))
-	for k, v := range projectors {
-		p[k] = v
+		return nil, fmt.Errorf("uiprojector: template provider is required")
 	}
 
 	return &Assembler{
 		templateProvider: tp,
-		projectors:       p,
-	}
+		projectors:       maps.Clone(projectors),
+	}, nil
 }
 
 // Assemble is the "pure" transformation logic.
@@ -37,6 +33,8 @@ func (a *Assembler) Assemble(ctx context.Context, blueprint *Blueprint, facts Fa
 	if blueprint == nil {
 		return nil, fmt.Errorf("assembler: blueprint is nil")
 	}
+
+	// TODO: Should add a cache to cache the frequently fetched templates. Should decide whether the template should be from the TemplateProvider level or This Level.
 
 	sections := make(map[string]Section, len(blueprint.Sections))
 

--- a/backend/pkg/uiprojector/assembler.go
+++ b/backend/pkg/uiprojector/assembler.go
@@ -3,7 +3,6 @@ package uiprojector
 import (
 	"context"
 	"fmt"
-	"maps"
 )
 
 // TemplateProvider abstracts the resolution of TemplateID to raw bytes.
@@ -14,17 +13,34 @@ type TemplateProvider interface {
 // Assembler transforms a Blueprint and Facts into a list of rendered Sections.
 type Assembler struct {
 	templateProvider TemplateProvider
-	projectors       map[string]Projector
+	projectors       map[ProjectorType]Projector
 }
 
-func NewAssembler(tp TemplateProvider, projectors map[string]Projector) (*Assembler, error) {
+// NewAssembler builds an Assembler from a TemplateProvider and a slice of Projectors.
+// Each projector's Type() is used as its registration key; duplicate types return an error.
+func NewAssembler(tp TemplateProvider, projectors []Projector) (*Assembler, error) {
 	if tp == nil {
 		return nil, fmt.Errorf("uiprojector: template provider is required")
 	}
 
+	registry := make(map[ProjectorType]Projector, len(projectors))
+	for _, p := range projectors {
+		if p == nil {
+			return nil, fmt.Errorf("uiprojector: nil projector in registration list")
+		}
+		t := p.Type()
+		if t == "" {
+			return nil, fmt.Errorf("uiprojector: projector %T returned empty Type()", p)
+		}
+		if _, exists := registry[t]; exists {
+			return nil, fmt.Errorf("uiprojector: duplicate projector type %q", t)
+		}
+		registry[t] = p
+	}
+
 	return &Assembler{
 		templateProvider: tp,
-		projectors:       maps.Clone(projectors),
+		projectors:       registry,
 	}, nil
 }
 
@@ -45,7 +61,7 @@ func (a *Assembler) Assemble(ctx context.Context, blueprint *Blueprint, facts Fa
 		}
 
 		// 2. Resolve Projector (Fail fast)
-		proj, ok := a.projectors[sb.Projector]
+		proj, ok := a.projectors[ProjectorType(sb.Projector)]
 		if !ok {
 			return nil, fmt.Errorf("assembler: unknown projector %s", sb.Projector)
 		}
@@ -72,7 +88,7 @@ func (a *Assembler) Assemble(ctx context.Context, blueprint *Blueprint, facts Fa
 
 		sections[zone] = Section{
 			ID:      sb.ID,
-			Type:    SectionType(sb.Projector),
+			Type:    SectionType(proj.Type()),
 			Title:   sb.Title,
 			Content: content,
 		}

--- a/backend/pkg/uiprojector/assembler.go
+++ b/backend/pkg/uiprojector/assembler.go
@@ -1,0 +1,73 @@
+package uiprojector
+
+import (
+	"context"
+	"fmt"
+)
+
+// TemplateProvider abstracts the resolution of TemplateID to raw bytes.
+type TemplateProvider interface {
+	GetTemplate(ctx context.Context, templateID string) ([]byte, error)
+}
+
+// Assembler transforms a Blueprint and Facts into a list of rendered Sections.
+type Assembler struct {
+	templateProvider TemplateProvider
+	projectors       map[string]Projector
+}
+
+func NewAssembler(tp TemplateProvider, projectors map[string]Projector) *Assembler {
+	return &Assembler{
+		templateProvider: tp,
+		projectors:       projectors,
+	}
+}
+
+// Assemble is the "pure" transformation logic.
+func (a *Assembler) Assemble(ctx context.Context, blueprint *Blueprint, facts Facts) ([]Section, error) {
+	var sections []Section
+
+	evaluator := NewVisibilityEvaluator()
+
+	for _, sb := range blueprint.Sections {
+		// 1. Visibility Check
+		if !evaluator.ShouldRender(sb, facts) {
+			continue
+		}
+
+		// 2. Fetch Template
+		templateContent, err := a.templateProvider.GetTemplate(ctx, sb.TemplateID)
+		if err != nil {
+			return nil, fmt.Errorf("assembler: failed to fetch template %s: %w", sb.TemplateID, err)
+		}
+
+		// 3. Resolve Projector
+		proj, ok := a.projectors[sb.Projector]
+		if !ok {
+			return nil, fmt.Errorf("assembler: unknown projector %s", sb.Projector)
+		}
+
+		// 4. Pluck Data from Registry via DataKey
+		var sectionData any
+		if sb.DataKey != "" {
+			sectionData = facts.Data[sb.DataKey]
+		} else {
+			sectionData = facts.Data
+		}
+
+		// 5. Project
+		content, err := proj.Project(ctx, templateContent, sectionData)
+		if err != nil {
+			return nil, fmt.Errorf("assembler: projection failed for section %s: %w", sb.ID, err)
+		}
+
+		sections = append(sections, Section{
+			ID:      sb.ID,
+			Type:    SectionType(sb.Projector),
+			Title:   sb.Title,
+			Content: content,
+		})
+	}
+
+	return sections, nil
+}

--- a/backend/pkg/uiprojector/assembler_test.go
+++ b/backend/pkg/uiprojector/assembler_test.go
@@ -1,0 +1,178 @@
+package uiprojector_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/OpenNSW/nsw/pkg/uiprojector"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type stubTemplateProvider struct {
+	templates map[string][]byte
+	err       error
+}
+
+func (s *stubTemplateProvider) GetTemplate(_ context.Context, id string) ([]byte, error) {
+	if s.err != nil {
+		return nil, s.err
+	}
+	t, ok := s.templates[id]
+	if !ok {
+		return nil, errors.New("template not found: " + id)
+	}
+	return t, nil
+}
+
+type stubProjector struct {
+	lastTemplate []byte
+	lastData     any
+	out          any
+	err          error
+}
+
+func (p *stubProjector) Project(_ context.Context, template []byte, data any) (any, error) {
+	p.lastTemplate = template
+	p.lastData = data
+	if p.err != nil {
+		return nil, p.err
+	}
+	return p.out, nil
+}
+
+func TestAssembler_Assemble_HappyPath(t *testing.T) {
+	ctx := context.Background()
+	tp := &stubTemplateProvider{templates: map[string][]byte{
+		"tpl-a": []byte("A"),
+		"tpl-b": []byte("B"),
+	}}
+	pA := &stubProjector{out: "rendered-A"}
+	pB := &stubProjector{out: "rendered-B"}
+	asm := uiprojector.NewAssembler(tp, map[string]uiprojector.Projector{"PA": pA, "PB": pB})
+
+	blueprint := &uiprojector.Blueprint{
+		ID: "bp",
+		Sections: []uiprojector.SectionBlueprint{
+			{ID: "s1", Title: "First", TemplateID: "tpl-a", Projector: "PA", DataKey: "alpha"},
+			{ID: "s2", Title: "Second", TemplateID: "tpl-b", Projector: "PB"},
+		},
+	}
+	facts := uiprojector.Facts{
+		State: "IN_PROGRESS",
+		Data: map[string]any{
+			"alpha": map[string]any{"x": 1},
+			"beta":  "value",
+		},
+	}
+
+	sections, err := asm.Assemble(ctx, blueprint, facts)
+	require.NoError(t, err)
+	require.Len(t, sections, 2)
+
+	assert.Equal(t, "s1", sections[0].ID)
+	assert.Equal(t, "First", sections[0].Title)
+	assert.Equal(t, uiprojector.SectionType("PA"), sections[0].Type)
+	assert.Equal(t, "rendered-A", sections[0].Content)
+	assert.Equal(t, map[string]any{"x": 1}, pA.lastData, "DataKey should pluck alpha")
+	assert.Equal(t, []byte("A"), pA.lastTemplate)
+
+	assert.Equal(t, "s2", sections[1].ID)
+	assert.Equal(t, uiprojector.SectionType("PB"), sections[1].Type)
+	assert.Equal(t, facts.Data, pB.lastData, "empty DataKey should pass full Data")
+}
+
+func TestAssembler_Assemble_SkipsHiddenSections(t *testing.T) {
+	ctx := context.Background()
+	tp := &stubTemplateProvider{templates: map[string][]byte{"t": []byte("x")}}
+	p := &stubProjector{out: "ok"}
+	asm := uiprojector.NewAssembler(tp, map[string]uiprojector.Projector{"P": p})
+
+	blueprint := &uiprojector.Blueprint{
+		Sections: []uiprojector.SectionBlueprint{
+			{ID: "visible", TemplateID: "t", Projector: "P"},
+			{ID: "hidden", TemplateID: "t", Projector: "P", VisibleWhen: &uiprojector.VisibleWhen{
+				States: []string{"NEVER"},
+			}},
+		},
+	}
+
+	sections, err := asm.Assemble(ctx, blueprint, uiprojector.Facts{State: "ANY"})
+	require.NoError(t, err)
+	require.Len(t, sections, 1)
+	assert.Equal(t, "visible", sections[0].ID)
+}
+
+func TestAssembler_Assemble_EmptyBlueprint(t *testing.T) {
+	ctx := context.Background()
+	asm := uiprojector.NewAssembler(&stubTemplateProvider{}, nil)
+
+	sections, err := asm.Assemble(ctx, &uiprojector.Blueprint{}, uiprojector.Facts{})
+	require.NoError(t, err)
+	assert.Empty(t, sections)
+}
+
+func TestAssembler_Assemble_TemplateFetchError(t *testing.T) {
+	ctx := context.Background()
+	fetchErr := errors.New("boom")
+	tp := &stubTemplateProvider{err: fetchErr}
+	asm := uiprojector.NewAssembler(tp, map[string]uiprojector.Projector{"P": &stubProjector{}})
+
+	bp := &uiprojector.Blueprint{Sections: []uiprojector.SectionBlueprint{
+		{ID: "s", TemplateID: "missing", Projector: "P"},
+	}}
+
+	_, err := asm.Assemble(ctx, bp, uiprojector.Facts{})
+	require.Error(t, err)
+	assert.ErrorIs(t, err, fetchErr)
+	assert.Contains(t, err.Error(), "missing", "error should mention the template ID")
+}
+
+func TestAssembler_Assemble_UnknownProjector(t *testing.T) {
+	ctx := context.Background()
+	tp := &stubTemplateProvider{templates: map[string][]byte{"t": []byte("x")}}
+	asm := uiprojector.NewAssembler(tp, map[string]uiprojector.Projector{})
+
+	bp := &uiprojector.Blueprint{Sections: []uiprojector.SectionBlueprint{
+		{ID: "s", TemplateID: "t", Projector: "GHOST"},
+	}}
+
+	_, err := asm.Assemble(ctx, bp, uiprojector.Facts{})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "unknown projector")
+	assert.Contains(t, err.Error(), "GHOST")
+}
+
+func TestAssembler_Assemble_ProjectorError(t *testing.T) {
+	ctx := context.Background()
+	tp := &stubTemplateProvider{templates: map[string][]byte{"t": []byte("x")}}
+	projErr := errors.New("render failed")
+	p := &stubProjector{err: projErr}
+	asm := uiprojector.NewAssembler(tp, map[string]uiprojector.Projector{"P": p})
+
+	bp := &uiprojector.Blueprint{Sections: []uiprojector.SectionBlueprint{
+		{ID: "section-7", TemplateID: "t", Projector: "P"},
+	}}
+
+	_, err := asm.Assemble(ctx, bp, uiprojector.Facts{})
+	require.Error(t, err)
+	assert.ErrorIs(t, err, projErr)
+	assert.Contains(t, err.Error(), "section-7", "error should mention the failing section ID")
+}
+
+func TestAssembler_Assemble_DataKeyMissingPassesNil(t *testing.T) {
+	ctx := context.Background()
+	tp := &stubTemplateProvider{templates: map[string][]byte{"t": []byte("x")}}
+	p := &stubProjector{out: "ok"}
+	asm := uiprojector.NewAssembler(tp, map[string]uiprojector.Projector{"P": p})
+
+	bp := &uiprojector.Blueprint{Sections: []uiprojector.SectionBlueprint{
+		{ID: "s", TemplateID: "t", Projector: "P", DataKey: "absent"},
+	}}
+	facts := uiprojector.Facts{Data: map[string]any{"other": 1}}
+
+	_, err := asm.Assemble(ctx, bp, facts)
+	require.NoError(t, err)
+	assert.Nil(t, p.lastData, "DataKey lookup on missing key should pass nil")
+}

--- a/backend/pkg/uiprojector/assembler_test.go
+++ b/backend/pkg/uiprojector/assembler_test.go
@@ -27,11 +27,14 @@ func (s *stubTemplateProvider) GetTemplate(_ context.Context, id string) ([]byte
 }
 
 type stubProjector struct {
+	typeName     uiprojector.ProjectorType
 	lastTemplate []byte
 	lastData     any
 	out          any
 	err          error
 }
+
+func (p *stubProjector) Type() uiprojector.ProjectorType { return p.typeName }
 
 func (p *stubProjector) Project(_ context.Context, template []byte, data any) (any, error) {
 	p.lastTemplate = template
@@ -50,23 +53,45 @@ func TestNewAssembler(t *testing.T) {
 		assert.Contains(t, err.Error(), "template provider is required")
 	})
 
-	t.Run("deep copies the projectors map", func(t *testing.T) {
-		pMap := map[string]uiprojector.Projector{"P1": &stubProjector{}}
-		tp := &stubTemplateProvider{}
-		asm, err := uiprojector.NewAssembler(tp, pMap)
+	t.Run("returns error on duplicate projector type", func(t *testing.T) {
+		asm, err := uiprojector.NewAssembler(&stubTemplateProvider{}, []uiprojector.Projector{
+			&stubProjector{typeName: "DUP"},
+			&stubProjector{typeName: "DUP"},
+		})
+		assert.Error(t, err)
+		assert.Nil(t, asm)
+		assert.Contains(t, err.Error(), "duplicate projector type")
+	})
+
+	t.Run("returns error on empty Type()", func(t *testing.T) {
+		asm, err := uiprojector.NewAssembler(&stubTemplateProvider{}, []uiprojector.Projector{
+			&stubProjector{typeName: ""},
+		})
+		assert.Error(t, err)
+		assert.Nil(t, asm)
+		assert.Contains(t, err.Error(), "empty Type()")
+	})
+
+	t.Run("returns error on nil projector entry", func(t *testing.T) {
+		asm, err := uiprojector.NewAssembler(&stubTemplateProvider{}, []uiprojector.Projector{nil})
+		assert.Error(t, err)
+		assert.Nil(t, asm)
+		assert.Contains(t, err.Error(), "nil projector")
+	})
+
+	t.Run("does not retain caller's slice", func(t *testing.T) {
+		list := []uiprojector.Projector{&stubProjector{typeName: "P1"}}
+		tp := &stubTemplateProvider{templates: map[string][]byte{"t": []byte("x")}}
+		asm, err := uiprojector.NewAssembler(tp, list)
 		require.NoError(t, err)
 
-		// Mutate original map
-		delete(pMap, "P1")
-		pMap["P2"] = &stubProjector{}
+		// Mutate the caller's slice; assembler keeps its own registry.
+		list[0] = &stubProjector{typeName: "P2"}
 
-		// Assembler should be unaffected
 		ctx := context.Background()
-		tp.templates = map[string][]byte{"t": []byte("x")}
 		bp := &uiprojector.Blueprint{Sections: map[string]uiprojector.SectionBlueprint{
 			"zone1": {ID: "s", TemplateID: "t", Projector: "P1"},
 		}}
-
 		_, err = asm.Assemble(ctx, bp, uiprojector.Facts{})
 		assert.NoError(t, err, "Assembler should still have P1")
 
@@ -84,9 +109,9 @@ func TestAssembler_Assemble_HappyPath(t *testing.T) {
 		"tpl-a": []byte("A"),
 		"tpl-b": []byte("B"),
 	}}
-	pA := &stubProjector{out: "rendered-A"}
-	pB := &stubProjector{out: "rendered-B"}
-	asm, err := uiprojector.NewAssembler(tp, map[string]uiprojector.Projector{"PA": pA, "PB": pB})
+	pA := &stubProjector{typeName: "PA", out: "rendered-A"}
+	pB := &stubProjector{typeName: "PB", out: "rendered-B"}
+	asm, err := uiprojector.NewAssembler(tp, []uiprojector.Projector{pA, pB})
 	require.NoError(t, err)
 
 	blueprint := &uiprojector.Blueprint{
@@ -123,8 +148,8 @@ func TestAssembler_Assemble_HappyPath(t *testing.T) {
 func TestAssembler_Assemble_SkipsHiddenSections(t *testing.T) {
 	ctx := context.Background()
 	tp := &stubTemplateProvider{templates: map[string][]byte{"t": []byte("x")}}
-	p := &stubProjector{out: "ok"}
-	asm, err := uiprojector.NewAssembler(tp, map[string]uiprojector.Projector{"P": p})
+	p := &stubProjector{typeName: "P", out: "ok"}
+	asm, err := uiprojector.NewAssembler(tp, []uiprojector.Projector{p})
 	require.NoError(t, err)
 
 	blueprint := &uiprojector.Blueprint{
@@ -167,7 +192,7 @@ func TestAssembler_Assemble_TemplateFetchError(t *testing.T) {
 	ctx := context.Background()
 	fetchErr := errors.New("boom")
 	tp := &stubTemplateProvider{err: fetchErr}
-	asm, err := uiprojector.NewAssembler(tp, map[string]uiprojector.Projector{"P": &stubProjector{}})
+	asm, err := uiprojector.NewAssembler(tp, []uiprojector.Projector{&stubProjector{typeName: "P"}})
 	require.NoError(t, err)
 
 	bp := &uiprojector.Blueprint{Sections: map[string]uiprojector.SectionBlueprint{
@@ -183,7 +208,7 @@ func TestAssembler_Assemble_TemplateFetchError(t *testing.T) {
 func TestAssembler_Assemble_UnknownProjector(t *testing.T) {
 	ctx := context.Background()
 	tp := &stubTemplateProvider{templates: map[string][]byte{"t": []byte("x")}}
-	asm, err := uiprojector.NewAssembler(tp, map[string]uiprojector.Projector{})
+	asm, err := uiprojector.NewAssembler(tp, nil)
 	require.NoError(t, err)
 
 	bp := &uiprojector.Blueprint{Sections: map[string]uiprojector.SectionBlueprint{
@@ -200,8 +225,8 @@ func TestAssembler_Assemble_ProjectorError(t *testing.T) {
 	ctx := context.Background()
 	tp := &stubTemplateProvider{templates: map[string][]byte{"t": []byte("x")}}
 	projErr := errors.New("render failed")
-	p := &stubProjector{err: projErr}
-	asm, err := uiprojector.NewAssembler(tp, map[string]uiprojector.Projector{"P": p})
+	p := &stubProjector{typeName: "P", err: projErr}
+	asm, err := uiprojector.NewAssembler(tp, []uiprojector.Projector{p})
 	require.NoError(t, err)
 
 	bp := &uiprojector.Blueprint{Sections: map[string]uiprojector.SectionBlueprint{
@@ -217,8 +242,8 @@ func TestAssembler_Assemble_ProjectorError(t *testing.T) {
 func TestAssembler_Assemble_DataKeyMissingPassesNil(t *testing.T) {
 	ctx := context.Background()
 	tp := &stubTemplateProvider{templates: map[string][]byte{"t": []byte("x")}}
-	p := &stubProjector{out: "ok"}
-	asm, err := uiprojector.NewAssembler(tp, map[string]uiprojector.Projector{"P": p})
+	p := &stubProjector{typeName: "P", out: "ok"}
+	asm, err := uiprojector.NewAssembler(tp, []uiprojector.Projector{p})
 	require.NoError(t, err)
 
 	bp := &uiprojector.Blueprint{Sections: map[string]uiprojector.SectionBlueprint{

--- a/backend/pkg/uiprojector/assembler_test.go
+++ b/backend/pkg/uiprojector/assembler_test.go
@@ -43,16 +43,18 @@ func (p *stubProjector) Project(_ context.Context, template []byte, data any) (a
 }
 
 func TestNewAssembler(t *testing.T) {
-	t.Run("panics on nil TemplateProvider", func(t *testing.T) {
-		assert.Panics(t, func() {
-			uiprojector.NewAssembler(nil, nil)
-		})
+	t.Run("returns error on nil TemplateProvider", func(t *testing.T) {
+		asm, err := uiprojector.NewAssembler(nil, nil)
+		assert.Error(t, err)
+		assert.Nil(t, asm)
+		assert.Contains(t, err.Error(), "template provider is required")
 	})
 
 	t.Run("deep copies the projectors map", func(t *testing.T) {
 		pMap := map[string]uiprojector.Projector{"P1": &stubProjector{}}
 		tp := &stubTemplateProvider{}
-		asm := uiprojector.NewAssembler(tp, pMap)
+		asm, err := uiprojector.NewAssembler(tp, pMap)
+		require.NoError(t, err)
 
 		// Mutate original map
 		delete(pMap, "P1")
@@ -65,7 +67,7 @@ func TestNewAssembler(t *testing.T) {
 			"zone1": {ID: "s", TemplateID: "t", Projector: "P1"},
 		}}
 
-		_, err := asm.Assemble(ctx, bp, uiprojector.Facts{})
+		_, err = asm.Assemble(ctx, bp, uiprojector.Facts{})
 		assert.NoError(t, err, "Assembler should still have P1")
 
 		bp2 := &uiprojector.Blueprint{Sections: map[string]uiprojector.SectionBlueprint{
@@ -84,7 +86,8 @@ func TestAssembler_Assemble_HappyPath(t *testing.T) {
 	}}
 	pA := &stubProjector{out: "rendered-A"}
 	pB := &stubProjector{out: "rendered-B"}
-	asm := uiprojector.NewAssembler(tp, map[string]uiprojector.Projector{"PA": pA, "PB": pB})
+	asm, err := uiprojector.NewAssembler(tp, map[string]uiprojector.Projector{"PA": pA, "PB": pB})
+	require.NoError(t, err)
 
 	blueprint := &uiprojector.Blueprint{
 		ID: "bp",
@@ -121,7 +124,8 @@ func TestAssembler_Assemble_SkipsHiddenSections(t *testing.T) {
 	ctx := context.Background()
 	tp := &stubTemplateProvider{templates: map[string][]byte{"t": []byte("x")}}
 	p := &stubProjector{out: "ok"}
-	asm := uiprojector.NewAssembler(tp, map[string]uiprojector.Projector{"P": p})
+	asm, err := uiprojector.NewAssembler(tp, map[string]uiprojector.Projector{"P": p})
+	require.NoError(t, err)
 
 	blueprint := &uiprojector.Blueprint{
 		Sections: map[string]uiprojector.SectionBlueprint{
@@ -141,7 +145,8 @@ func TestAssembler_Assemble_SkipsHiddenSections(t *testing.T) {
 
 func TestAssembler_Assemble_EmptyBlueprint(t *testing.T) {
 	ctx := context.Background()
-	asm := uiprojector.NewAssembler(&stubTemplateProvider{}, nil)
+	asm, err := uiprojector.NewAssembler(&stubTemplateProvider{}, nil)
+	require.NoError(t, err)
 
 	sections, err := asm.Assemble(ctx, &uiprojector.Blueprint{}, uiprojector.Facts{})
 	require.NoError(t, err)
@@ -150,9 +155,10 @@ func TestAssembler_Assemble_EmptyBlueprint(t *testing.T) {
 
 func TestAssembler_Assemble_BlueprintIsNil(t *testing.T) {
 	ctx := context.Background()
-	asm := uiprojector.NewAssembler(&stubTemplateProvider{}, nil)
+	asm, err := uiprojector.NewAssembler(&stubTemplateProvider{}, nil)
+	require.NoError(t, err)
 
-	_, err := asm.Assemble(ctx, nil, uiprojector.Facts{})
+	_, err = asm.Assemble(ctx, nil, uiprojector.Facts{})
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "blueprint is nil")
 }
@@ -161,13 +167,14 @@ func TestAssembler_Assemble_TemplateFetchError(t *testing.T) {
 	ctx := context.Background()
 	fetchErr := errors.New("boom")
 	tp := &stubTemplateProvider{err: fetchErr}
-	asm := uiprojector.NewAssembler(tp, map[string]uiprojector.Projector{"P": &stubProjector{}})
+	asm, err := uiprojector.NewAssembler(tp, map[string]uiprojector.Projector{"P": &stubProjector{}})
+	require.NoError(t, err)
 
 	bp := &uiprojector.Blueprint{Sections: map[string]uiprojector.SectionBlueprint{
 		"main": {ID: "s", TemplateID: "missing", Projector: "P"},
 	}}
 
-	_, err := asm.Assemble(ctx, bp, uiprojector.Facts{})
+	_, err = asm.Assemble(ctx, bp, uiprojector.Facts{})
 	require.Error(t, err)
 	assert.ErrorIs(t, err, fetchErr)
 	assert.Contains(t, err.Error(), "missing", "error should mention the template ID")
@@ -176,13 +183,14 @@ func TestAssembler_Assemble_TemplateFetchError(t *testing.T) {
 func TestAssembler_Assemble_UnknownProjector(t *testing.T) {
 	ctx := context.Background()
 	tp := &stubTemplateProvider{templates: map[string][]byte{"t": []byte("x")}}
-	asm := uiprojector.NewAssembler(tp, map[string]uiprojector.Projector{})
+	asm, err := uiprojector.NewAssembler(tp, map[string]uiprojector.Projector{})
+	require.NoError(t, err)
 
 	bp := &uiprojector.Blueprint{Sections: map[string]uiprojector.SectionBlueprint{
 		"main": {ID: "s", TemplateID: "t", Projector: "GHOST"},
 	}}
 
-	_, err := asm.Assemble(ctx, bp, uiprojector.Facts{})
+	_, err = asm.Assemble(ctx, bp, uiprojector.Facts{})
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "unknown projector")
 	assert.Contains(t, err.Error(), "GHOST")
@@ -193,13 +201,14 @@ func TestAssembler_Assemble_ProjectorError(t *testing.T) {
 	tp := &stubTemplateProvider{templates: map[string][]byte{"t": []byte("x")}}
 	projErr := errors.New("render failed")
 	p := &stubProjector{err: projErr}
-	asm := uiprojector.NewAssembler(tp, map[string]uiprojector.Projector{"P": p})
+	asm, err := uiprojector.NewAssembler(tp, map[string]uiprojector.Projector{"P": p})
+	require.NoError(t, err)
 
 	bp := &uiprojector.Blueprint{Sections: map[string]uiprojector.SectionBlueprint{
 		"main": {ID: "section-7", TemplateID: "t", Projector: "P"},
 	}}
 
-	_, err := asm.Assemble(ctx, bp, uiprojector.Facts{})
+	_, err = asm.Assemble(ctx, bp, uiprojector.Facts{})
 	require.Error(t, err)
 	assert.ErrorIs(t, err, projErr)
 	assert.Contains(t, err.Error(), "section-7", "error should mention the failing section ID")
@@ -209,14 +218,15 @@ func TestAssembler_Assemble_DataKeyMissingPassesNil(t *testing.T) {
 	ctx := context.Background()
 	tp := &stubTemplateProvider{templates: map[string][]byte{"t": []byte("x")}}
 	p := &stubProjector{out: "ok"}
-	asm := uiprojector.NewAssembler(tp, map[string]uiprojector.Projector{"P": p})
+	asm, err := uiprojector.NewAssembler(tp, map[string]uiprojector.Projector{"P": p})
+	require.NoError(t, err)
 
 	bp := &uiprojector.Blueprint{Sections: map[string]uiprojector.SectionBlueprint{
 		"main": {ID: "s", TemplateID: "t", Projector: "P", DataKey: "absent"},
 	}}
 	facts := uiprojector.Facts{Data: map[string]any{"other": 1}}
 
-	_, err := asm.Assemble(ctx, bp, facts)
+	_, err = asm.Assemble(ctx, bp, facts)
 	require.NoError(t, err)
 	assert.Nil(t, p.lastData, "DataKey lookup on missing key should pass nil")
 }

--- a/backend/pkg/uiprojector/assembler_test.go
+++ b/backend/pkg/uiprojector/assembler_test.go
@@ -42,6 +42,40 @@ func (p *stubProjector) Project(_ context.Context, template []byte, data any) (a
 	return p.out, nil
 }
 
+func TestNewAssembler(t *testing.T) {
+	t.Run("panics on nil TemplateProvider", func(t *testing.T) {
+		assert.Panics(t, func() {
+			uiprojector.NewAssembler(nil, nil)
+		})
+	})
+
+	t.Run("deep copies the projectors map", func(t *testing.T) {
+		pMap := map[string]uiprojector.Projector{"P1": &stubProjector{}}
+		tp := &stubTemplateProvider{}
+		asm := uiprojector.NewAssembler(tp, pMap)
+
+		// Mutate original map
+		delete(pMap, "P1")
+		pMap["P2"] = &stubProjector{}
+
+		// Assembler should be unaffected
+		ctx := context.Background()
+		tp.templates = map[string][]byte{"t": []byte("x")}
+		bp := &uiprojector.Blueprint{Sections: []uiprojector.SectionBlueprint{
+			{ID: "s", TemplateID: "t", Projector: "P1"},
+		}}
+
+		_, err := asm.Assemble(ctx, bp, uiprojector.Facts{})
+		assert.NoError(t, err, "Assembler should still have P1")
+
+		bp2 := &uiprojector.Blueprint{Sections: []uiprojector.SectionBlueprint{
+			{ID: "s", TemplateID: "t", Projector: "P2"},
+		}}
+		_, err = asm.Assemble(ctx, bp2, uiprojector.Facts{})
+		assert.Error(t, err, "Assembler should NOT have P2")
+	})
+}
+
 func TestAssembler_Assemble_HappyPath(t *testing.T) {
 	ctx := context.Background()
 	tp := &stubTemplateProvider{templates: map[string][]byte{
@@ -111,6 +145,15 @@ func TestAssembler_Assemble_EmptyBlueprint(t *testing.T) {
 	sections, err := asm.Assemble(ctx, &uiprojector.Blueprint{}, uiprojector.Facts{})
 	require.NoError(t, err)
 	assert.Empty(t, sections)
+}
+
+func TestAssembler_Assemble_BlueprintIsNil(t *testing.T) {
+	ctx := context.Background()
+	asm := uiprojector.NewAssembler(&stubTemplateProvider{}, nil)
+
+	_, err := asm.Assemble(ctx, nil, uiprojector.Facts{})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "blueprint is nil")
 }
 
 func TestAssembler_Assemble_TemplateFetchError(t *testing.T) {

--- a/backend/pkg/uiprojector/assembler_test.go
+++ b/backend/pkg/uiprojector/assembler_test.go
@@ -61,15 +61,15 @@ func TestNewAssembler(t *testing.T) {
 		// Assembler should be unaffected
 		ctx := context.Background()
 		tp.templates = map[string][]byte{"t": []byte("x")}
-		bp := &uiprojector.Blueprint{Sections: []uiprojector.SectionBlueprint{
-			{ID: "s", TemplateID: "t", Projector: "P1"},
+		bp := &uiprojector.Blueprint{Sections: map[string]uiprojector.SectionBlueprint{
+			"zone1": {ID: "s", TemplateID: "t", Projector: "P1"},
 		}}
 
 		_, err := asm.Assemble(ctx, bp, uiprojector.Facts{})
 		assert.NoError(t, err, "Assembler should still have P1")
 
-		bp2 := &uiprojector.Blueprint{Sections: []uiprojector.SectionBlueprint{
-			{ID: "s", TemplateID: "t", Projector: "P2"},
+		bp2 := &uiprojector.Blueprint{Sections: map[string]uiprojector.SectionBlueprint{
+			"zone1": {ID: "s", TemplateID: "t", Projector: "P2"},
 		}}
 		_, err = asm.Assemble(ctx, bp2, uiprojector.Facts{})
 		assert.Error(t, err, "Assembler should NOT have P2")
@@ -88,9 +88,9 @@ func TestAssembler_Assemble_HappyPath(t *testing.T) {
 
 	blueprint := &uiprojector.Blueprint{
 		ID: "bp",
-		Sections: []uiprojector.SectionBlueprint{
-			{ID: "s1", Title: "First", TemplateID: "tpl-a", Projector: "PA", DataKey: "alpha"},
-			{ID: "s2", Title: "Second", TemplateID: "tpl-b", Projector: "PB"},
+		Sections: map[string]uiprojector.SectionBlueprint{
+			"main":    {ID: "s1", Title: "First", TemplateID: "tpl-a", Projector: "PA", DataKey: "alpha"},
+			"sidebar": {ID: "s2", Title: "Second", TemplateID: "tpl-b", Projector: "PB"},
 		},
 	}
 	facts := uiprojector.Facts{
@@ -105,15 +105,15 @@ func TestAssembler_Assemble_HappyPath(t *testing.T) {
 	require.NoError(t, err)
 	require.Len(t, sections, 2)
 
-	assert.Equal(t, "s1", sections[0].ID)
-	assert.Equal(t, "First", sections[0].Title)
-	assert.Equal(t, uiprojector.SectionType("PA"), sections[0].Type)
-	assert.Equal(t, "rendered-A", sections[0].Content)
+	assert.Equal(t, "s1", sections["main"].ID)
+	assert.Equal(t, "First", sections["main"].Title)
+	assert.Equal(t, uiprojector.SectionType("PA"), sections["main"].Type)
+	assert.Equal(t, "rendered-A", sections["main"].Content)
 	assert.Equal(t, map[string]any{"x": 1}, pA.lastData, "DataKey should pluck alpha")
 	assert.Equal(t, []byte("A"), pA.lastTemplate)
 
-	assert.Equal(t, "s2", sections[1].ID)
-	assert.Equal(t, uiprojector.SectionType("PB"), sections[1].Type)
+	assert.Equal(t, "s2", sections["sidebar"].ID)
+	assert.Equal(t, uiprojector.SectionType("PB"), sections["sidebar"].Type)
 	assert.Equal(t, facts.Data, pB.lastData, "empty DataKey should pass full Data")
 }
 
@@ -124,9 +124,9 @@ func TestAssembler_Assemble_SkipsHiddenSections(t *testing.T) {
 	asm := uiprojector.NewAssembler(tp, map[string]uiprojector.Projector{"P": p})
 
 	blueprint := &uiprojector.Blueprint{
-		Sections: []uiprojector.SectionBlueprint{
-			{ID: "visible", TemplateID: "t", Projector: "P"},
-			{ID: "hidden", TemplateID: "t", Projector: "P", VisibleWhen: &uiprojector.VisibleWhen{
+		Sections: map[string]uiprojector.SectionBlueprint{
+			"visible": {ID: "visible", TemplateID: "t", Projector: "P"},
+			"hidden": {ID: "hidden", TemplateID: "t", Projector: "P", VisibleWhen: &uiprojector.VisibleWhen{
 				States: []string{"NEVER"},
 			}},
 		},
@@ -135,7 +135,8 @@ func TestAssembler_Assemble_SkipsHiddenSections(t *testing.T) {
 	sections, err := asm.Assemble(ctx, blueprint, uiprojector.Facts{State: "ANY"})
 	require.NoError(t, err)
 	require.Len(t, sections, 1)
-	assert.Equal(t, "visible", sections[0].ID)
+	assert.Contains(t, sections, "visible")
+	assert.NotContains(t, sections, "hidden")
 }
 
 func TestAssembler_Assemble_EmptyBlueprint(t *testing.T) {
@@ -162,8 +163,8 @@ func TestAssembler_Assemble_TemplateFetchError(t *testing.T) {
 	tp := &stubTemplateProvider{err: fetchErr}
 	asm := uiprojector.NewAssembler(tp, map[string]uiprojector.Projector{"P": &stubProjector{}})
 
-	bp := &uiprojector.Blueprint{Sections: []uiprojector.SectionBlueprint{
-		{ID: "s", TemplateID: "missing", Projector: "P"},
+	bp := &uiprojector.Blueprint{Sections: map[string]uiprojector.SectionBlueprint{
+		"main": {ID: "s", TemplateID: "missing", Projector: "P"},
 	}}
 
 	_, err := asm.Assemble(ctx, bp, uiprojector.Facts{})
@@ -177,8 +178,8 @@ func TestAssembler_Assemble_UnknownProjector(t *testing.T) {
 	tp := &stubTemplateProvider{templates: map[string][]byte{"t": []byte("x")}}
 	asm := uiprojector.NewAssembler(tp, map[string]uiprojector.Projector{})
 
-	bp := &uiprojector.Blueprint{Sections: []uiprojector.SectionBlueprint{
-		{ID: "s", TemplateID: "t", Projector: "GHOST"},
+	bp := &uiprojector.Blueprint{Sections: map[string]uiprojector.SectionBlueprint{
+		"main": {ID: "s", TemplateID: "t", Projector: "GHOST"},
 	}}
 
 	_, err := asm.Assemble(ctx, bp, uiprojector.Facts{})
@@ -194,8 +195,8 @@ func TestAssembler_Assemble_ProjectorError(t *testing.T) {
 	p := &stubProjector{err: projErr}
 	asm := uiprojector.NewAssembler(tp, map[string]uiprojector.Projector{"P": p})
 
-	bp := &uiprojector.Blueprint{Sections: []uiprojector.SectionBlueprint{
-		{ID: "section-7", TemplateID: "t", Projector: "P"},
+	bp := &uiprojector.Blueprint{Sections: map[string]uiprojector.SectionBlueprint{
+		"main": {ID: "section-7", TemplateID: "t", Projector: "P"},
 	}}
 
 	_, err := asm.Assemble(ctx, bp, uiprojector.Facts{})
@@ -210,8 +211,8 @@ func TestAssembler_Assemble_DataKeyMissingPassesNil(t *testing.T) {
 	p := &stubProjector{out: "ok"}
 	asm := uiprojector.NewAssembler(tp, map[string]uiprojector.Projector{"P": p})
 
-	bp := &uiprojector.Blueprint{Sections: []uiprojector.SectionBlueprint{
-		{ID: "s", TemplateID: "t", Projector: "P", DataKey: "absent"},
+	bp := &uiprojector.Blueprint{Sections: map[string]uiprojector.SectionBlueprint{
+		"main": {ID: "s", TemplateID: "t", Projector: "P", DataKey: "absent"},
 	}}
 	facts := uiprojector.Facts{Data: map[string]any{"other": 1}}
 

--- a/backend/pkg/uiprojector/blueprint.go
+++ b/backend/pkg/uiprojector/blueprint.go
@@ -1,0 +1,47 @@
+package uiprojector
+
+// Blueprint defines the layout and rules for a UI view.
+type Blueprint struct {
+	ID       string             `json:"id"`
+	Sections []SectionBlueprint `json:"sections"`
+}
+
+// SectionBlueprint defines an individual component within a layout.
+type SectionBlueprint struct {
+	ID          string       `json:"id"`
+	TemplateID  string       `json:"templateId"`
+	Title       string       `json:"title"`
+	Projector   string       `json:"projector"` // e.g., FORM, MARKDOWN
+	DataKey     string       `json:"dataKey"`   // The key in Facts.Data to pluck for this section
+	VisibleWhen *VisibleWhen `json:"visibleWhen,omitempty"`
+}
+
+// VisibleWhen defines declarative visibility rules based on Facts.
+type VisibleWhen struct {
+	States         []string `json:"states,omitempty"`         // Required Facts.State values
+	RequireDataKey string   `json:"requireDataKey,omitempty"` // Section only visible if this key exists in data
+}
+
+// Facts represents the current state of a business entity to be rendered.
+type Facts struct {
+	State string         `json:"state"` // Logical status (e.g., "PENDING", "COMPLETED")
+	Data  map[string]any `json:"data"`  // The snapshot/registry of business data
+}
+
+// SectionType identifies the projector used for a section.
+type SectionType string
+
+// Section represents a rendered component.
+type Section struct {
+	ID      string      `json:"id"`
+	Type    SectionType `json:"type"`
+	Title   string      `json:"title"`
+	Content any         `json:"content"`
+}
+
+// FormContent is the payload for a FORM projector.
+type FormContent struct {
+	Schema   any `json:"schema"`
+	UISchema any `json:"uiSchema,omitempty"`
+	FormData any `json:"formData,omitempty"`
+}

--- a/backend/pkg/uiprojector/blueprint.go
+++ b/backend/pkg/uiprojector/blueprint.go
@@ -2,8 +2,8 @@ package uiprojector
 
 // Blueprint defines the layout and rules for a UI view.
 type Blueprint struct {
-	ID       string             `json:"id"`
-	Sections []SectionBlueprint `json:"sections"`
+	ID       string                      `json:"id"`
+	Sections map[string]SectionBlueprint `json:"sections"`
 }
 
 // SectionBlueprint defines an individual component within a layout.

--- a/backend/pkg/uiprojector/defaults.go
+++ b/backend/pkg/uiprojector/defaults.go
@@ -1,0 +1,21 @@
+package uiprojector
+
+// Built-in projector keys. These are the names under which DefaultProjectors
+// registers the projectors shipped with this package. Consumers may use any
+// other string as a key when registering additional projectors.
+const (
+	ProjectorForm     = "FORM"
+	ProjectorMarkdown = "MARKDOWN"
+	ProjectorRaw      = "RAW"
+)
+
+// DefaultProjectors returns a fresh map containing the projectors shipped with
+// this package. The returned map is owned by the caller and safe to mutate —
+// add, override, or delete entries before passing it to NewAssembler.
+func DefaultProjectors() map[string]Projector {
+	return map[string]Projector{
+		ProjectorForm:     NewFormProjector(),
+		ProjectorMarkdown: NewMarkdownProjector(),
+		ProjectorRaw:      NewRawProjector(),
+	}
+}

--- a/backend/pkg/uiprojector/defaults.go
+++ b/backend/pkg/uiprojector/defaults.go
@@ -1,21 +1,22 @@
 package uiprojector
 
-// Built-in projector keys. These are the names under which DefaultProjectors
-// registers the projectors shipped with this package. Consumers may use any
-// other string as a key when registering additional projectors.
+// Built-in projector keys. These are the names returned by each projector's
+// Type() method, and they match the SectionBlueprint.Projector values used in
+// blueprints. Consumers may register additional projectors whose Type() returns
+// any other unique string.
 const (
-	ProjectorForm     = "FORM"
-	ProjectorMarkdown = "MARKDOWN"
-	ProjectorRaw      = "RAW"
+	ProjectorForm     ProjectorType = "FORM"
+	ProjectorMarkdown ProjectorType = "MARKDOWN"
+	ProjectorRaw      ProjectorType = "RAW"
 )
 
-// DefaultProjectors returns a fresh map containing the projectors shipped with
-// this package. The returned map is owned by the caller and safe to mutate —
-// add, override, or delete entries before passing it to NewAssembler.
-func DefaultProjectors() map[string]Projector {
-	return map[string]Projector{
-		ProjectorForm:     NewFormProjector(),
-		ProjectorMarkdown: NewMarkdownProjector(),
-		ProjectorRaw:      NewRawProjector(),
+// DefaultProjectors returns a fresh slice containing the projectors shipped
+// with this package. The returned slice is owned by the caller and safe to
+// mutate — append, replace, or drop entries before passing it to NewAssembler.
+func DefaultProjectors() []Projector {
+	return []Projector{
+		NewFormProjector(),
+		NewMarkdownProjector(),
+		NewRawProjector(),
 	}
 }

--- a/backend/pkg/uiprojector/defaults_test.go
+++ b/backend/pkg/uiprojector/defaults_test.go
@@ -1,0 +1,34 @@
+package uiprojector_test
+
+import (
+	"testing"
+
+	"github.com/OpenNSW/nsw/pkg/uiprojector"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestProjectorConstants(t *testing.T) {
+	assert.Equal(t, "FORM", uiprojector.ProjectorForm)
+	assert.Equal(t, "MARKDOWN", uiprojector.ProjectorMarkdown)
+	assert.Equal(t, "RAW", uiprojector.ProjectorRaw)
+}
+
+func TestDefaultProjectors_RegistersBuiltIns(t *testing.T) {
+	p := uiprojector.DefaultProjectors()
+
+	assert.Len(t, p, 3)
+	assert.IsType(t, &uiprojector.FormProjector{}, p[uiprojector.ProjectorForm])
+	assert.IsType(t, &uiprojector.MarkdownProjector{}, p[uiprojector.ProjectorMarkdown])
+	assert.IsType(t, &uiprojector.RawProjector{}, p[uiprojector.ProjectorRaw])
+}
+
+func TestDefaultProjectors_ReturnsIndependentMaps(t *testing.T) {
+	a := uiprojector.DefaultProjectors()
+	b := uiprojector.DefaultProjectors()
+
+	delete(a, uiprojector.ProjectorForm)
+	a["CUSTOM"] = uiprojector.NewRawProjector()
+
+	assert.Contains(t, b, uiprojector.ProjectorForm, "mutating one map must not affect another")
+	assert.NotContains(t, b, "CUSTOM")
+}

--- a/backend/pkg/uiprojector/defaults_test.go
+++ b/backend/pkg/uiprojector/defaults_test.go
@@ -8,27 +8,29 @@ import (
 )
 
 func TestProjectorConstants(t *testing.T) {
-	assert.Equal(t, "FORM", uiprojector.ProjectorForm)
-	assert.Equal(t, "MARKDOWN", uiprojector.ProjectorMarkdown)
-	assert.Equal(t, "RAW", uiprojector.ProjectorRaw)
+	assert.Equal(t, uiprojector.ProjectorType("FORM"), uiprojector.ProjectorForm)
+	assert.Equal(t, uiprojector.ProjectorType("MARKDOWN"), uiprojector.ProjectorMarkdown)
+	assert.Equal(t, uiprojector.ProjectorType("RAW"), uiprojector.ProjectorRaw)
 }
 
 func TestDefaultProjectors_RegistersBuiltIns(t *testing.T) {
 	p := uiprojector.DefaultProjectors()
 
 	assert.Len(t, p, 3)
-	assert.IsType(t, &uiprojector.FormProjector{}, p[uiprojector.ProjectorForm])
-	assert.IsType(t, &uiprojector.MarkdownProjector{}, p[uiprojector.ProjectorMarkdown])
-	assert.IsType(t, &uiprojector.RawProjector{}, p[uiprojector.ProjectorRaw])
+	byType := make(map[uiprojector.ProjectorType]uiprojector.Projector, len(p))
+	for _, proj := range p {
+		byType[proj.Type()] = proj
+	}
+	assert.IsType(t, &uiprojector.FormProjector{}, byType[uiprojector.ProjectorForm])
+	assert.IsType(t, &uiprojector.MarkdownProjector{}, byType[uiprojector.ProjectorMarkdown])
+	assert.IsType(t, &uiprojector.RawProjector{}, byType[uiprojector.ProjectorRaw])
 }
 
-func TestDefaultProjectors_ReturnsIndependentMaps(t *testing.T) {
+func TestDefaultProjectors_ReturnsIndependentSlices(t *testing.T) {
 	a := uiprojector.DefaultProjectors()
 	b := uiprojector.DefaultProjectors()
 
-	delete(a, uiprojector.ProjectorForm)
-	a["CUSTOM"] = uiprojector.NewRawProjector()
+	a[0] = uiprojector.NewRawProjector()
 
-	assert.Contains(t, b, uiprojector.ProjectorForm, "mutating one map must not affect another")
-	assert.NotContains(t, b, "CUSTOM")
+	assert.IsType(t, &uiprojector.FormProjector{}, b[0], "mutating one slice must not affect another")
 }

--- a/backend/pkg/uiprojector/projector.go
+++ b/backend/pkg/uiprojector/projector.go
@@ -8,8 +8,15 @@ import (
 	"text/template"
 )
 
+// ProjectorType identifies a projector implementation. External packages may
+// declare their own ProjectorType constants to register custom projectors.
+type ProjectorType string
+
 // Projector defines the interface for transforming raw template + data into a UI payload.
+// Type returns the identifier under which the projector is registered; it must match
+// the SectionBlueprint.Projector values used in blueprints.
 type Projector interface {
+	Type() ProjectorType
 	Project(ctx context.Context, templateContent []byte, data any) (any, error)
 }
 
@@ -19,6 +26,8 @@ type FormProjector struct{}
 func NewFormProjector() *FormProjector {
 	return &FormProjector{}
 }
+
+func (p *FormProjector) Type() ProjectorType { return ProjectorForm }
 
 func (p *FormProjector) Project(ctx context.Context, templateContent []byte, data any) (any, error) {
 	var schema map[string]any
@@ -40,6 +49,8 @@ func NewMarkdownProjector() *MarkdownProjector {
 	return &MarkdownProjector{}
 }
 
+func (p *MarkdownProjector) Type() ProjectorType { return ProjectorMarkdown }
+
 func (p *MarkdownProjector) Project(ctx context.Context, templateContent []byte, data any) (any, error) {
 	tmpl, err := template.New("markdown").Parse(string(templateContent))
 	if err != nil {
@@ -60,6 +71,8 @@ type RawProjector struct{}
 func NewRawProjector() *RawProjector {
 	return &RawProjector{}
 }
+
+func (p *RawProjector) Type() ProjectorType { return ProjectorRaw }
 
 func (p *RawProjector) Project(ctx context.Context, templateContent []byte, data any) (any, error) {
 	return data, nil

--- a/backend/pkg/uiprojector/projector.go
+++ b/backend/pkg/uiprojector/projector.go
@@ -1,0 +1,66 @@
+package uiprojector
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"text/template"
+)
+
+// Projector defines the interface for transforming raw template + data into a UI payload.
+type Projector interface {
+	Project(ctx context.Context, templateContent []byte, data any) (any, error)
+}
+
+// FormProjector projects raw JSON schema into a FormContent payload.
+type FormProjector struct{}
+
+func NewFormProjector() *FormProjector {
+	return &FormProjector{}
+}
+
+func (p *FormProjector) Project(ctx context.Context, templateContent []byte, data any) (any, error) {
+	var schema map[string]any
+	if err := json.Unmarshal(templateContent, &schema); err != nil {
+		return nil, fmt.Errorf("form_projector: failed to parse schema: %w", err)
+	}
+
+	return FormContent{
+		Schema:   schema["schema"],
+		UISchema: schema["uiSchema"],
+		FormData: data,
+	}, nil
+}
+
+// MarkdownProjector projects a markdown template using Go's text/template.
+type MarkdownProjector struct{}
+
+func NewMarkdownProjector() *MarkdownProjector {
+	return &MarkdownProjector{}
+}
+
+func (p *MarkdownProjector) Project(ctx context.Context, templateContent []byte, data any) (any, error) {
+	tmpl, err := template.New("markdown").Parse(string(templateContent))
+	if err != nil {
+		return nil, fmt.Errorf("markdown_projector: failed to parse template: %w", err)
+	}
+
+	var buf bytes.Buffer
+	if err := tmpl.Execute(&buf, data); err != nil {
+		return nil, fmt.Errorf("markdown_projector: failed to execute template: %w", err)
+	}
+
+	return buf.String(), nil
+}
+
+// RawProjector returns the data as-is without any transformation.
+type RawProjector struct{}
+
+func NewRawProjector() *RawProjector {
+	return &RawProjector{}
+}
+
+func (p *RawProjector) Project(ctx context.Context, templateContent []byte, data any) (any, error) {
+	return data, nil
+}

--- a/backend/pkg/uiprojector/projector_test.go
+++ b/backend/pkg/uiprojector/projector_test.go
@@ -1,0 +1,117 @@
+package uiprojector_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/OpenNSW/nsw/pkg/uiprojector"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestFormProjector_Project(t *testing.T) {
+	ctx := context.Background()
+	p := uiprojector.NewFormProjector()
+
+	t.Run("returns FormContent populated from schema, uiSchema, and data", func(t *testing.T) {
+		template := []byte(`{"schema": {"type": "object"}, "uiSchema": {"ui:order": ["name"]}}`)
+		data := map[string]any{"name": "John"}
+
+		out, err := p.Project(ctx, template, data)
+		require.NoError(t, err)
+
+		fc, ok := out.(uiprojector.FormContent)
+		require.True(t, ok, "expected FormContent, got %T", out)
+		assert.Equal(t, map[string]any{"type": "object"}, fc.Schema)
+		assert.Equal(t, map[string]any{"ui:order": []any{"name"}}, fc.UISchema)
+		assert.Equal(t, data, fc.FormData)
+	})
+
+	t.Run("uiSchema is nil when absent from template", func(t *testing.T) {
+		template := []byte(`{"schema": {"type": "object"}}`)
+		out, err := p.Project(ctx, template, nil)
+		require.NoError(t, err)
+
+		fc := out.(uiprojector.FormContent)
+		assert.NotNil(t, fc.Schema)
+		assert.Nil(t, fc.UISchema)
+		assert.Nil(t, fc.FormData)
+	})
+
+	t.Run("empty JSON object yields nil schema and uiSchema but preserves data", func(t *testing.T) {
+		out, err := p.Project(ctx, []byte("{}"), "data")
+		require.NoError(t, err)
+
+		fc := out.(uiprojector.FormContent)
+		assert.Nil(t, fc.Schema)
+		assert.Nil(t, fc.UISchema)
+		assert.Equal(t, "data", fc.FormData)
+	})
+
+	t.Run("returns error on invalid JSON", func(t *testing.T) {
+		_, err := p.Project(ctx, []byte("not json"), nil)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "form_projector")
+		assert.Contains(t, err.Error(), "failed to parse schema")
+	})
+}
+
+func TestMarkdownProjector_Project(t *testing.T) {
+	ctx := context.Background()
+	p := uiprojector.NewMarkdownProjector()
+
+	t.Run("substitutes data fields into template", func(t *testing.T) {
+		out, err := p.Project(ctx, []byte("Hello {{.Name}}!"), map[string]any{"Name": "World"})
+		require.NoError(t, err)
+		assert.Equal(t, "Hello World!", out)
+	})
+
+	t.Run("returns template verbatim when there are no placeholders", func(t *testing.T) {
+		out, err := p.Project(ctx, []byte("static text"), nil)
+		require.NoError(t, err)
+		assert.Equal(t, "static text", out)
+	})
+
+	t.Run("returns empty string for empty template", func(t *testing.T) {
+		out, err := p.Project(ctx, []byte(""), nil)
+		require.NoError(t, err)
+		assert.Equal(t, "", out)
+	})
+
+	t.Run("renders <no value> for missing fields under default text/template options", func(t *testing.T) {
+		out, err := p.Project(ctx, []byte("Hello {{.Missing}}"), map[string]any{})
+		require.NoError(t, err)
+		assert.Contains(t, out.(string), "<no value>")
+	})
+
+	t.Run("returns parse error for malformed template syntax", func(t *testing.T) {
+		_, err := p.Project(ctx, []byte("{{.Name"), nil)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "markdown_projector")
+		assert.Contains(t, err.Error(), "failed to parse template")
+	})
+}
+
+func TestRawProjector_Project(t *testing.T) {
+	ctx := context.Background()
+	p := uiprojector.NewRawProjector()
+
+	t.Run("returns data unchanged for map input", func(t *testing.T) {
+		data := map[string]any{"foo": "bar"}
+		out, err := p.Project(ctx, []byte("ignored"), data)
+		require.NoError(t, err)
+		assert.Equal(t, data, out)
+	})
+
+	t.Run("returns nil when data is nil", func(t *testing.T) {
+		out, err := p.Project(ctx, nil, nil)
+		require.NoError(t, err)
+		assert.Nil(t, out)
+	})
+
+	t.Run("ignores template content entirely", func(t *testing.T) {
+		out, err := p.Project(ctx, []byte("garbage that would break other projectors"), 42)
+		require.NoError(t, err)
+		assert.Equal(t, 42, out)
+	})
+}

--- a/backend/pkg/uiprojector/test/integration/integration_test.go
+++ b/backend/pkg/uiprojector/test/integration/integration_test.go
@@ -1,0 +1,175 @@
+package integration
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/OpenNSW/nsw/pkg/uiprojector"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// fileTemplateProvider implements uiprojector.TemplateProvider by reading from local files.
+type fileTemplateProvider struct {
+	basePath string
+}
+
+func (p *fileTemplateProvider) GetTemplate(ctx context.Context, templateID string) ([]byte, error) {
+	path := filepath.Join(p.basePath, templateID)
+	content, err := os.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read template %s: %w", templateID, err)
+	}
+	return content, nil
+}
+
+func TestUIProjectorIntegration(t *testing.T) {
+	ctx := context.Background()
+	testDataPath := "testdata/templates"
+
+	// 1. Initialize Assembler with real projectors
+	provider := &fileTemplateProvider{basePath: testDataPath}
+	projectors := map[string]uiprojector.Projector{
+		"FORM":     uiprojector.NewFormProjector(),
+		"MARKDOWN": uiprojector.NewMarkdownProjector(),
+	}
+	assembler := uiprojector.NewAssembler(provider, projectors)
+
+	// 2. Define a Blueprint for a complex view
+	blueprint := &uiprojector.Blueprint{
+		ID: "consignment_review",
+		Sections: []uiprojector.SectionBlueprint{
+			{
+				ID:         "header",
+				Title:      "Consignment Status",
+				TemplateID: "markdown.md",
+				Projector:  "MARKDOWN",
+				DataKey:    "summary",
+			},
+			{
+				ID:         "declaration_form",
+				Title:      "Import Declaration",
+				TemplateID: "form.json",
+				Projector:  "FORM",
+				DataKey:    "declaration",
+				VisibleWhen: &uiprojector.VisibleWhen{
+					States: []string{"INITIALIZED", "IN_PROGRESS"},
+				},
+			},
+			{
+				ID:         "approval_note",
+				Title:      "Final Approval",
+				TemplateID: "markdown.md",
+				Projector:  "MARKDOWN",
+				DataKey:    "approval",
+				VisibleWhen: &uiprojector.VisibleWhen{
+					States: []string{"APPROVED"},
+				},
+			},
+		},
+	}
+
+	t.Run("Assemble InProgress State", func(t *testing.T) {
+		facts := uiprojector.Facts{
+			State: "IN_PROGRESS",
+			Data: map[string]any{
+				"summary": map[string]any{
+					"name":   "Trader Joe",
+					"status": "In Progress",
+				},
+				"declaration": map[string]any{
+					"name":  "John Doe",
+					"email": "john@example.com",
+				},
+			},
+		}
+
+		sections, err := assembler.Assemble(ctx, blueprint, facts)
+		require.NoError(t, err)
+
+		// Should have header and declaration form (not approval note)
+		assert.Len(t, sections, 2)
+		assert.Equal(t, "header", sections[0].ID)
+		assert.Equal(t, "declaration_form", sections[1].ID)
+
+		// Verify Markdown content
+		assert.Contains(t, sections[0].Content.(string), "Welcome, Trader Joe!")
+		assert.Contains(t, sections[0].Content.(string), "In Progress")
+
+		// Verify Form content
+		formContent := sections[1].Content.(uiprojector.FormContent)
+		assert.NotNil(t, formContent.Schema)
+		assert.Equal(t, "John Doe", formContent.FormData.(map[string]any)["name"])
+	})
+
+	t.Run("Assemble Approved State (Visibility Logic)", func(t *testing.T) {
+		facts := uiprojector.Facts{
+			State: "APPROVED",
+			Data: map[string]any{
+				"summary": map[string]any{
+					"name":   "Trader Joe",
+					"status": "Completed",
+				},
+				"approval": map[string]any{
+					"name":   "Officer Smith",
+					"status": "APPROVED",
+				},
+			},
+		}
+
+		sections, err := assembler.Assemble(ctx, blueprint, facts)
+		require.NoError(t, err)
+
+		// Should have header and approval note (not declaration form)
+		assert.Len(t, sections, 2)
+		assert.Equal(t, "header", sections[0].ID)
+		assert.Equal(t, "approval_note", sections[1].ID)
+
+		assert.Contains(t, sections[1].Content.(string), "Welcome, Officer Smith!")
+	})
+
+	t.Run("DataKey Requirement Validation", func(t *testing.T) {
+		// Add a section that requires a specific data key to be present
+		blueprint.Sections = append(blueprint.Sections, uiprojector.SectionBlueprint{
+			ID:         "conditional_section",
+			TemplateID: "markdown.md",
+			Projector:  "MARKDOWN",
+			DataKey:    "extra_info",
+			VisibleWhen: &uiprojector.VisibleWhen{
+				RequireDataKey: "extra_info",
+			},
+		})
+
+		facts := uiprojector.Facts{
+			State: "IN_PROGRESS",
+			Data: map[string]any{
+				"summary": map[string]any{"name": "Joe", "status": "Test"},
+			},
+		}
+
+		sections, err := assembler.Assemble(ctx, blueprint, facts)
+		require.NoError(t, err)
+
+		// conditional_section should be missing because extra_info data key is missing
+		for _, s := range sections {
+			assert.NotEqual(t, "conditional_section", s.ID)
+		}
+
+		// Now add the data key
+		facts.Data["extra_info"] = map[string]any{"name": "Admin", "status": "Online"}
+		sections, err = assembler.Assemble(ctx, blueprint, facts)
+		require.NoError(t, err)
+
+		found := false
+		for _, s := range sections {
+			if s.ID == "conditional_section" {
+				found = true
+				break
+			}
+		}
+		assert.True(t, found, "conditional_section should be present when DataKey exists")
+	})
+}

--- a/backend/pkg/uiprojector/test/integration/integration_test.go
+++ b/backend/pkg/uiprojector/test/integration/integration_test.go
@@ -36,7 +36,8 @@ func TestUIProjectorIntegration(t *testing.T) {
 		"FORM":     uiprojector.NewFormProjector(),
 		"MARKDOWN": uiprojector.NewMarkdownProjector(),
 	}
-	assembler := uiprojector.NewAssembler(provider, projectors)
+	assembler, err := uiprojector.NewAssembler(provider, projectors)
+	require.NoError(t, err)
 
 	// 2. Define a Blueprint for a complex view
 	blueprint := &uiprojector.Blueprint{

--- a/backend/pkg/uiprojector/test/integration/integration_test.go
+++ b/backend/pkg/uiprojector/test/integration/integration_test.go
@@ -32,9 +32,9 @@ func TestUIProjectorIntegration(t *testing.T) {
 
 	// 1. Initialize Assembler with real projectors
 	provider := &fileTemplateProvider{basePath: testDataPath}
-	projectors := map[string]uiprojector.Projector{
-		"FORM":     uiprojector.NewFormProjector(),
-		"MARKDOWN": uiprojector.NewMarkdownProjector(),
+	projectors := []uiprojector.Projector{
+		uiprojector.NewFormProjector(),
+		uiprojector.NewMarkdownProjector(),
 	}
 	assembler, err := uiprojector.NewAssembler(provider, projectors)
 	require.NoError(t, err)

--- a/backend/pkg/uiprojector/test/integration/integration_test.go
+++ b/backend/pkg/uiprojector/test/integration/integration_test.go
@@ -41,15 +41,15 @@ func TestUIProjectorIntegration(t *testing.T) {
 	// 2. Define a Blueprint for a complex view
 	blueprint := &uiprojector.Blueprint{
 		ID: "consignment_review",
-		Sections: []uiprojector.SectionBlueprint{
-			{
+		Sections: map[string]uiprojector.SectionBlueprint{
+			"header": {
 				ID:         "header",
 				Title:      "Consignment Status",
 				TemplateID: "markdown.md",
 				Projector:  "MARKDOWN",
 				DataKey:    "summary",
 			},
-			{
+			"declaration_form": {
 				ID:         "declaration_form",
 				Title:      "Import Declaration",
 				TemplateID: "form.json",
@@ -59,7 +59,7 @@ func TestUIProjectorIntegration(t *testing.T) {
 					States: []string{"INITIALIZED", "IN_PROGRESS"},
 				},
 			},
-			{
+			"approval_note": {
 				ID:         "approval_note",
 				Title:      "Final Approval",
 				TemplateID: "markdown.md",
@@ -92,15 +92,16 @@ func TestUIProjectorIntegration(t *testing.T) {
 
 		// Should have header and declaration form (not approval note)
 		assert.Len(t, sections, 2)
-		assert.Equal(t, "header", sections[0].ID)
-		assert.Equal(t, "declaration_form", sections[1].ID)
+		assert.Contains(t, sections, "header")
+		assert.Contains(t, sections, "declaration_form")
+		assert.NotContains(t, sections, "approval_note")
 
 		// Verify Markdown content
-		assert.Contains(t, sections[0].Content.(string), "Welcome, Trader Joe!")
-		assert.Contains(t, sections[0].Content.(string), "In Progress")
+		assert.Contains(t, sections["header"].Content.(string), "Welcome, Trader Joe!")
+		assert.Contains(t, sections["header"].Content.(string), "In Progress")
 
 		// Verify Form content
-		formContent := sections[1].Content.(uiprojector.FormContent)
+		formContent := sections["declaration_form"].Content.(uiprojector.FormContent)
 		assert.NotNil(t, formContent.Schema)
 		assert.Equal(t, "John Doe", formContent.FormData.(map[string]any)["name"])
 	})
@@ -125,15 +126,16 @@ func TestUIProjectorIntegration(t *testing.T) {
 
 		// Should have header and approval note (not declaration form)
 		assert.Len(t, sections, 2)
-		assert.Equal(t, "header", sections[0].ID)
-		assert.Equal(t, "approval_note", sections[1].ID)
+		assert.Contains(t, sections, "header")
+		assert.Contains(t, sections, "approval_note")
+		assert.NotContains(t, sections, "declaration_form")
 
-		assert.Contains(t, sections[1].Content.(string), "Welcome, Officer Smith!")
+		assert.Contains(t, sections["approval_note"].Content.(string), "Welcome, Officer Smith!")
 	})
 
 	t.Run("DataKey Requirement Validation", func(t *testing.T) {
 		// Add a section that requires a specific data key to be present
-		blueprint.Sections = append(blueprint.Sections, uiprojector.SectionBlueprint{
+		blueprint.Sections["conditional_section"] = uiprojector.SectionBlueprint{
 			ID:         "conditional_section",
 			TemplateID: "markdown.md",
 			Projector:  "MARKDOWN",
@@ -141,7 +143,7 @@ func TestUIProjectorIntegration(t *testing.T) {
 			VisibleWhen: &uiprojector.VisibleWhen{
 				RequireDataKey: "extra_info",
 			},
-		})
+		}
 
 		facts := uiprojector.Facts{
 			State: "IN_PROGRESS",
@@ -154,22 +156,13 @@ func TestUIProjectorIntegration(t *testing.T) {
 		require.NoError(t, err)
 
 		// conditional_section should be missing because extra_info data key is missing
-		for _, s := range sections {
-			assert.NotEqual(t, "conditional_section", s.ID)
-		}
+		assert.NotContains(t, sections, "conditional_section")
 
 		// Now add the data key
 		facts.Data["extra_info"] = map[string]any{"name": "Admin", "status": "Online"}
 		sections, err = assembler.Assemble(ctx, blueprint, facts)
 		require.NoError(t, err)
 
-		found := false
-		for _, s := range sections {
-			if s.ID == "conditional_section" {
-				found = true
-				break
-			}
-		}
-		assert.True(t, found, "conditional_section should be present when DataKey exists")
+		assert.Contains(t, sections, "conditional_section", "conditional_section should be present when DataKey exists")
 	})
 }

--- a/backend/pkg/uiprojector/test/integration/testdata/templates/form.json
+++ b/backend/pkg/uiprojector/test/integration/testdata/templates/form.json
@@ -1,0 +1,10 @@
+{
+	"schema": {
+		"type": "object",
+		"properties": {
+			"name": { "type": "string" },
+			"email": { "type": "string", "format": "email" }
+		},
+		"required": ["name"]
+	}
+}

--- a/backend/pkg/uiprojector/test/integration/testdata/templates/markdown.md
+++ b/backend/pkg/uiprojector/test/integration/testdata/templates/markdown.md
@@ -1,0 +1,3 @@
+# Welcome, {{.name}}!
+
+Your status is currently **{{.status}}**.

--- a/backend/pkg/uiprojector/visibility.go
+++ b/backend/pkg/uiprojector/visibility.go
@@ -4,14 +4,8 @@ import (
 	"strings"
 )
 
-// VisibilityEvaluator implements generic visibility logic.
-type VisibilityEvaluator struct{}
-
-func NewVisibilityEvaluator() *VisibilityEvaluator {
-	return &VisibilityEvaluator{}
-}
-
-func (e *VisibilityEvaluator) ShouldRender(section SectionBlueprint, facts Facts) bool {
+// ShouldRender implements generic visibility logic.
+func ShouldRender(section SectionBlueprint, facts Facts) bool {
 	if section.VisibleWhen == nil {
 		return true
 	}

--- a/backend/pkg/uiprojector/visibility.go
+++ b/backend/pkg/uiprojector/visibility.go
@@ -1,0 +1,44 @@
+package uiprojector
+
+import (
+	"strings"
+)
+
+// VisibilityEvaluator implements generic visibility logic.
+type VisibilityEvaluator struct{}
+
+func NewVisibilityEvaluator() *VisibilityEvaluator {
+	return &VisibilityEvaluator{}
+}
+
+func (e *VisibilityEvaluator) ShouldRender(section SectionBlueprint, facts Facts) bool {
+	if section.VisibleWhen == nil {
+		return true
+	}
+
+	rules := section.VisibleWhen
+
+	// State-based visibility
+	if len(rules.States) > 0 {
+		found := false
+		for _, s := range rules.States {
+			if strings.EqualFold(s, facts.State) {
+				found = true
+				break
+			}
+		}
+		if !found {
+			return false
+		}
+	}
+
+	// Data-existence visibility
+	if rules.RequireDataKey != "" {
+		val, exists := facts.Data[rules.RequireDataKey]
+		if !exists || val == nil {
+			return false
+		}
+	}
+
+	return true
+}

--- a/backend/pkg/uiprojector/visibility_test.go
+++ b/backend/pkg/uiprojector/visibility_test.go
@@ -1,0 +1,131 @@
+package uiprojector_test
+
+import (
+	"testing"
+
+	"github.com/OpenNSW/nsw/pkg/uiprojector"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestVisibilityEvaluator_ShouldRender(t *testing.T) {
+	e := uiprojector.NewVisibilityEvaluator()
+
+	tests := []struct {
+		name    string
+		section uiprojector.SectionBlueprint
+		facts   uiprojector.Facts
+		want    bool
+	}{
+		{
+			name:    "nil VisibleWhen renders by default",
+			section: uiprojector.SectionBlueprint{},
+			facts:   uiprojector.Facts{State: "ANY"},
+			want:    true,
+		},
+		{
+			name: "state matches one of allowed states",
+			section: uiprojector.SectionBlueprint{
+				VisibleWhen: &uiprojector.VisibleWhen{States: []string{"DRAFT", "IN_PROGRESS"}},
+			},
+			facts: uiprojector.Facts{State: "IN_PROGRESS"},
+			want:  true,
+		},
+		{
+			name: "state does not match any allowed state",
+			section: uiprojector.SectionBlueprint{
+				VisibleWhen: &uiprojector.VisibleWhen{States: []string{"DRAFT"}},
+			},
+			facts: uiprojector.Facts{State: "COMPLETED"},
+			want:  false,
+		},
+		{
+			name: "state comparison is case-insensitive",
+			section: uiprojector.SectionBlueprint{
+				VisibleWhen: &uiprojector.VisibleWhen{States: []string{"in_progress"}},
+			},
+			facts: uiprojector.Facts{State: "IN_PROGRESS"},
+			want:  true,
+		},
+		{
+			name: "empty VisibleWhen struct does not filter",
+			section: uiprojector.SectionBlueprint{
+				VisibleWhen: &uiprojector.VisibleWhen{},
+			},
+			facts: uiprojector.Facts{State: "ANYTHING"},
+			want:  true,
+		},
+		{
+			name: "RequireDataKey present with non-nil value renders",
+			section: uiprojector.SectionBlueprint{
+				VisibleWhen: &uiprojector.VisibleWhen{RequireDataKey: "approval"},
+			},
+			facts: uiprojector.Facts{Data: map[string]any{"approval": "yes"}},
+			want:  true,
+		},
+		{
+			name: "RequireDataKey present but nil hides",
+			section: uiprojector.SectionBlueprint{
+				VisibleWhen: &uiprojector.VisibleWhen{RequireDataKey: "approval"},
+			},
+			facts: uiprojector.Facts{Data: map[string]any{"approval": nil}},
+			want:  false,
+		},
+		{
+			name: "RequireDataKey absent hides",
+			section: uiprojector.SectionBlueprint{
+				VisibleWhen: &uiprojector.VisibleWhen{RequireDataKey: "approval"},
+			},
+			facts: uiprojector.Facts{Data: map[string]any{}},
+			want:  false,
+		},
+		{
+			name: "states and RequireDataKey both pass renders",
+			section: uiprojector.SectionBlueprint{
+				VisibleWhen: &uiprojector.VisibleWhen{
+					States:         []string{"APPROVED"},
+					RequireDataKey: "approval",
+				},
+			},
+			facts: uiprojector.Facts{
+				State: "APPROVED",
+				Data:  map[string]any{"approval": "yes"},
+			},
+			want: true,
+		},
+		{
+			name: "state fails even when data key present",
+			section: uiprojector.SectionBlueprint{
+				VisibleWhen: &uiprojector.VisibleWhen{
+					States:         []string{"APPROVED"},
+					RequireDataKey: "approval",
+				},
+			},
+			facts: uiprojector.Facts{
+				State: "DRAFT",
+				Data:  map[string]any{"approval": "yes"},
+			},
+			want: false,
+		},
+		{
+			name: "data key missing even when state passes",
+			section: uiprojector.SectionBlueprint{
+				VisibleWhen: &uiprojector.VisibleWhen{
+					States:         []string{"APPROVED"},
+					RequireDataKey: "approval",
+				},
+			},
+			facts: uiprojector.Facts{
+				State: "APPROVED",
+				Data:  map[string]any{},
+			},
+			want: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := e.ShouldRender(tt.section, tt.facts)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}

--- a/backend/pkg/uiprojector/visibility_test.go
+++ b/backend/pkg/uiprojector/visibility_test.go
@@ -7,9 +7,7 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestVisibilityEvaluator_ShouldRender(t *testing.T) {
-	e := uiprojector.NewVisibilityEvaluator()
-
+func TestShouldRender(t *testing.T) {
 	tests := []struct {
 		name    string
 		section uiprojector.SectionBlueprint
@@ -124,7 +122,7 @@ func TestVisibilityEvaluator_ShouldRender(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := e.ShouldRender(tt.section, tt.facts)
+			got := uiprojector.ShouldRender(tt.section, tt.facts)
 			assert.Equal(t, tt.want, got)
 		})
 	}


### PR DESCRIPTION
## Summary

Introduces `pkg/uiprojector`, a generic Blueprint × Facts × Projectors → Sections engine that internal renderers (`internal/taskworkflow/renderer/`, `internal/taskv2/renderer/`) can share instead of reimplementing projection logic in each consumer. Ships with built-in projectors for form, markdown, and raw output, a declarative visibility evaluator, and full unit + integration test coverage.

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Other (please describe):

## Changes Made

- New package `pkg/uiprojector/` containing:
  - `Blueprint` / `SectionBlueprint` / `Facts` / `Section` data types (`blueprint.go`).
  - `Projector` interface plus built-in `FormProjector`, `MarkdownProjector`, `RawProjector` (`projector.go`).
  - `Assembler` that resolves visibility, fetches templates via an injected `TemplateProvider`, and dispatches to projectors (`assembler.go`).
  - `VisibilityEvaluator` with declarative state and `RequireDataKey` rules (`visibility.go`).
  - Exported constants `ProjectorForm`, `ProjectorMarkdown`, `ProjectorRaw` and a `DefaultProjectors()` factory returning a fresh, mutable `map[string]Projector` (`defaults.go`).
- In-package unit tests covering each projector (happy paths and error paths), the visibility truth table (state, `RequireDataKey`, and combinations), the assembler (DataKey pluck, hidden sections, fetch error, unknown projector, projector error, empty blueprint, missing DataKey), and the defaults factory.
- Integration test under `test/integration/` that exercises a multi-section blueprint with visibility transitions against on-disk template fixtures.

No consumer wiring is touched in this PR. Internal renderers will adopt the engine in follow-up PRs.

## Testing

- [x] I have tested this change locally
- [x] I have added unit tests for new functionality
- [x] I have tested edge cases
- [x] All existing tests pass

```
$ go test ./pkg/uiprojector/...
ok  	github.com/OpenNSW/nsw/pkg/uiprojector
ok  	github.com/OpenNSW/nsw/pkg/uiprojector/test/integration
```

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have checked that there are no merge conflicts

## Related Issues

Closes #475

## Screenshots/Demo

N/A — this PR introduces a backend library; there is no user-facing surface.

## Additional Notes

- **Location (`pkg/` vs `internal/`).** Placed under `pkg/` to signal intended reusability. If no consumer outside this Go module materializes, a follow-up can relocate to `internal/uiprojector/` with no API change.
- **Open registry, not a closed enum.** Projector keys are plain strings and the registration map is mutable; the exported constants exist purely to remove typo risk on the built-in keys. Consumers may register any additional projector under any key.
- **Renderer adoption.** Adoption by `internal/taskworkflow/renderer/` and `internal/taskv2/renderer/` will land as separate PRs to keep this change reviewable as a pure addition.

## Deployment Notes

None. New package with no consumers in this PR; no schema, config, or migration changes.