### PR TITLE
[Portals][CI] chore: migrate pnpm from v10.28.1 to v11.1.2

### DIFF
--- a/.github/workflows/portals-ci.yml
+++ b/.github/workflows/portals-ci.yml
@@ -22,7 +22,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v6
+        uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6.0.8
         with:
           version: 11.1.2
 
@@ -80,7 +80,7 @@ jobs:
 
       # Setup environment for Audit
       - name: Setup pnpm
-        uses: pnpm/action-setup@v6
+        uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6.0.8
         with:
           version: 11.1.2
 

--- a/.github/workflows/portals-ci.yml
+++ b/.github/workflows/portals-ci.yml
@@ -22,9 +22,9 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v3
+        uses: pnpm/action-setup@v6
         with:
-          version: 10.28.1
+          version: 11.1.2
 
       - name: Setup Node.js
         uses: actions/setup-node@v4
@@ -80,9 +80,9 @@ jobs:
 
       # Setup environment for Audit
       - name: Setup pnpm
-        uses: pnpm/action-setup@v3
+        uses: pnpm/action-setup@v6
         with:
-          version: 10.28.1
+          version: 11.1.2
 
       - name: Setup Node.js
         uses: actions/setup-node@v4

--- a/portals/Makefile
+++ b/portals/Makefile
@@ -26,14 +26,15 @@ help:
 	@echo "  make type-check     - Run TypeScript type checking"
 	@echo ""
 
-# Setup pnpm if not installed
+# Setup pnpm via corepack (reads version from package.json packageManager field)
 setup:
 	@echo "🔧 Setting up development environment..."
