### PR TITLE
fix(helm): resolve nginx mount paths and oga-backend configmap collisions

### DIFF
--- a/deployments/helm/oga-app/templates/deployment.yaml
+++ b/deployments/helm/oga-app/templates/deployment.yaml
@@ -49,7 +49,7 @@ spec:
               mountPath: /etc/nginx/nginx.conf
               subPath: nginx.conf
             - name: nginx-config
-              mountPath: /etc/nginx/conf.d/default.conf
+              mountPath: /etc/nginx/templates/default.conf.template
               subPath: default.conf
             - name: nginx-config
               mountPath: /usr/share/nginx/html/branding-config.js

--- a/deployments/helm/oga-app/templates/nginx-cm.yaml
+++ b/deployments/helm/oga-app/templates/nginx-cm.yaml
@@ -41,7 +41,7 @@ data:
         }
 
         location = /runtime-env.js {
-            alias /tmp/runtime-env.js;
+            alias /usr/share/nginx/html/runtime-env.js;
         }
 
         location /api/api/oga/ {

--- a/deployments/helm/oga-app/templates/nginx-cm.yaml
+++ b/deployments/helm/oga-app/templates/nginx-cm.yaml
@@ -36,12 +36,16 @@ data:
         root /usr/share/nginx/html;
         index index.html;
 
+        # Dynamically inject runtime-env.js into the head to prevent module loading race condition
+        sub_filter '<head>' '<head><script src="/runtime-env.js"></script>';
+        sub_filter_once on;
+
         location / {
             try_files $uri $uri/ /index.html;
         }
 
         location = /runtime-env.js {
-            alias /usr/share/nginx/html/runtime-env.js;
+            try_files $uri =404;
         }
 
         location /api/api/oga/ {

--- a/deployments/helm/oga-backend/templates/deployment.yaml
+++ b/deployments/helm/oga-backend/templates/deployment.yaml
@@ -39,12 +39,12 @@ spec:
             - name: OGA_DB_USER
               valueFrom:
                 secretKeyRef:
-                  name: {{ .Values.config.database.credentialsSecretName | default (printf "%s-db-credentials" .Release.Name) }}
+                  name: {{ .Values.config.database.credentialsSecretName | default (printf "%s-db-credentials" (include "oga-backend.fullname" .)) }}
                   key: {{ .Values.config.database.userKey | default "user" }}
             - name: OGA_DB_PASSWORD
               valueFrom:
                 secretKeyRef:
-                  name: {{ .Values.config.database.credentialsSecretName | default (printf "%s-db-credentials" .Release.Name) }}
+                  name: {{ .Values.config.database.credentialsSecretName | default (printf "%s-db-credentials" (include "oga-backend.fullname" .)) }}
                   key: password
             - name: OGA_PORT
               value: {{ .Values.config.port | default "8081" | quote }}

--- a/deployments/helm/oga-backend/templates/deployment.yaml
+++ b/deployments/helm/oga-backend/templates/deployment.yaml
@@ -99,4 +99,4 @@ spec:
       volumes:
         - name: forms-volume
           configMap:
-            name: {{ .Release.Name }}-forms
+            name: {{ include "oga-backend.fullname" . }}-forms

--- a/deployments/helm/oga-backend/templates/forms-cm.yaml
+++ b/deployments/helm/oga-backend/templates/forms-cm.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: {{ .Release.Name }}-forms
+  name: {{ include "oga-backend.fullname" . }}-forms
   labels:
     {{- include "oga-backend.labels" . | nindent 4 }}
 data:

--- a/deployments/helm/trader-app/templates/deployment.yaml
+++ b/deployments/helm/trader-app/templates/deployment.yaml
@@ -72,7 +72,7 @@ spec:
             failureThreshold: 3
           volumeMounts:
             - name: nginx-config
-              mountPath: /etc/nginx/conf.d/default.conf
+              mountPath: /etc/nginx/templates/default.conf.template
               subPath: default.conf.template
           resources:
             {{- toYaml .Values.resources | nindent 12 }}

--- a/deployments/helm/trader-app/templates/nginx-cm.yaml
+++ b/deployments/helm/trader-app/templates/nginx-cm.yaml
@@ -24,6 +24,10 @@ data:
         add_header X-Content-Type-Options "nosniff" always;
         add_header Referrer-Policy "strict-origin-when-cross-origin" always;
 
+        # Dynamically inject runtime-env.js into the head to prevent module loading race condition
+        sub_filter '<head>' '<head><script src="/runtime-env.js"></script>';
+        sub_filter_once on;
+
         location / {
             root /usr/share/nginx/html;
             try_files $uri $uri/ /index.html;


### PR DESCRIPTION
## Summary
When debugging the ArgoCD auto-deploy to dev, found some issues in existing Helm setup 

## Changes
1. oga-app: point nginx-cm alias for runtime-env.js to actual entrypoint output directory
2. oga-app and trader-app: mount configs as templates to prevent runtime permission issues
3. oga-backend: namespace forms configmaps using fullname helper to prevent umbrella release naming collisions

## Testing
LGC Deployments in `nsw-dev` namespace
- [https://trader-app-nsw-dev.apps.sovecloud1.akaza.lk/login](https://trader-app-nsw-dev.apps.sovecloud1.akaza.lk/login)
- [https://oga-fcau-app-nsw-dev.apps.sovecloud1.akaza.lk/login](https://oga-fcau-app-nsw-dev.apps.sovecloud1.akaza.lk/login)
