### PR TITLE
fix runtime configuration injection in Trader App and OGA App

### DIFF
--- a/portals/apps/oga-app/index.html
+++ b/portals/apps/oga-app/index.html
@@ -5,10 +5,10 @@
     <link rel="icon" type="image/svg+xml" href="/vite.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>OGA Officer Portal</title>
+    <script src="/runtime-env.js"></script>
   </head>
   <body>
     <div id="root"></div>
-    <script src="/runtime-env.js"></script>
     <script type="module" src="/src/main.tsx"></script>
   </body>
 </html>

--- a/portals/apps/oga-app/index.html
+++ b/portals/apps/oga-app/index.html
@@ -5,7 +5,7 @@
     <link rel="icon" type="image/svg+xml" href="/vite.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>OGA Officer Portal</title>
-    <script src="/runtime-env.js"></script>
+    <script defer src="/runtime-env.js"></script>
   </head>
   <body>
     <div id="root"></div>

--- a/portals/apps/trader-app/index.html
+++ b/portals/apps/trader-app/index.html
@@ -5,7 +5,7 @@
     <link rel="icon" type="image/png" href="/favicon_onetrade.png" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Trader Portal</title>
-    <script src="/runtime-env.js"></script>
+    <script defer src="/runtime-env.js"></script>
   </head>
   <body>
     <div id="root"></div>

--- a/portals/apps/trader-app/index.html
+++ b/portals/apps/trader-app/index.html
@@ -5,10 +5,10 @@
     <link rel="icon" type="image/png" href="/favicon_onetrade.png" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Trader Portal</title>
+    <script src="/runtime-env.js"></script>
   </head>
   <body>
     <div id="root"></div>
-    <script src="/runtime-env.js"></script>
     <script type="module" src="/src/main.tsx"></script>
   </body>
 </html>


### PR DESCRIPTION
## Summary
There's a race condition per Vite's production bundling. In a production build, Vite compiles assets and injects the entry point as:
```html
<script type="module" crossorigin src="/assets/index.js"></script>
```
Because of the `type="module"` attribute, browsers fetch and execute this script asynchronously in a deferred manner. This caused issues during bootstrap (in LGC deployment), specifically the Asgardeo SDK and Vite constants immediately evaluated `window.__APP_CONFIG__` (which was still `undefined`). 

By placing `<script src="/runtime-env.js"></script>` in the `<head>` above the module scripts, we guarantee the browser fetches and executes the configuration synchronous script block **first**, ensuring `window.__APP_CONFIG__` is fully populated before any React/Asgardeo code begins execution.


## Changes
Update script tag order in both OGA app and Trader app `index.html`

## Verification 

When redeploying trader app and OGA app in LGC, verify no more fallback to "https://localhost:8090/gate/error?errorCode=invalid_request&errorMessage=Invalid+client_id" and the error in OGA app is resolved (screenshot below) 


<img width="1710" height="1025" alt="image" src="https://github.com/user-attachments/assets/50a54b71-0e6e-4b77-aa8e-979a4b8fc4c3" />
