### PR TITLE
Add publish-helm.yml to publish Helm Charts to GHCR

### DIFF
--- a/.github/workflows/publish-helm.yml
+++ b/.github/workflows/publish-helm.yml
@@ -1,0 +1,55 @@
+name: Publish Helm Charts
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - 'deployments/helm/**'
+
+env:
+  REGISTRY: ghcr.io
+
+jobs:
+  publish:
+    name: Publish Helm Charts to GHCR
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Helm
+        uses: azure/setup-helm@v4
+        with:
+          version: v3.14.0
+
+      - name: Convert repository owner to lowercase
+        id: repo_owner
+        run: echo "owner=$(echo '${{ github.repository_owner }}' | tr '[:upper:]' '[:lower:]')" >> "$GITHUB_OUTPUT"
+
+      - name: Log in to GHCR
+        run: echo "${{ secrets.GITHUB_TOKEN }}" | helm registry login ${{ env.REGISTRY }} -u ${{ github.actor }} --password-stdin
+
+      - name: Package and Publish Charts
+        run: |
+          # Iterate through each directory in deployments/helm
+          for chart_dir in deployments/helm/*; do
+            if [ -d "$chart_dir" ]; then
+              chart_name=$(basename "$chart_dir")
+              echo "Packaging chart: $chart_name"
+              
+              # Package the chart, which outputs a .tgz file
+              helm package "$chart_dir" -d ./packaged-charts
+            fi
+          done
+
+          echo "Publishing charts to GHCR..."
+          for pkg in ./packaged-charts/*.tgz; do
+            if [ -f "$pkg" ]; then
+              echo "Pushing $pkg to oci://${{ env.REGISTRY }}/${{ steps.repo_owner.outputs.owner }}/charts"
+              helm push "$pkg" "oci://${{ env.REGISTRY }}/${{ steps.repo_owner.outputs.owner }}/charts"
+            fi
+          done

--- a/.github/workflows/publish-helm.yml
+++ b/.github/workflows/publish-helm.yml
@@ -33,23 +33,106 @@ jobs:
       - name: Log in to GHCR
         run: echo "${{ secrets.GITHUB_TOKEN }}" | helm registry login ${{ env.REGISTRY }} -u ${{ github.actor }} --password-stdin
 
-      - name: Package and Publish Charts
+      # (#3) Lint all charts before touching the registry.
+      # A malformed chart is caught here and the job fails cleanly.
+      - name: Lint all charts
         run: |
-          # Iterate through each directory in deployments/helm
-          for chart_dir in deployments/helm/*; do
-            if [ -d "$chart_dir" ]; then
-              chart_name=$(basename "$chart_dir")
-              echo "Packaging chart: $chart_name"
-              
-              # Package the chart, which outputs a .tgz file
-              helm package "$chart_dir" -d ./packaged-charts
+          lint_failed=0
+          for chart_dir in deployments/helm/*/; do
+            chart_name=$(basename "$chart_dir")
+            echo "::group::Linting $chart_name"
+            if ! helm lint "$chart_dir"; then
+              echo "::error::helm lint failed for $chart_name"
+              lint_failed=1
+            fi
+            echo "::endgroup::"
+          done
+          if [ "$lint_failed" -ne 0 ]; then
+            echo "One or more charts failed linting. Aborting publish."
+            exit 1
+          fi
+
+      # (#6) Explicitly create a clean output directory each run so no
+      # stale .tgz artifacts from a previous (partial) run can be pushed.
+      - name: Prepare clean output directory
+        run: |
+          rm -rf ./packaged-charts
+          mkdir -p ./packaged-charts
+
+      # (#2) Only publish a chart if its version does not already exist in
+      # GHCR. This prevents silent overwrites and makes published versions
+      # immutable — a given chart version is write-once.
+      # (#4) The loop runs with set -e so any helm package / push failure
+      # immediately aborts the job rather than silently continuing.
+      - name: Package and publish charts
+        id: publish
+        env:
+          OCI_REPO: oci://${{ env.REGISTRY }}/${{ steps.repo_owner.outputs.owner }}/charts
+        run: |
+          set -euo pipefail
+          published_charts=""
+
+          for chart_dir in deployments/helm/*/; do
+            [ -d "$chart_dir" ] || continue
+            chart_name=$(basename "$chart_dir")
+            chart_version=$(helm show chart "$chart_dir" | grep '^version:' | awk '{print $2}')
+
+            echo "::group::Processing $chart_name @ $chart_version"
+
+            # (#2) Check whether this exact version is already in the registry.
+            if helm show chart "${OCI_REPO}/${chart_name}" --version "$chart_version" &>/dev/null; then
+              echo "⚠️  $chart_name@$chart_version already exists in GHCR — skipping to avoid overwrite."
+              echo "::endgroup::"
+              continue
+            fi
+
+            echo "📦 Packaging $chart_name..."
+            helm package "$chart_dir" -d ./packaged-charts
+
+            pkg="./packaged-charts/${chart_name}-${chart_version}.tgz"
+            echo "🚀 Pushing $pkg to ${OCI_REPO}..."
+            helm push "$pkg" "${OCI_REPO}"
+
+            published_charts="${published_charts} ${chart_name}@${chart_version}"
+            echo "::endgroup::"
+          done
+
+          if [ -z "$published_charts" ]; then
+            echo "No new chart versions to publish."
+          else
+            echo "Published:$published_charts"
+          fi
+
+          # Expose for the verification step
+          echo "published=${published_charts}" >> "$GITHUB_OUTPUT"
+
+      # (#5) Verify each newly pushed chart is pullable from GHCR.
+      # Runs as continue-on-error so a transient registry delay does not
+      # fail the overall workflow, but surfaces as a visible warning.
+      - name: Verify published charts are pullable
+        if: steps.publish.outputs.published != ''
+        continue-on-error: true
+        env:
+          OCI_REPO: oci://${{ env.REGISTRY }}/${{ steps.repo_owner.outputs.owner }}/charts
+        run: |
+          set -euo pipefail
+          failed=0
+
+          for chart_dir in deployments/helm/*/; do
+            [ -d "$chart_dir" ] || continue
+            chart_name=$(basename "$chart_dir")
+            chart_version=$(helm show chart "$chart_dir" | grep '^version:' | awk '{print $2}')
+
+            # Only verify charts we actually just published
+            if echo "${{ steps.publish.outputs.published }}" | grep -q "${chart_name}@${chart_version}"; then
+              echo "Verifying ${chart_name}@${chart_version}..."
+              if helm show chart "${OCI_REPO}/${chart_name}" --version "$chart_version" > /dev/null; then
+                echo "✅ ${chart_name}@${chart_version} is pullable from GHCR."
+              else
+                echo "::warning::❌ ${chart_name}@${chart_version} could not be pulled after push."
+                failed=1
+              fi
             fi
           done
 
