### PR TITLE
453 refactor config validate

### DIFF
--- a/backend/internal/auth/config.go
+++ b/backend/internal/auth/config.go
@@ -14,7 +14,7 @@ type Config struct {
 	InsecureSkipTLSVerify bool
 }
 
-func (c *Config) Validate() error {
+func (c Config) Validate() error {
 	if c.JWKSURL == "" {
 		return fmt.Errorf("AUTH_JWKS_URL is required")
 	}

--- a/backend/internal/config/config.go
+++ b/backend/internal/config/config.go
@@ -127,6 +127,11 @@ func Load() (*Config, error) {
 		},
 	}
 
+	// Normalize parses PortRaw → Port before validation and client creation.
+	if err := cfg.Temporal.Normalize(); err != nil {
+		return nil, fmt.Errorf("invalid temporal configuration: %w", err)
+	}
+
 	// Validate required fields
 	if err := cfg.Validate(); err != nil {
 		return nil, err

--- a/backend/internal/config/config.go
+++ b/backend/internal/config/config.go
@@ -65,6 +65,11 @@ func Load() (*Config, error) {
 		return nil, fmt.Errorf("invalid SERVER_PORT: %w", err)
 	}
 
+	temporalPortStr := strings.TrimSpace(getEnvOrDefault("TEMPORAL_PORT", "7233"))
+	temporalPort, err := strconv.Atoi(temporalPortStr)
+	if err != nil {
+		return nil, fmt.Errorf("invalid TEMPORAL_PORT: %w", err)
+	}
 
 	cfg := &Config{
 		Database: database.Config{
@@ -123,7 +128,7 @@ func Load() (*Config, error) {
 		},
 		Temporal: temporal.Config{
 			Host:      getEnvOrDefault("TEMPORAL_HOST", "localhost"),
-			Port:      getIntOrDefault("TEMPORAL_PORT", 7233),
+			Port:      temporalPort,
 			Namespace: getEnvOrDefault("TEMPORAL_NAMESPACE", "default"),
 		},
 	}
@@ -173,17 +178,17 @@ func (c *Config) Validate() error {
 	return nil
 }
 
-// getEnvOrDefault returns the value of an environment variable or a default value
+// getEnvOrDefault returns the trimmed value of an environment variable or a default value
 func getEnvOrDefault(key, defaultValue string) string {
-	if value := os.Getenv(key); value != "" {
+	if value := strings.TrimSpace(os.Getenv(key)); value != "" {
 		return value
 	}
 	return defaultValue
 }
 
-// getIntOrDefault returns the integer value of an environment variable or a default value
+// getIntOrDefault returns the trimmed integer value of an environment variable or a default value
 func getIntOrDefault(key string, defaultValue int) int {
-	if value := os.Getenv(key); value != "" {
+	if value := strings.TrimSpace(os.Getenv(key)); value != "" {
 		if intValue, err := strconv.Atoi(value); err == nil {
 			return intValue
 		}

--- a/backend/internal/config/config.go
+++ b/backend/internal/config/config.go
@@ -128,9 +128,9 @@ func Load() (*Config, error) {
 			TemplateRoot: getEnvOrDefault("EMAIL_TEMPLATE_ROOT", "./configs/email-templates"),
 		},
 		Temporal: temporal.Config{
-			Host:      temporalHost,
-			Port:      temporalPort,
-			Namespace: temporalNamespace,
+			Host:      getEnvOrDefault("TEMPORAL_HOST", "localhost"),
+			Port:      getIntOrDefault("TEMPORAL_PORT", 7233),
+			Namespace: getEnvOrDefault("TEMPORAL_NAMESPACE", "default"),
 		},
 	}
 

--- a/backend/internal/config/config.go
+++ b/backend/internal/config/config.go
@@ -65,6 +65,13 @@ func Load() (*Config, error) {
 		return nil, fmt.Errorf("invalid SERVER_PORT: %w", err)
 	}
 
+	temporalHost := strings.TrimSpace(getEnvOrDefault("TEMPORAL_HOST", "localhost"))
+	temporalPort, err := strconv.Atoi(strings.TrimSpace(getEnvOrDefault("TEMPORAL_PORT", "7233")))
+	if err != nil {
+		return nil, fmt.Errorf("invalid TEMPORAL_PORT: %w", err)
+	}
+	temporalNamespace := strings.TrimSpace(getEnvOrDefault("TEMPORAL_NAMESPACE", "default"))
+
 	cfg := &Config{
 		Database: database.Config{
 			Host:                   getEnvOrDefault("DB_HOST", "localhost"),
@@ -121,15 +128,10 @@ func Load() (*Config, error) {
 			TemplateRoot: getEnvOrDefault("EMAIL_TEMPLATE_ROOT", "./configs/email-templates"),
 		},
 		Temporal: temporal.Config{
-			Host:      getEnvOrDefault("TEMPORAL_HOST", "localhost"),
-			PortRaw:   getEnvOrDefault("TEMPORAL_PORT", "7233"),
-			Namespace: getEnvOrDefault("TEMPORAL_NAMESPACE", "default"),
+			Host:      temporalHost,
+			Port:      temporalPort,
+			Namespace: temporalNamespace,
 		},
-	}
-
-	// Normalize parses PortRaw → Port before validation and client creation.
-	if err := cfg.Temporal.Normalize(); err != nil {
-		return nil, fmt.Errorf("invalid temporal configuration: %w", err)
 	}
 
 	// Validate required fields

--- a/backend/internal/config/config.go
+++ b/backend/internal/config/config.go
@@ -65,12 +65,6 @@ func Load() (*Config, error) {
 		return nil, fmt.Errorf("invalid SERVER_PORT: %w", err)
 	}
 
-	temporalHost := strings.TrimSpace(getEnvOrDefault("TEMPORAL_HOST", "localhost"))
-	temporalPort, err := strconv.Atoi(strings.TrimSpace(getEnvOrDefault("TEMPORAL_PORT", "7233")))
-	if err != nil {
-		return nil, fmt.Errorf("invalid TEMPORAL_PORT: %w", err)
-	}
-	temporalNamespace := strings.TrimSpace(getEnvOrDefault("TEMPORAL_NAMESPACE", "default"))
 
 	cfg := &Config{
 		Database: database.Config{

--- a/backend/internal/config/config_test.go
+++ b/backend/internal/config/config_test.go
@@ -19,9 +19,6 @@ func TestLoadTemporalDefaults(t *testing.T) {
 	if cfg.Temporal.Host != "localhost" {
 		t.Fatalf("Host default = %q, want %q", cfg.Temporal.Host, "localhost")
 	}
-	if cfg.Temporal.PortRaw != "7233" {
-		t.Fatalf("PortRaw default = %q, want %q", cfg.Temporal.PortRaw, "7233")
-	}
 	if cfg.Temporal.Port != 7233 {
 		t.Fatalf("Port default = %d, want %d", cfg.Temporal.Port, 7233)
 	}
@@ -43,9 +40,6 @@ func TestLoadTemporalOverrides(t *testing.T) {
 
 	if cfg.Temporal.Host != "temporal.example" {
 		t.Fatalf("Host override = %q, want %q", cfg.Temporal.Host, "temporal.example")
-	}
-	if cfg.Temporal.PortRaw != "7234" {
-		t.Fatalf("PortRaw override = %q, want %q", cfg.Temporal.PortRaw, "7234")
 	}
 	if cfg.Temporal.Port != 7234 {
 		t.Fatalf("Port override = %d, want %d", cfg.Temporal.Port, 7234)

--- a/backend/internal/database/config.go
+++ b/backend/internal/database/config.go
@@ -18,7 +18,7 @@ type Config struct {
 	MaxConnLifetimeSeconds int
 }
 
-func (c *Config) Validate() error {
+func (c Config) Validate() error {
 	if c.Host == "" {
 		return fmt.Errorf("DB_HOST is required")
 	}
@@ -35,7 +35,7 @@ func (c *Config) Validate() error {
 }
 
 // DSN returns the database connection string.
-func (c *Config) DSN() string {
+func (c Config) DSN() string {
 	// Using the URL format is more robust for handling special characters in passwords.
 	// format: postgres://user:password@host:port/dbname?sslmode=disable
 	dsn := url.URL{

--- a/backend/internal/temporal/config.go
+++ b/backend/internal/temporal/config.go
@@ -2,8 +2,6 @@ package temporal
 
 import (
 	"fmt"
-	"strconv"
-	"strings"
 
 	"github.com/OpenNSW/nsw/internal/validation"
 )
@@ -16,24 +14,9 @@ import (
 // Host/Port are kept separate to make configuration via environment variables
 // easier and more explicit.
 type Config struct {
-	Host string
-	// Port is the parsed TCP port number, populated by Validate().
-	Port int
-	// PortRaw is the raw port value (typically from the TEMPORAL_PORT env var).
-	PortRaw   string
+	Host      string
+	Port      int
 	Namespace string
-}
-
-func (c *Config) Normalize() error {
-	c.Host = strings.TrimSpace(c.Host)
-	c.Namespace = strings.TrimSpace(c.Namespace)
-	c.PortRaw = strings.TrimSpace(c.PortRaw)
-	port, err := strconv.Atoi(c.PortRaw)
-	if err != nil {
-		return fmt.Errorf("invalid TEMPORAL_PORT: %w", err)
-	}
-	c.Port = port
-	return nil
 }
 
 // Validate ensures the Temporal configuration is usable.
@@ -41,15 +24,7 @@ func (c Config) Validate() error {
 	if c.Host == "" {
 		return fmt.Errorf("TEMPORAL_HOST is required")
 	}
-	portStr := c.PortRaw
-	if portStr == "" {
-		return fmt.Errorf("TEMPORAL_PORT is required")
-	}
-	port, err := strconv.Atoi(portStr)
-	if err != nil {
-		return fmt.Errorf("invalid TEMPORAL_PORT: %w", err)
-	}
-	if err := validation.TCPPort("TEMPORAL_PORT", port); err != nil {
+	if err := validation.TCPPort("TEMPORAL_PORT", c.Port); err != nil {
 		return err
 	}
 	if c.Namespace == "" {

--- a/backend/internal/temporal/config.go
+++ b/backend/internal/temporal/config.go
@@ -24,12 +24,20 @@ type Config struct {
 	Namespace string
 }
 
-// Validate ensures the Temporal configuration is usable.
-func (c *Config) Validate() error {
+func (c *Config) Normalize() error {
 	c.Host = strings.TrimSpace(c.Host)
 	c.Namespace = strings.TrimSpace(c.Namespace)
 	c.PortRaw = strings.TrimSpace(c.PortRaw)
+	port, err := strconv.Atoi(c.PortRaw)
+	if err != nil {
+		return fmt.Errorf("invalid TEMPORAL_PORT: %w", err)
+	}
+	c.Port = port
+	return nil
+}
 
+// Validate ensures the Temporal configuration is usable.
+func (c Config) Validate() error {
 	if c.Host == "" {
 		return fmt.Errorf("TEMPORAL_HOST is required")
 	}
@@ -47,7 +55,5 @@ func (c *Config) Validate() error {
 	if c.Namespace == "" {
 		return fmt.Errorf("TEMPORAL_NAMESPACE is required")
 	}
-
-	c.Port = port
 	return nil
 }

--- a/backend/internal/temporal/config_test.go
+++ b/backend/internal/temporal/config_test.go
@@ -3,43 +3,35 @@ package temporal
 import "testing"
 
 func TestConfigValidateDefaultsOK(t *testing.T) {
-	cfg := Config{Host: "localhost", PortRaw: "7233", Namespace: "default"}
-	if err := cfg.Normalize(); err != nil {
-		t.Fatalf("Normalize() error = %v", err)
-	}
+	cfg := Config{Host: "localhost", Port: 7233, Namespace: "default"}
 	if err := cfg.Validate(); err != nil {
 		t.Fatalf("Validate() error = %v", err)
-	}
-	if cfg.Port != 7233 {
-		t.Fatalf("Port = %d, want %d", cfg.Port, 7233)
 	}
 }
 
 func TestConfigValidateMissingHost(t *testing.T) {
-	cfg := Config{Host: " ", PortRaw: "7233", Namespace: "default"}
-	if err := cfg.Normalize(); err != nil {
-		t.Fatalf("Normalize() error = %v", err)
-	}
+	cfg := Config{Host: "", Port: 7233, Namespace: "default"}
 	if err := cfg.Validate(); err == nil {
 		t.Fatalf("Validate() expected error")
 	}
 }
 
 func TestConfigValidateInvalidPort(t *testing.T) {
-	cfg := Config{Host: "localhost", PortRaw: "0", Namespace: "default"}
-	if err := cfg.Normalize(); err != nil {
-		t.Fatalf("Normalize() error = %v", err)
+	cfg := Config{Host: "localhost", Port: 0, Namespace: "default"}
+	if err := cfg.Validate(); err == nil {
+		t.Fatalf("Validate() expected error")
 	}
+}
+
+func TestConfigValidatePortTooHigh(t *testing.T) {
+	cfg := Config{Host: "localhost", Port: 65536, Namespace: "default"}
 	if err := cfg.Validate(); err == nil {
 		t.Fatalf("Validate() expected error")
 	}
 }
 
 func TestConfigValidateMissingNamespace(t *testing.T) {
-	cfg := Config{Host: "localhost", PortRaw: "7233", Namespace: " "}
-	if err := cfg.Normalize(); err != nil {
-		t.Fatalf("Normalize() error = %v", err)
-	}
+	cfg := Config{Host: "localhost", Port: 7233, Namespace: ""}
 	if err := cfg.Validate(); err == nil {
 		t.Fatalf("Validate() expected error")
 	}

--- a/backend/internal/temporal/config_test.go
+++ b/backend/internal/temporal/config_test.go
@@ -4,6 +4,9 @@ import "testing"
 
 func TestConfigValidateDefaultsOK(t *testing.T) {
 	cfg := Config{Host: "localhost", PortRaw: "7233", Namespace: "default"}
+	if err := cfg.Normalize(); err != nil {
+		t.Fatalf("Normalize() error = %v", err)
+	}
 	if err := cfg.Validate(); err != nil {
 		t.Fatalf("Validate() error = %v", err)
 	}
@@ -14,6 +17,9 @@ func TestConfigValidateDefaultsOK(t *testing.T) {
 
 func TestConfigValidateMissingHost(t *testing.T) {
 	cfg := Config{Host: " ", PortRaw: "7233", Namespace: "default"}
+	if err := cfg.Normalize(); err != nil {
+		t.Fatalf("Normalize() error = %v", err)
+	}
 	if err := cfg.Validate(); err == nil {
 		t.Fatalf("Validate() expected error")
 	}
@@ -21,6 +27,9 @@ func TestConfigValidateMissingHost(t *testing.T) {
 
 func TestConfigValidateInvalidPort(t *testing.T) {
 	cfg := Config{Host: "localhost", PortRaw: "0", Namespace: "default"}
+	if err := cfg.Normalize(); err != nil {
+		t.Fatalf("Normalize() error = %v", err)
+	}
 	if err := cfg.Validate(); err == nil {
 		t.Fatalf("Validate() expected error")
 	}
@@ -28,6 +37,9 @@ func TestConfigValidateInvalidPort(t *testing.T) {
 
 func TestConfigValidateMissingNamespace(t *testing.T) {
 	cfg := Config{Host: "localhost", PortRaw: "7233", Namespace: " "}
+	if err := cfg.Normalize(); err != nil {
+		t.Fatalf("Normalize() error = %v", err)
+	}
 	if err := cfg.Validate(); err == nil {
 		t.Fatalf("Validate() expected error")
 	}

--- a/backend/internal/uploads/config.go
+++ b/backend/internal/uploads/config.go
@@ -23,7 +23,7 @@ type Config struct {
 	PresignTTL     time.Duration
 }
 
-func (c *Config) Validate() error {
+func (c Config) Validate() error {
 	switch strings.TrimSpace(c.Type) {
 	case "local":
 		if strings.TrimSpace(c.LocalBaseDir) == "" {


### PR DESCRIPTION
## Summary

This PR completes the transition to a decoupled configuration strategy (Option B) in #453 by moving normalization logic from sub-packages into the root configuration loader. These updates resolve the failures in internal/config tests that occurred after normalization logic was removed from the temporal package