-	@command -v pnpm >/dev/null 2>&1 || { \
-		echo "📥 Installing pnpm globally..."; \
-		npm install -g pnpm@11.1.2; \
+	@command -v corepack >/dev/null 2>&1 || { \
+		echo "❌ corepack not found — install Node.js 22+ (see docs/SETUP_WORKSPACE.md)"; \
+		exit 1; \
 	}
-	@echo "✅ pnpm is installed"
+	@corepack enable
+	@echo "✅ pnpm available via corepack"
 	@$(MAKE) install
 	@echo "✅ Setup complete!"
 

--- a/portals/Makefile
+++ b/portals/Makefile
@@ -31,7 +31,7 @@ setup:
 	@echo "🔧 Setting up development environment..."
 	@command -v pnpm >/dev/null 2>&1 || { \
 		echo "📥 Installing pnpm globally..."; \
-		npm install -g pnpm@10.28.1; \
+		npm install -g pnpm@11.1.2; \
 	}
 	@echo "✅ pnpm is installed"
 	@$(MAKE) install

--- a/portals/docs/SETUP_WORKSPACE.md
+++ b/portals/docs/SETUP_WORKSPACE.md
@@ -556,7 +556,7 @@ This section tracks recommended future upgrades and the migration process.
 
 ### How to Update (Maintainer Guide)
 
-et's say we're going to `Update Node.js from v22.18.0 to v24.13.0` and `Update pnpm from 11.1.2 to 11.1.3`
+Let's say we're going to update the project dependencies.
 
 #### Step 1: Update Node.js to v24.13.0
 

--- a/portals/docs/SETUP_WORKSPACE.md
+++ b/portals/docs/SETUP_WORKSPACE.md
@@ -19,14 +19,14 @@ This project uses **strict version enforcement** to ensure consistent dependency
 | Tool        | Required Version | Why?                                       |
 | ----------- | ---------------- | ------------------------------------------ |
 | **Node.js** | `v22.18.0`       | Locked to prevent lockfile inconsistencies |
-| **pnpm**    | `v10.28.1`       | Enforced via `packageManager` field        |
+| **pnpm**    | `v11.1.2`        | Enforced via `packageManager` field        |
 
 > **⚠️ Important**: Using different versions will cause `pnpm-lock.yaml` to change unexpectedly, creating merge conflicts and CI failures.
 
 ### Why These Specific Versions?
 
 - **Node v22.x**: Latest stable version with modern JavaScript features
-- **pnpm v10.28.x**: Latest stable version with improved monorepo support
+- **pnpm v11.1.x**: Latest stable version with improved monorepo support
 - **Locked versions**: Prevents platform-specific lockfile differences (e.g., `libc: [glibc]` appearing/disappearing)
 
 ---
@@ -82,13 +82,13 @@ corepack enable
 
 # Verify pnpm installation
 pnpm --version
-# Expected output: 10.28.1
+# Expected output: 11.1.2
 ```
 
 **Alternative (manual installation):**
 
 ```bash
-npm install -g pnpm@10.28.1
+npm install -g pnpm@11.1.2
 ```
 
 ### Step 5: Install Dependencies
@@ -232,11 +232,11 @@ corepack enable
 pnpm --version
 
 # Method 2: Manual installation
-npm install -g pnpm@10.28.1
+npm install -g pnpm@11.1.2
 
 # Verify
 pnpm --version
-# Must show: 10.28.1
+# Must show: 11.1.2
 ```
 
 #### 6. Fresh Install
@@ -350,8 +350,8 @@ node --version
 
 # 2. Verify pnpm version
 pnpm --version
-# Expected: 10.28.1
-# If wrong: npm install -g pnpm@10.28.1 OR corepack enable
+# Expected: 11.1.2
+# If wrong: npm install -g pnpm@11.1.2 OR corepack enable
 
 # 3. Clean install
 rm -rf node_modules apps/*/node_modules packages/*/node_modules
@@ -393,7 +393,7 @@ pnpm --filter @opennsw/ui build
 corepack enable
 
 # Or install manually
-npm install -g pnpm@10.28.1
+npm install -g pnpm@11.1.2
 ```
 
 ---
@@ -423,7 +423,7 @@ node --version
 
 # 2. Check pnpm version
 pnpm --version
-# ✅ Expected: 10.28.1
+# ✅ Expected: 11.1.2
 
 # 3. Check if in correct directory
 pwd
@@ -487,7 +487,7 @@ node --version && pnpm --version
 Compare outputs. Everyone should have:
 
 - Node: `v22.18.0`
-- pnpm: `10.28.1`
+- pnpm: `11.1.2`
 
 ### Clean Slate Reset
 
@@ -502,7 +502,7 @@ rm -rf .pnpm-store pnpm-lock.yaml
 # 2. Reinstall Node/pnpm (start from scratch)
 nvm install 22.18.0
 nvm use 22.18.0
-npm install -g pnpm@10.28.1
+npm install -g pnpm@11.1.2
 
 # 3. Fresh install
 pnpm install
@@ -532,10 +532,10 @@ If you're still stuck:
 
 Always keep your Node.js and pnpm versions up to date with security patches. The team will coordinate version updates through pull requests to ensure everyone stays synchronized.
 
-**Current versions locked as of:** January 2026
+**Current versions locked as of:** May 2026
 
 - Node.js: v22.18.0
-- pnpm: v10.28.1
+- pnpm: v11.1.2
 
 When updating these versions, the team lead will:
 
@@ -549,14 +549,14 @@ When updating these versions, the team lead will:
 
 This section tracks recommended future upgrades and the migration process.
 
-### Current Status (Jan 2026)
+### Current Status (May 2026)
 
 - **Node.js:** `v22.18.0` (Locked)
-- **pnpm:** `v10.28.1` (Locked)
+- **pnpm:** `v11.1.2` (Locked)
 
 ### How to Update (Maintainer Guide)
 
-et's say we're going to `Update Node.js from v22.18.0 to v24.13.0` and `Update pnpm from 10.28.1 to 10.28.2`
+et's say we're going to `Update Node.js from v22.18.0 to v24.13.0` and `Update pnpm from 11.1.2 to 11.1.3`
 
 #### Step 1: Update Node.js to v24.13.0
 
@@ -572,7 +572,7 @@ et's say we're going to `Update Node.js from v22.18.0 to v24.13.0` and `Update p
    {
      "engines": {
        "node": "24.13.0",
-       "pnpm": "10.28.2"
+       "pnpm": "11.1.3"
      }
    }
    ```
@@ -582,12 +582,12 @@ et's say we're going to `Update Node.js from v22.18.0 to v24.13.0` and `Update p
    use-node-version=24.13.0
    ```
 
-#### Step 2: Update pnpm to v10.28.2
+#### Step 2: Update pnpm to v11.1.3
 
 1. **Update `package.json` packageManager:**
    ```json
    {
-     "packageManager": "pnpm@10.28.2"
+     "packageManager": "pnpm@11.1.3"
    }
    ```
 
@@ -604,7 +604,7 @@ node --version  # Should show v24.13.0
 # Update pnpm
 corepack enable
 # OR manually
-npm install -g pnpm@10.28.2
+npm install -g pnpm@11.1.3
 
 # Clean install
 rm -rf node_modules apps/*/node_modules packages/*/node_modules
@@ -668,7 +668,7 @@ git checkout main -- .nvmrc package.json .npmrc
 nvm use 22.18.0
 
 # 3. Reinstall old pnpm
-npm install -g pnpm@10.28.1
+npm install -g pnpm@11.1.2
 
 # 4. Restore lockfile
 git checkout main -- pnpm-lock.yaml
@@ -684,7 +684,7 @@ pnpm install
 
 **Current recommendation for your team:**
 
-1. **✅ Update pnpm to v10.28.2** - Safe patch update, minimal risk
+1. **✅ Update pnpm to v11.1.3** - Safe patch update, minimal risk
 2. **🟡 Plan Node.js v24 upgrade** - Current LTS, but coordinate with team first
 3. **📝 Create migration plan** - Use this guide
 4. **🧪 Test thoroughly** - Run full test suite before team rollout

--- a/portals/package.json
+++ b/portals/package.json
@@ -2,10 +2,10 @@
   "name": "portals-workspace",
   "version": "1.0.0",
   "description": "",
-  "packageManager": "pnpm@10.28.1",
+  "packageManager": "pnpm@11.1.2",
   "engines": {
     "node": ">=22.18.0",
-    "pnpm": ">=10.28.1"
+    "pnpm": ">=11.0.0"
   },
   "scripts": {
     "build": "pnpm --recursive run build",

--- a/portals/pnpm-workspace.yaml
+++ b/portals/pnpm-workspace.yaml
@@ -6,7 +6,3 @@ allowBuilds:
   '@swc/core': true
   core-js: false
   esbuild: true
-
-onlyBuiltDependencies:
-  - '@swc/core'
-  - esbuild

--- a/portals/pnpm-workspace.yaml
+++ b/portals/pnpm-workspace.yaml
@@ -2,6 +2,11 @@ packages:
   - apps/*
   - packages/*
 
+allowBuilds:
+  '@swc/core': true
+  core-js: false
+  esbuild: true
+
 onlyBuiltDependencies:
   - '@swc/core'
   - esbuild


### PR DESCRIPTION
## Summary

Migrate pnpm from **v10.28.1 to v11.1.2** across the Portals workspace, CI workflow, Makefile, and developer documentation, plus follow-up cleanups (SHA-pinned `pnpm/action-setup`, corepack-based Makefile setup, removed redundant `onlyBuiltDependencies`). Brings the Portals tooling onto the supported pnpm major and aligns supply-chain / DX with current best practices.

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [x] Other (please describe): Tooling upgrade — pnpm v10.28.1 → v11.1.2

> The "Breaking change" box is checked because `engine-strict=true` in `portals/.npmrc` will block `pnpm install` for any developer still on pnpm < 11.0.0 until they update locally. See Deployment Notes.

## Changes Made

The PR contains **two commits** intentionally kept separate to preserve `git bisect` and selective-revert capability.

**Phase 1 — pnpm v11 migration** (`22d2f951`):
- `portals/package.json`: `packageManager: pnpm@11.1.2`, `engines.pnpm: ">=11.0.0"`
- `portals/Makefile`: setup target installs `pnpm@11.1.2` (further cleaned in Phase 2)
- `.github/workflows/portals-ci.yml`: `pnpm/action-setup@v3` → `@v6` (v6 added pnpm v11 support); `version: 10.28.1` → `11.1.2` in both `qa-and-build` and `security-scan` jobs
- `portals/pnpm-workspace.yaml`: added `allowBuilds` block (new in pnpm v11) — `@swc/core: true` and `esbuild: true` preserve the v10 `onlyBuiltDependencies` behavior; `core-js: false` is a safe default for a newly-flagged package
- `portals/docs/SETUP_WORKSPACE.md`: version-string sweep + version-update appendix rewritten so its worked example is `v11.1.2 → v11.1.3` instead of the obsolete `v10.28.1 → v10.28.2`; "Current versions locked as of" date refreshed

**Phase 2 — supply-chain & DX cleanups** (`9d34a8f6`):
- Removed redundant `onlyBuiltDependencies` from `portals/pnpm-workspace.yaml`. Verified via clean install that `allowBuilds` alone is sufficient to run `@swc/core` and `esbuild` postinstall scripts
- SHA-pinned `pnpm/action-setup` to `0e279bb959325dab635dd2c09392533439d90093 # v6.0.8` in both Portals CI jobs (supply-chain hardening)
- Switched `portals/Makefile` setup target from `npm install -g pnpm@11.1.2` to `corepack enable`. Corepack reads the pnpm version from the `packageManager` field, removing the hardcoded version duplication in the Makefile

**Lockfile note:** `portals/pnpm-lock.yaml` is **unchanged**. pnpm v9, v10, and v11 all share `lockfileVersion: '9.0'` — the v11 major didn't bump the format.

## Testing

- [x] I have tested this change locally
- [ ] I have added unit tests for new functionality (N/A — no new functionality)
- [x] I have tested edge cases
- [x] All existing tests pass

**Local verification suite** (run with pnpm 11.1.2, Node 22.22.1):

| Check | Result |
|---|---|
| `pnpm install --frozen-lockfile` | ✅ exit 0 |
| `pnpm run type-check` | ✅ all 4 workspaces |
| `pnpm run build` | ✅ all apps + UI library |
| `pnpm run format:check` | ✅ on tracked files |
| `pnpm run lint` | ⚠️ pre-existing failures in `jsonforms-renderers` (CI has `continue-on-error: true`) |
| `pnpm audit --audit-level=high` | ⚠️ 45 pre-existing vulnerabilities (CI has `continue-on-error: true`) |
| `docker build apps/oga-app/Dockerfile` | ✅ 144 MB image; confirms corepack inside the container picks up pnpm 11.1.2 from the new `packageManager` field |

**Edge cases verified:**
- `allowBuilds` alone (no `onlyBuiltDependencies`) — confirmed `@swc/core` and `esbuild` postinstalls run cleanly
- Docker corepack auto-adapt — confirmed via successful image build
- `--frozen-lockfile` against the unchanged v9 lockfile — confirmed v11 accepts the v10-generated lockfile

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas (N/A — config-only change)
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have checked that there are no merge conflicts

## Related Issues

No directly-related issue. A follow-up **umbrella issue** covering remaining best-practice items (Dependabot config, SHA-pinning the other GH Actions in this workflow, pnpm catalogs, `pnpm dedupe --check` gate, `pnpm@latest` canary, `SETUP_WORKSPACE.md` corepack-first refresh) will be filed separately and will reference [#427](https://github.com/OpenNSW/nsw/issues/427).

## Screenshots/Demo

N/A — tooling change with no UI impact.

## Additional Notes

**New pnpm v11 behavior — `allowBuilds`:** pnpm v11 introduced a stricter per-package build-script approval mechanism in `pnpm-workspace.yaml`. On first install under v11, pnpm auto-injects an `allowBuilds:` block listing every package with postinstall scripts (it appeared with `set this to true or false` placeholder strings on first run). The explicit values set here:

- `@swc/core: true` and `esbuild: true` — these need their postinstall scripts to download platform-specific native binaries; matches what `onlyBuiltDependencies` allowed under v10
- `core-js: false` — a newly-flagged package not previously listed in `onlyBuiltDependencies` under v10. Denying maintains the existing security posture

**Why the lockfile didn't change:** Every prior pnpm major bumped the lockfile (v7→6.0, v8→6.1, v9→9.0), but the format stabilized at v9 and has held across v9 / v10 / v11. v11 reads and writes `lockfileVersion: '9.0'` — same as v10. This was confirmed empirically by running `pnpm install --frozen-lockfile` against the existing lockfile with no diff.

## Deployment Notes

**⚠️ Existing developers must update pnpm locally before next `pnpm install`** — `engine-strict=true` in `portals/.npmrc` will block the install for any pnpm version below `11.0.0`. Two paths:

1. **Recommended (corepack):** `corepack enable` — corepack will auto-install pnpm 11.1.2 from the `packageManager` field on the next `pnpm` invocation
2. **Manual fallback:** `npm install -g pnpm@11.1.2`

After merge, please notify the team (e.g., Slack channel) so existing local checkouts can be updated in coordination.

**CI runners:** unaffected — the workflow's `pnpm/action-setup` step installs pnpm 11.1.2 automatically (now SHA-pinned for supply-chain safety).

**Docker builds (`oga-app`, `trader-app`):** unaffected — both Dockerfiles use `corepack enable` and inherit the version from the `packageManager` field. Verified locally via `docker build` of `apps/oga-app/Dockerfile`.

**`SETUP_WORKSPACE.md`** already documents the migration steps for individual developers in its "Existing Developer Migration" section, including pnpm version verification commands.