### PR TITLE
fix(ci): point Renovate webhook to nsw-gitops repository

### DIFF
--- a/.github/workflows/build-dev.yml
+++ b/.github/workflows/build-dev.yml
@@ -80,5 +80,5 @@ jobs:
       - name: Trigger Renovate Bot Webhook
         run: |
           curl -X POST -H "Content-Type: application/json" \
-          -d '{"repository": "${{ github.repository }}"}' \
+          -d '{"repository": "${{ github.repository_owner }}/nsw-gitops"}' \
           https://app.renovatebot.com/webhook/github

--- a/.github/workflows/build-dev.yml
+++ b/.github/workflows/build-dev.yml
@@ -78,6 +78,9 @@ jobs:
     if: github.event_name != 'pull_request'
     steps:
       - name: Trigger Renovate Bot Webhook
+        # NOTE: If we need to support N deployment repositories in the future, delete this Renovate webhook step.
+        # Hardcoding N webhooks creates tight coupling. The best decoupled solution is to use ArgoCD Image Updater
+        # running in the cluster to poll GHCR and automatically update target GitOps repos.
         run: |
           curl -X POST -H "Content-Type: application/json" \
           -d '{"repository": "${{ github.repository_owner }}/nsw-gitops"}' \

--- a/deployments/helm/nsw-api/templates/migration-job.yaml
+++ b/deployments/helm/nsw-api/templates/migration-job.yaml
@@ -2,7 +2,7 @@
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: {{ include "nsw-api.fullname" . }}-migration-{{ .Values.dbMigrations.image.tag | default .Values.image.tag | trunc 7 }}
+  name: {{ include "nsw-api.fullname" . }}-migration-{{ .Values.dbMigrations.image.tag | default .Values.image.tag | trunc 7 | trimSuffix "-" }}
   labels:
     {{- include "nsw-api.labels" . | nindent 4 }}
   annotations:

--- a/deployments/helm/nsw-api/templates/migration-job.yaml
+++ b/deployments/helm/nsw-api/templates/migration-job.yaml
@@ -2,7 +2,7 @@
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: {{ include "nsw-api.fullname" . }}-migration-{{ .Values.dbMigrations.image.tag | default .Values.image.tag | truncate 7 }}
+  name: {{ include "nsw-api.fullname" . }}-migration-{{ .Values.dbMigrations.image.tag | default .Values.image.tag | trunc 7 }}
   labels:
     {{- include "nsw-api.labels" . | nindent 4 }}
   annotations:


### PR DESCRIPTION
## Summary
The dev build workflow was incorrectly triggering Renovate on the application repository instead of the GitOps repository. This corrects the webhook payload to trigger 'nsw-gitops', enabling automated PR creation for new image tags to complete the GitOps deployment flow