### PR TITLE
fix: redirect authenticated users away from /login route in oga-app and trader-app

### DIFF
--- a/portals/apps/oga-app/src/App.tsx
+++ b/portals/apps/oga-app/src/App.tsx
@@ -47,7 +47,7 @@ function App() {
       <Route
         path="/login"
         element={
-          <SignedOut>
+          <SignedOut fallback={<Navigate to="/" replace />}>
             <LoginScreen />
           </SignedOut>
         }

--- a/portals/apps/trader-app/src/App.tsx
+++ b/portals/apps/trader-app/src/App.tsx
@@ -48,7 +48,7 @@ function App() {
       <Route
         path="/login"
         element={
-          <SignedOut>
+          <SignedOut fallback={<Navigate to="/" replace />}>
             <LoginScreen />
           </SignedOut>
         }


### PR DESCRIPTION
## Summary

When an already-authenticated user navigates to `APP_BASE_PATH/login`, both `oga-app` and `trader-app` rendered a blank white screen instead of redirecting to the application's default route. This PR fixes that by providing a redirect fallback on the `SignedOut` component for the `/login` route in both apps.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Changes Made

- `portals/apps/oga-app/src/App.tsx`: Added `fallback={<Navigate to="/" replace />}` to the `<SignedOut>` wrapper on the `/login` route
- `portals/apps/trader-app/src/App.tsx`: Same change applied

## Testing

- [x] I have tested this change locally
- [ ] I have added unit tests for new functionality
- [x] I have tested edge cases
- [x] All existing tests pass

**Manual test steps:**
1. Log in to either app
2. Manually navigate to `/login` in the browser
3. Confirm the app redirects to the default route (`/workflows` for oga-app, `/consignments` for trader-app) instead of showing a blank screen

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have checked that there are no merge conflicts

## Related Issues

Closes #508 

## Screenshots/Demo

https://github.com/user-attachments/assets/3dcde8ae-7a92-4c99-9f2b-e75b0204a98c

## Additional Notes

Root cause: `<SignedOut>` from `@asgardeo/react` renders its `fallback` prop (defaulting to `null`) when the user is signed in. Without an explicit fallback, no redirect occurred — just an empty render. The fix uses the built-in `fallback` prop to trigger a React Router `<Navigate>` redirect.

## Deployment Notes

No special deployment steps required. Frontend-only change.