-          echo "Publishing charts to GHCR..."
-          for pkg in ./packaged-charts/*.tgz; do
-            if [ -f "$pkg" ]; then
-              echo "Pushing $pkg to oci://${{ env.REGISTRY }}/${{ steps.repo_owner.outputs.owner }}/charts"
-              helm push "$pkg" "oci://${{ env.REGISTRY }}/${{ steps.repo_owner.outputs.owner }}/charts"
-            fi
-          done
+          exit "$failed"


### PR DESCRIPTION
## Summary
Add `.github/workflows/publish-helm.yml` workflow to automate the packaging and publishing of our Helm subcharts to GHCR secure, remote OCI artifacts (`oci://ghcr.io/opennsw/charts`) whenever changes are merged into the `main` branch under the `deployments/helm/**` directory


## Why we want this

Currently, the `nsw-gitops` umbrella chart [envs/base/apps-umbrella/Chart.yaml](https://github.com/OpenNSW/nsw-gitops/blob/main/envs/base/apps-umbrella/Chart.yaml#L10) relies on locally bundled `.tgz` files** stored under the `charts/` directory. This causes issues including the following
1. any modifications to the Helm charts require manual repackaging via `helm package` and manual commits/pushes of binarily encoded `.tgz` files directly to the `nsw-gitops` repository. This is highly error-prone and slow
2. storing binary `.tgz` packages directly inside Git causes massive, unnecessary repository bloat and pollutes git history
4. Code changes to app manifests are coupled directly to the GitOps sync configurations, not following GitOps best practices where application definitions and env configurations should be cleanly separated

## Changes
By moving to an **OCI-based publishing model** via `publish-helm.yml`, we can:
* publish every chart change directly to GHCR as a versioned artifact automatically upon merging to `main`
* have the `nsw-gitops` repository to point directly to these remote OCI packages, completely eliminating the need for checked-in `.tgz` files
* allow Renovate bot to automatically detect newer chart versions in GHCR and automatically open PRs to bump charts in `nsw-gitops`, achieving fully **automated GitOps deployments for Helm chart changes**


## Verification
1. verify the workflow is successfully triggered upon merging this branch to `main`.
2. confirm that the charts (`oga-app`, `oga-backend`, `trader-app`, etc.) appear under the GHCR Packages page (`ghcr.io/opennsw/charts/`)
3. ArgoCD Reference Update: once published, update the dependencies in `envs/base/apps-umbrella/Chart.yaml` to reference:
   ```yaml
   dependencies:
     - name: trader-app
       version: "0.1.0"
       repository: "oci://ghcr.io/opennsw/charts"
   ```
   and run a test sync in `nsw-dev` to verify the remote fetching works.
