### PR TITLE
chore: add VS Code workspace settings for consistent formatting

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,6 @@
+{
+  "recommendations": [
+    "esbenp.prettier-vscode",
+    "dbaeumer.vscode-eslint"
+  ]
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,15 @@
+{
+  "files.insertFinalNewline": true,
+  "[typescriptreact][javascriptreact][typescript][javascript][json]": {
+    "editor.formatOnSave": true,
+    "editor.defaultFormatter": "esbenp.prettier-vscode",
+    "editor.codeActionsOnSave": ["source.fixAll.eslint", "source.fixAll.format"]
+  },
+  "prettier.prettierPath": "./frontend/node_modules/prettier",
+  "[typescriptreact]": {
+    "editor.defaultFormatter": "esbenp.prettier-vscode"
+  },
+  "[typescript]": {
+    "editor.defaultFormatter": "esbenp.prettier-vscode"
+  },
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -5,11 +5,5 @@
     "editor.defaultFormatter": "esbenp.prettier-vscode",
     "editor.codeActionsOnSave": ["source.fixAll.eslint", "source.fixAll.format"]
   },
-  "prettier.prettierPath": "./frontend/node_modules/prettier",
-  "[typescriptreact]": {
-    "editor.defaultFormatter": "esbenp.prettier-vscode"
-  },
-  "[typescript]": {
-    "editor.defaultFormatter": "esbenp.prettier-vscode"
-  },
+  "prettier.prettierPath": "./portals/node_modules/prettier",
 }


### PR DESCRIPTION
## Summary

Adds a `.vscode/settings.json` to enforce consistent format-on-save behaviour across the team for frontend files (TypeScript, JavaScript, JSON, JSX/TSX) using Prettier and ESLint.

## Type of Change

- [x] Other (please describe): Developer tooling / workspace configuration

## Changes Made

- Added `.vscode/settings.json` with format-on-save rules for TypeScript, JavaScript, JSON, and their React variants using Prettier as the default formatter and ESLint fix-all on save.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings