### PR TITLE
feat(templatesource): introduce pkg/templatesource with local and GitHub-backed sources

### DIFF
--- a/backend/pkg/templatesource/README.md
+++ b/backend/pkg/templatesource/README.md
@@ -33,7 +33,7 @@ if err != nil {
 }
 defer src.Close()
 
-raw, ok, err := src.GetTemplate(ctx, "build-licence")
+raw, ok, err := src.GetTemplate(context.Background(), "build-licence")
 ```
 
 - Returns an error and refuses to start if `dir` is missing or any file
@@ -48,7 +48,7 @@ raw, ok, err := src.GetTemplate(ctx, "build-licence")
 first access.
 
 ```go
-src, err := templatesource.NewGitHub(ctx, templatesource.GitHubConfig{
+src, err := templatesource.NewGitHub(context.Background(), templatesource.GitHubConfig{
     Repo:            "OpenNSW/one-trade-templates",
     Ref:             "abc1234",           // pin to a SHA in production
     RefreshInterval: 5 * time.Minute,    // 0 disables background refresh
@@ -57,6 +57,8 @@ if err != nil {
     log.Fatal(err)
 }
 defer src.Close()
+
+raw, ok, err := src.GetTemplate(context.Background(), "build-licence")
 ```
 
 #### `GitHubConfig` fields

--- a/backend/pkg/templatesource/README.md
+++ b/backend/pkg/templatesource/README.md
@@ -8,10 +8,8 @@ interface with two implementations:
 | Local filesystem | `NewLocal(dir)` | Development / offline testing |
 | GitHub raw content | `NewGitHub(ctx, cfg)` | Staging and production |
 
-The package returns opaque `json.RawMessage` bytes and never inspects the JSON
-shape, so it can serve forms, workflow definitions, or any other
-manifest-keyed artifact. It is intentionally free of OGA-specific config or
-env coupling so it can be reused by other services.
+Each implementation validates that blobs are syntactically valid JSON but never
+inspects the document structure, leaving interpretation entirely to the caller.
 
 ## Import
 

--- a/backend/pkg/templatesource/README.md
+++ b/backend/pkg/templatesource/README.md
@@ -1,0 +1,101 @@
+# templatesource
+
+Resolves JSON template blobs by ID. The package exposes a single `Source`
+interface with two implementations:
+
+| Implementation | Constructor | When to use |
+|---|---|---|
+| Local filesystem | `NewLocal(dir)` | Development / offline testing |
+| GitHub raw content | `NewGitHub(ctx, cfg)` | Staging and production |
+
+The package returns opaque `json.RawMessage` bytes and never inspects the JSON
+shape, so it can serve forms, workflow definitions, or any other
+manifest-keyed artifact. It is intentionally free of OGA-specific config or
+env coupling so it can be reused by other services.
+
+## Import
+
+```go
+import "github.com/OpenNSW/nsw/pkg/templatesource"
+```
+
+## Usage
+
+### Local source
+
+`NewLocal` reads every `.json` file in `dir` into memory at startup. The file
+basename without the `.json` extension becomes the template ID.
+
+```go
+src, err := templatesource.NewLocal("/etc/oga/templates")
+if err != nil {
+    log.Fatal(err)
+}
+defer src.Close()
+
+raw, ok, err := src.GetTemplate(ctx, "build-licence")
+```
+
+- Returns an error and refuses to start if `dir` is missing or any file
+  contains invalid JSON.
+- Subdirectories and non-`.json` files are silently skipped.
+- `Close` is a no-op but must still be called to satisfy the interface.
+
+### GitHub source
+
+`NewGitHub` fetches `manifest.json` from a GitHub repository at startup
+(fail-fast), then lazily fetches and caches individual template files on
+first access.
+
+```go
+src, err := templatesource.NewGitHub(ctx, templatesource.GitHubConfig{
+    Repo:            "OpenNSW/one-trade-templates",
+    Ref:             "abc1234",           // pin to a SHA in production
+    RefreshInterval: 5 * time.Minute,    // 0 disables background refresh
+})
+if err != nil {
+    log.Fatal(err)
+}
+defer src.Close()
+```
+
+#### `GitHubConfig` fields
+
+| Field | Required | Default | Description |
+|---|---|---|---|
+| `Repo` | yes | — | `"owner/name"` e.g. `"OpenNSW/one-trade-templates"` |
+| `Ref` | yes | — | Branch name or commit SHA. Pin to a SHA in production. |
+| `RefreshInterval` | no | `0` (disabled) | How often to re-fetch `manifest.json` in the background. |
+| `BaseURL` | no | `https://raw.githubusercontent.com` | Override for GitHub Enterprise, mirrors, or test servers. |
+| `HTTPClient` | no | 10 s-timeout client | Override for custom TLS, proxies, or test transports. |
+
+#### How it works
+
+1. **Manifest** — `manifest.json` must contain a top-level `byId` object that
+   maps template IDs to repo-relative file paths:
+   ```json
+   { "byId": { "build-licence": "forms/build-licence.json" } }
+   ```
+2. **Lazy fetch** — the first `GetTemplate` call for an ID fetches the file
+   and caches it.
+3. **Background refresh** — when `RefreshInterval > 0`, a goroutine
+   periodically re-fetches the manifest. Cache entries whose paths no longer
+   appear in the new manifest are evicted automatically.
+4. **`Close`** — stops the background goroutine. Safe to call multiple times.
+
+## `Source` contract
+
+```
+(bytes, true,  nil) — template found
+(nil,  false,  nil) — ID unknown to this source; caller should skip
+(nil,  false,  err) — fetch or parse failed; caller should warn-log and skip
+```
+
+## Running the tests
+
+```bash
+cd backend
+go test ./pkg/templatesource/...
+```
+
+Tests use `net/http/httptest` — no network access required.

--- a/backend/pkg/templatesource/github.go
+++ b/backend/pkg/templatesource/github.go
@@ -1,0 +1,234 @@
+package templatesource
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"log/slog"
+	"net/http"
+	"net/url"
+	"sync"
+	"time"
+)
+
+// DefaultGitHubBaseURL is the raw-content host for github.com.
+const DefaultGitHubBaseURL = "https://raw.githubusercontent.com"
+
+// maxResponseBytes caps the size of manifest.json and template payloads we
+// will read into memory. 10 MiB is well above any real JSON template and
+// prevents memory exhaustion if a misconfigured BaseURL points at something
+// that streams unbounded bytes.
+const maxResponseBytes int64 = 10 * 1024 * 1024
+
+// GitHubConfig configures a Source backed by a GitHub repository's
+// manifest.json (e.g. OpenNSW/one-trade-templates).
+type GitHubConfig struct {
+	// Repo is "owner/name", e.g. "OpenNSW/one-trade-templates".
+	Repo string
+	// Ref is a branch name or commit SHA. Pin to a SHA in production for
+	// reproducibility.
+	Ref string
+	// RefreshInterval is how often to re-fetch manifest.json in the background.
+	// 0 disables background refresh.
+	RefreshInterval time.Duration
+	// BaseURL overrides the raw-content host. Defaults to DefaultGitHubBaseURL.
+	// Set this when pointing at an httptest server, a self-hosted mirror, or
+	// GitHub Enterprise.
+	BaseURL string
+	// HTTPClient overrides the HTTP client. Defaults to a client with a 10s
+	// timeout.
+	HTTPClient *http.Client
+}
+
+// manifestData mirrors the subset of one-trade-templates/manifest.json that we
+// rely on. The full manifest also includes workflows/version/generated fields
+// which we ignore.
+type manifestData struct {
+	ByID map[string]string `json:"byId"`
+}
+
+// githubSource loads templates from a GitHub repo by reading its manifest.json
+// and fetching individual template files on demand. The manifest is refreshed
+// on a background ticker; template bytes are cached in memory keyed by their
+// manifest path so pushes that move a template to a different path invalidate
+// the cache for free.
+type githubSource struct {
+	repo     string
+	ref      string
+	baseURL  string
+	interval time.Duration
+	client   *http.Client
+
+	mu            sync.RWMutex
+	byID          map[string]string          // templateID -> repo-relative path
+	templateCache map[string]json.RawMessage // path -> template bytes
+
+	done      chan struct{}
+	closeOnce sync.Once
+}
+
+// NewGitHub builds a Source that loads its manifest from a GitHub repo at
+// startup (fail-fast on error) and refreshes it on a background ticker if
+// RefreshInterval > 0. Template files are fetched lazily on first GetTemplate
+// and cached in memory.
+func NewGitHub(ctx context.Context, cfg GitHubConfig) (Source, error) {
+	if cfg.Repo == "" {
+		return nil, fmt.Errorf("templatesource: GitHubConfig.Repo is required")
+	}
+	if cfg.Ref == "" {
+		return nil, fmt.Errorf("templatesource: GitHubConfig.Ref is required")
+	}
+	baseURL := cfg.BaseURL
+	if baseURL == "" {
+		baseURL = DefaultGitHubBaseURL
+	}
+	if _, err := url.Parse(baseURL); err != nil {
+		return nil, fmt.Errorf("templatesource: invalid BaseURL %q: %w", baseURL, err)
+	}
+	client := cfg.HTTPClient
+	if client == nil {
+		client = &http.Client{Timeout: 10 * time.Second}
+	}
+
+	src := &githubSource{
+		repo:          cfg.Repo,
+		ref:           cfg.Ref,
+		baseURL:       baseURL,
+		interval:      cfg.RefreshInterval,
+		client:        client,
+		byID:          map[string]string{},
+		templateCache: map[string]json.RawMessage{},
+		done:          make(chan struct{}),
+	}
+	if err := src.loadManifest(ctx); err != nil {
+		return nil, fmt.Errorf("templatesource: failed to load manifest from %s: %w", src.manifestURL(), err)
+	}
+	slog.Info("github template source initialized",
+		"repo", src.repo, "ref", src.ref, "manifestEntries", len(src.byID))
+	if src.interval > 0 {
+		go src.refreshLoop()
+	}
+	return src, nil
+}
+
+func (s *githubSource) manifestURL() string {
+	// BaseURL is validated at construction; JoinPath only errors on an
+	// unparseable base, so the discarded error is unreachable here.
+	u, _ := url.JoinPath(s.baseURL, s.repo, s.ref, "manifest.json")
+	return u
+}
+
+func (s *githubSource) templateURL(path string) string {
+	u, _ := url.JoinPath(s.baseURL, s.repo, s.ref, path)
+	return u
+}
+
+func (s *githubSource) loadManifest(ctx context.Context) error {
+	url := s.manifestURL()
+	body, err := s.fetch(ctx, url)
+	if err != nil {
+		return err
+	}
+	var m manifestData
+	if err := json.Unmarshal(body, &m); err != nil {
+		return fmt.Errorf("failed to parse manifest at %s: %w", url, err)
+	}
+	if m.ByID == nil {
+		return fmt.Errorf("manifest at %s has no byId field", url)
+	}
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	// Invalidate cache entries whose path is no longer referenced by the new
+	// manifest. Path equality across refreshes is enough — if the same path
+	// still appears in byId, its bytes are still correct.
+	newPaths := make(map[string]struct{}, len(m.ByID))
+	for _, p := range m.ByID {
+		newPaths[p] = struct{}{}
+	}
+	for path := range s.templateCache {
+		if _, ok := newPaths[path]; !ok {
+			delete(s.templateCache, path)
+		}
+	}
+	s.byID = m.ByID
+	return nil
+}
+
+func (s *githubSource) refreshLoop() {
+	ticker := time.NewTicker(s.interval)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-s.done:
+			return
+		case <-ticker.C:
+			s.refresh()
+		}
+	}
+}
+
+func (s *githubSource) refresh() {
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	if err := s.loadManifest(ctx); err != nil {
+		slog.Warn("templatesource: github manifest refresh failed", "error", err)
+	}
+}
+
+func (s *githubSource) GetTemplate(ctx context.Context, id string) (json.RawMessage, bool, error) {
+	s.mu.RLock()
+	path, known := s.byID[id]
+	if !known {
+		s.mu.RUnlock()
+		return nil, false, nil
+	}
+	if cached, hit := s.templateCache[path]; hit {
+		s.mu.RUnlock()
+		return cached, true, nil
+	}
+	s.mu.RUnlock()
+
+	body, err := s.fetch(ctx, s.templateURL(path))
+	if err != nil {
+		return nil, false, err
+	}
+	if !json.Valid(body) {
+		return nil, false, fmt.Errorf("templatesource: template %q at %s is not valid JSON", id, path)
+	}
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if cached, hit := s.templateCache[path]; hit {
+		return cached, true, nil
+	}
+	// Only cache if the manifest still maps this id to this path. A concurrent
+	// refresh could have moved the template elsewhere while we were fetching.
+	if curPath, stillKnown := s.byID[id]; stillKnown && curPath == path {
+		s.templateCache[path] = body
+	}
+	return body, true, nil
+}
+
+func (s *githubSource) Close() error {
+	s.closeOnce.Do(func() { close(s.done) })
+	return nil
+}
+
+func (s *githubSource) fetch(ctx context.Context, requestURL string) ([]byte, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, requestURL, nil)
+	if err != nil {
+		return nil, fmt.Errorf("build request for %s: %w", requestURL, err)
+	}
+	resp, err := s.client.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("GET %s: %w", requestURL, err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return nil, fmt.Errorf("GET %s: unexpected status %d", requestURL, resp.StatusCode)
+	}
+	return io.ReadAll(io.LimitReader(resp.Body, maxResponseBytes))
+}

--- a/backend/pkg/templatesource/github.go
+++ b/backend/pkg/templatesource/github.go
@@ -60,12 +60,12 @@ type githubSource struct {
 	interval time.Duration
 	client   *http.Client
 
+	ctx    context.Context
+	cancel context.CancelFunc
+
 	mu            sync.RWMutex
 	byID          map[string]string          // templateID -> repo-relative path
 	templateCache map[string]json.RawMessage // path -> template bytes
-
-	done      chan struct{}
-	closeOnce sync.Once
 }
 
 // NewGitHub builds a Source that loads its manifest from a GitHub repo at
@@ -91,15 +91,17 @@ func NewGitHub(ctx context.Context, cfg GitHubConfig) (Source, error) {
 		client = &http.Client{Timeout: 10 * time.Second}
 	}
 
+	srcCtx, cancel := context.WithCancel(context.Background())
 	src := &githubSource{
 		repo:          cfg.Repo,
 		ref:           cfg.Ref,
 		baseURL:       baseURL,
 		interval:      cfg.RefreshInterval,
 		client:        client,
+		ctx:           srcCtx,
+		cancel:        cancel,
 		byID:          map[string]string{},
 		templateCache: map[string]json.RawMessage{},
-		done:          make(chan struct{}),
 	}
 	if err := src.loadManifest(ctx); err != nil {
 		return nil, fmt.Errorf("templatesource: failed to load manifest from %s: %w", src.manifestURL(), err)
@@ -157,7 +159,7 @@ func (s *githubSource) refreshLoop() {
 	defer ticker.Stop()
 	for {
 		select {
-		case <-s.done:
+		case <-s.ctx.Done():
 			return
 		case <-ticker.C:
 			s.refresh()
@@ -166,7 +168,7 @@ func (s *githubSource) refreshLoop() {
 }
 
 func (s *githubSource) refresh() {
-	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	ctx, cancel := context.WithTimeout(s.ctx, 10*time.Second)
 	defer cancel()
 	if err := s.loadManifest(ctx); err != nil {
 		slog.Warn("templatesource: github manifest refresh failed", "error", err)
@@ -207,8 +209,10 @@ func (s *githubSource) GetTemplate(ctx context.Context, id string) (json.RawMess
 	return body, true, nil
 }
 
+// Close stops the background refresh goroutine and cancels any in-flight
+// manifest fetch. Safe to call multiple times.
 func (s *githubSource) Close() error {
-	s.closeOnce.Do(func() { close(s.done) })
+	s.cancel()
 	return nil
 }
 

--- a/backend/pkg/templatesource/github.go
+++ b/backend/pkg/templatesource/github.go
@@ -141,18 +141,13 @@ func (s *githubSource) loadManifest(ctx context.Context) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
-	// Invalidate cache entries whose path is no longer referenced by the new
-	// manifest. Path equality across refreshes is enough — if the same path
-	// still appears in byId, its bytes are still correct.
-	newPaths := make(map[string]struct{}, len(m.ByID))
-	for _, p := range m.ByID {
-		newPaths[p] = struct{}{}
-	}
-	for path := range s.templateCache {
-		if _, ok := newPaths[path]; !ok {
-			delete(s.templateCache, path)
-		}
-	}
+	// Clear the entire template cache on every refresh. When Ref is a branch
+	// name a template file can be updated in-place (same manifest path, new
+	// bytes), so selective path-based eviction would keep serving stale
+	// content. A full clear ensures the next GetTemplate always fetches the
+	// latest bytes. The trade-off (one extra fetch per cached template after
+	// each refresh) is acceptable given typical refresh intervals.
+	s.templateCache = make(map[string]json.RawMessage)
 	s.byID = m.ByID
 	return nil
 }

--- a/backend/pkg/templatesource/github_test.go
+++ b/backend/pkg/templatesource/github_test.go
@@ -231,6 +231,40 @@ func TestGitHub_ManifestRefreshInvalidatesCache(t *testing.T) {
 	}
 }
 
+// TestGitHub_ManifestRefreshClearsStaleContent verifies that updating a
+// template file in-place (same manifest path, new bytes) is reflected after
+// a manifest refresh. The old selective-eviction logic would have served
+// stale content in this scenario.
+func TestGitHub_ManifestRefreshClearsStaleContent(t *testing.T) {
+	stub, srv := newStubTemplateServer(t)
+	stub.setManifest(map[string]string{"alpha": "templates/a.json"})
+	stub.setFile("templates/a.json", `{"v":1}`)
+
+	src := newTestGitHubSource(t, srv.URL, 0)
+
+	if _, ok, err := src.GetTemplate(context.Background(), "alpha"); err != nil || !ok {
+		t.Fatalf("expected initial alpha (ok=%v, err=%v)", ok, err)
+	}
+
+	// Update file content in-place; manifest path is unchanged.
+	stub.setFile("templates/a.json", `{"v":2}`)
+	gs, ok := src.(*githubSource)
+	if !ok {
+		t.Fatalf("expected *githubSource, got %T", src)
+	}
+	if err := gs.loadManifest(context.Background()); err != nil {
+		t.Fatalf("manifest reload: %v", err)
+	}
+
+	body, ok, err := src.GetTemplate(context.Background(), "alpha")
+	if err != nil || !ok {
+		t.Fatalf("expected refreshed alpha (ok=%v, err=%v)", ok, err)
+	}
+	if got := string(body); got != `{"v":2}` {
+		t.Errorf("expected updated content after manifest refresh, got %s", got)
+	}
+}
+
 func TestGitHub_BackgroundRefreshTicks(t *testing.T) {
 	stub, srv := newStubTemplateServer(t)
 	stub.setManifest(map[string]string{"alpha": "templates/a.json"})

--- a/backend/pkg/templatesource/github_test.go
+++ b/backend/pkg/templatesource/github_test.go
@@ -1,0 +1,346 @@
+package templatesource
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+// stubTemplateServer serves a manifest + arbitrary form files. Routes match
+// the raw.githubusercontent.com layout: /<owner>/<repo>/<ref>/<path>.
+type stubTemplateServer struct {
+	t        *testing.T
+	mu       sync.Mutex
+	manifest atomic.Value // []byte
+	files    map[string][]byte
+	fetches  atomic.Int64 // counts manifest GETs
+}
+
+func newStubTemplateServer(t *testing.T) (*stubTemplateServer, *httptest.Server) {
+	t.Helper()
+	s := &stubTemplateServer{t: t, files: make(map[string][]byte)}
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		path := strings.TrimPrefix(r.URL.Path, "/")
+		// path looks like "<owner>/<repo>/<ref>/<rest>"
+		// strip the first three segments to get the in-repo path.
+		parts := strings.SplitN(path, "/", 4)
+		if len(parts) < 4 {
+			http.NotFound(w, r)
+			return
+		}
+		repoRelative := parts[3]
+
+		if repoRelative == "manifest.json" {
+			s.fetches.Add(1)
+			body, _ := s.manifest.Load().([]byte)
+			if body == nil {
+				http.NotFound(w, r)
+				return
+			}
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write(body)
+			return
+		}
+
+		s.mu.Lock()
+		body, ok := s.files[repoRelative]
+		s.mu.Unlock()
+		if !ok {
+			http.NotFound(w, r)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write(body)
+	}))
+	t.Cleanup(srv.Close)
+	return s, srv
+}
+
+// setManifest installs a manifest whose byId is the given map.
+func (s *stubTemplateServer) setManifest(byID map[string]string) {
+	body, err := json.Marshal(map[string]any{"byId": byID})
+	if err != nil {
+		s.t.Fatalf("marshal manifest: %v", err)
+	}
+	s.manifest.Store(body)
+}
+
+// setRawManifest installs an arbitrary body (for parse-error tests).
+func (s *stubTemplateServer) setRawManifest(body []byte) {
+	s.manifest.Store(body)
+}
+
+func (s *stubTemplateServer) setFile(path, body string) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.files[path] = []byte(body)
+}
+
+func (s *stubTemplateServer) deleteFile(path string) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	delete(s.files, path)
+}
+
+func newTestGitHubSource(t *testing.T, srvURL string, interval time.Duration) Source {
+	t.Helper()
+	src, err := NewGitHub(context.Background(), GitHubConfig{
+		Repo:            "owner/repo",
+		Ref:             "main",
+		BaseURL:         srvURL,
+		RefreshInterval: interval,
+	})
+	if err != nil {
+		t.Fatalf("NewGitHub: %v", err)
+	}
+	t.Cleanup(func() { _ = src.Close() })
+	return src
+}
+
+func TestGitHub_HappyPath(t *testing.T) {
+	stub, srv := newStubTemplateServer(t)
+	stub.setManifest(map[string]string{"alpha": "templates/a.json"})
+	stub.setFile("templates/a.json", `{"schema":{"type":"object"}}`)
+
+	src := newTestGitHubSource(t, srv.URL, 0)
+
+	body, ok, err := src.GetTemplate(context.Background(), "alpha")
+	if err != nil || !ok {
+		t.Fatalf("expected alpha (ok=%v, err=%v)", ok, err)
+	}
+	var got map[string]any
+	if err := json.Unmarshal(body, &got); err != nil {
+		t.Fatalf("returned form is not valid JSON: %v", err)
+	}
+	if _, ok := got["schema"]; !ok {
+		t.Errorf("expected schema field, got %v", got)
+	}
+
+	// Second call should hit the in-memory cache (no new file fetch); easiest
+	// check is that it succeeds even after we delete the upstream file.
+	stub.deleteFile("templates/a.json")
+	if _, ok, err := src.GetTemplate(context.Background(), "alpha"); err != nil || !ok {
+		t.Fatalf("expected cached alpha (ok=%v, err=%v)", ok, err)
+	}
+}
+
+func TestGitHub_UnknownIDReturnsNotFound(t *testing.T) {
+	stub, srv := newStubTemplateServer(t)
+	stub.setManifest(map[string]string{"alpha": "templates/a.json"})
+
+	src := newTestGitHubSource(t, srv.URL, 0)
+
+	body, ok, err := src.GetTemplate(context.Background(), "missing")
+	if err != nil {
+		t.Fatalf("expected nil error for unknown ID, got %v", err)
+	}
+	if ok || body != nil {
+		t.Fatalf("expected (nil, false, nil) for unknown ID, got (%v, %v, %v)", body, ok, err)
+	}
+}
+
+func TestGitHub_ManifestMissingFailsFast(t *testing.T) {
+	// Manifest not installed -> handler returns 404 on the first fetch.
+	_, srv := newStubTemplateServer(t)
+
+	_, err := NewGitHub(context.Background(), GitHubConfig{
+		Repo:    "owner/repo",
+		Ref:     "main",
+		BaseURL: srv.URL,
+	})
+	if err == nil {
+		t.Fatalf("expected ctor error when manifest is missing, got nil")
+	}
+}
+
+func TestGitHub_ManifestInvalidJSONFailsFast(t *testing.T) {
+	stub, srv := newStubTemplateServer(t)
+	stub.setRawManifest([]byte(`{not json`))
+
+	_, err := NewGitHub(context.Background(), GitHubConfig{
+		Repo:    "owner/repo",
+		Ref:     "main",
+		BaseURL: srv.URL,
+	})
+	if err == nil {
+		t.Fatalf("expected ctor error on invalid manifest JSON, got nil")
+	}
+}
+
+func TestGitHub_FormFetchErrorPropagates(t *testing.T) {
+	stub, srv := newStubTemplateServer(t)
+	stub.setManifest(map[string]string{"alpha": "templates/a.json"})
+	// Intentionally do not install templates/a.json.
+
+	src := newTestGitHubSource(t, srv.URL, 0)
+
+	_, _, err := src.GetTemplate(context.Background(), "alpha")
+	if err == nil {
+		t.Fatalf("expected fetch error for missing form file, got nil")
+	}
+}
+
+func TestGitHub_FormInvalidJSONReturnsError(t *testing.T) {
+	stub, srv := newStubTemplateServer(t)
+	stub.setManifest(map[string]string{"alpha": "templates/a.json"})
+	stub.setFile("templates/a.json", `not json`)
+
+	src := newTestGitHubSource(t, srv.URL, 0)
+
+	_, _, err := src.GetTemplate(context.Background(), "alpha")
+	if err == nil {
+		t.Fatalf("expected error for invalid form JSON, got nil")
+	}
+}
+
+func TestGitHub_ManifestRefreshInvalidatesCache(t *testing.T) {
+	stub, srv := newStubTemplateServer(t)
+	stub.setManifest(map[string]string{"alpha": "templates/a.json"})
+	stub.setFile("templates/a.json", `{"v":1}`)
+	stub.setFile("templates/a2.json", `{"v":2}`)
+
+	src := newTestGitHubSource(t, srv.URL, 0)
+
+	if _, ok, err := src.GetTemplate(context.Background(), "alpha"); err != nil || !ok {
+		t.Fatalf("expected initial alpha (ok=%v, err=%v)", ok, err)
+	}
+
+	// Repoint alpha to a different path; manually reload manifest via type assertion.
+	stub.setManifest(map[string]string{"alpha": "templates/a2.json"})
+	gs, ok := src.(*githubSource)
+	if !ok {
+		t.Fatalf("expected *githubSource, got %T", src)
+	}
+	if err := gs.loadManifest(context.Background()); err != nil {
+		t.Fatalf("manifest reload: %v", err)
+	}
+
+	body, ok, err := src.GetTemplate(context.Background(), "alpha")
+	if err != nil || !ok {
+		t.Fatalf("expected refreshed alpha (ok=%v, err=%v)", ok, err)
+	}
+	if got := string(body); got != `{"v":2}` {
+		t.Errorf("expected new bytes after manifest swap, got %s", got)
+	}
+}
+
+func TestGitHub_BackgroundRefreshTicks(t *testing.T) {
+	stub, srv := newStubTemplateServer(t)
+	stub.setManifest(map[string]string{"alpha": "templates/a.json"})
+
+	src := newTestGitHubSource(t, srv.URL, 30*time.Millisecond)
+
+	// First fetch happened in ctor (count == 1). Wait for at least one tick.
+	deadline := time.Now().Add(2 * time.Second)
+	for stub.fetches.Load() < 2 {
+		if time.Now().After(deadline) {
+			t.Fatalf("manifest never re-fetched: fetches=%d", stub.fetches.Load())
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+
+	if err := src.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+}
+
+func TestGitHub_RequiresRepoAndRef(t *testing.T) {
+	_, err := NewGitHub(context.Background(), GitHubConfig{Ref: "main"})
+	if err == nil {
+		t.Fatalf("expected error for missing Repo")
+	}
+	_, err = NewGitHub(context.Background(), GitHubConfig{Repo: "owner/repo"})
+	if err == nil {
+		t.Fatalf("expected error for missing Ref")
+	}
+}
+
+// roundTripFunc lets a plain function satisfy http.RoundTripper.
+type roundTripFunc func(*http.Request) (*http.Response, error)
+
+func (f roundTripFunc) RoundTrip(r *http.Request) (*http.Response, error) { return f(r) }
+
+func TestGitHub_InvalidBaseURLReturnsError(t *testing.T) {
+	_, err := NewGitHub(context.Background(), GitHubConfig{
+		Repo:    "owner/repo",
+		Ref:     "main",
+		BaseURL: "://invalid", // empty scheme — url.Parse rejects this
+	})
+	if err == nil {
+		t.Fatal("expected error for invalid BaseURL, got nil")
+	}
+}
+
+func TestGitHub_DefaultBaseURLFallback(t *testing.T) {
+	// Failing transport prevents real network calls while still exercising the
+	// empty-BaseURL → DefaultGitHubBaseURL assignment and the transport-error path.
+	failClient := &http.Client{
+		Transport: roundTripFunc(func(r *http.Request) (*http.Response, error) {
+			return nil, context.DeadlineExceeded
+		}),
+	}
+	_, err := NewGitHub(context.Background(), GitHubConfig{
+		Repo:       "owner/repo",
+		Ref:        "main",
+		HTTPClient: failClient,
+		// BaseURL intentionally omitted to exercise the default-assignment branch.
+	})
+	if err == nil {
+		t.Fatal("expected error when manifest fetch fails, got nil")
+	}
+}
+
+func TestGitHub_ManifestMissingByIDField(t *testing.T) {
+	stub, srv := newStubTemplateServer(t)
+	stub.setRawManifest([]byte(`{"workflows":{}}`)) // valid JSON but no byId key
+
+	_, err := NewGitHub(context.Background(), GitHubConfig{
+		Repo:    "owner/repo",
+		Ref:     "main",
+		BaseURL: srv.URL,
+	})
+	if err == nil {
+		t.Fatal("expected error when manifest lacks byId field, got nil")
+	}
+}
+
+func TestGitHub_BackgroundRefreshLogsOnError(t *testing.T) {
+	stub, srv := newStubTemplateServer(t)
+	stub.setManifest(map[string]string{})
+
+	src := newTestGitHubSource(t, srv.URL, 30*time.Millisecond)
+
+	// Replace the manifest with invalid JSON so the next background tick fails
+	// and exercises the slog.Warn branch inside refresh().
+	stub.setRawManifest([]byte("{not json"))
+
+	deadline := time.Now().Add(2 * time.Second)
+	for stub.fetches.Load() < 2 {
+		if time.Now().After(deadline) {
+			t.Fatalf("background refresh never ticked: fetches=%d", stub.fetches.Load())
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	_ = src
+}
+
+// Close is idempotent.
+func TestGitHub_CloseIsIdempotent(t *testing.T) {
+	stub, srv := newStubTemplateServer(t)
+	stub.setManifest(map[string]string{})
+
+	src := newTestGitHubSource(t, srv.URL, 0)
+	if err := src.Close(); err != nil {
+		t.Fatalf("first Close: %v", err)
+	}
+	if err := src.Close(); err != nil {
+		t.Fatalf("second Close: %v", err)
+	}
+}

--- a/backend/pkg/templatesource/local.go
+++ b/backend/pkg/templatesource/local.go
@@ -43,6 +43,10 @@ func NewLocal(dir string) (Source, error) {
 		slog.Info("loaded template", "id", id)
 	}
 
+	if len(templates) == 0 {
+		return nil, fmt.Errorf("templatesource: no .json files found in %q", dir)
+	}
+
 	slog.Info("local template source initialized", "dir", dir, "count", len(templates))
 	return &localSource{templates: templates}, nil
 }

--- a/backend/pkg/templatesource/local.go
+++ b/backend/pkg/templatesource/local.go
@@ -1,0 +1,58 @@
+package templatesource
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+type localSource struct {
+	templates map[string]json.RawMessage
+}
+
+// NewLocal reads every .json file directly from dir into memory and returns
+// a Source that serves them. The file basename (without ".json") is the
+// template ID. Returns an error if dir is missing or any file contains
+// invalid JSON.
+func NewLocal(dir string) (Source, error) {
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read templates directory %q: %w", dir, err)
+	}
+
+	templates := make(map[string]json.RawMessage)
+	for _, entry := range entries {
+		if entry.IsDir() || !strings.HasSuffix(entry.Name(), ".json") {
+			continue
+		}
+
+		data, err := os.ReadFile(filepath.Join(dir, entry.Name()))
+		if err != nil {
+			return nil, fmt.Errorf("failed to read template file %q: %w", entry.Name(), err)
+		}
+		if !json.Valid(data) {
+			return nil, fmt.Errorf("template file %q contains invalid JSON", entry.Name())
+		}
+
+		id := strings.TrimSuffix(entry.Name(), ".json")
+		templates[id] = data
+		slog.Info("loaded template", "id", id)
+	}
+
+	slog.Info("local template source initialized", "dir", dir, "count", len(templates))
+	return &localSource{templates: templates}, nil
+}
+
+func (s *localSource) GetTemplate(_ context.Context, id string) (json.RawMessage, bool, error) {
+	tpl, ok := s.templates[id]
+	if !ok {
+		return nil, false, nil
+	}
+	return tpl, true, nil
+}
+
+func (s *localSource) Close() error { return nil }

--- a/backend/pkg/templatesource/local_test.go
+++ b/backend/pkg/templatesource/local_test.go
@@ -1,0 +1,177 @@
+package templatesource
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// writeTemplateFile writes content to <dir>/<name>.
+func writeTemplateFile(t *testing.T, dir, name, content string) {
+	t.Helper()
+	path := filepath.Join(dir, name)
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		t.Fatalf("failed to write %s: %v", path, err)
+	}
+}
+
+func TestLocal_LoadsValidTemplates(t *testing.T) {
+	dir := t.TempDir()
+	writeTemplateFile(t, dir, "alpha.json", `{"schema":{"type":"object"},"uiSchema":{"type":"VerticalLayout"}}`)
+	writeTemplateFile(t, dir, "beta.json", `{"schema":{"type":"object","title":"Beta"}}`)
+
+	src, err := NewLocal(dir)
+	if err != nil {
+		t.Fatalf("NewLocal failed: %v", err)
+	}
+
+	if _, ok, err := src.GetTemplate(context.Background(), "alpha"); err != nil || !ok {
+		t.Errorf("expected template alpha to be loaded (ok=%v, err=%v)", ok, err)
+	}
+	if _, ok, err := src.GetTemplate(context.Background(), "beta"); err != nil || !ok {
+		t.Errorf("expected template beta to be loaded (ok=%v, err=%v)", ok, err)
+	}
+}
+
+func TestLocal_GetTemplateReturnsRawJSON(t *testing.T) {
+	dir := t.TempDir()
+	body := `{"schema":{"type":"object","required":["foo"]},"uiSchema":{"type":"VerticalLayout"}}`
+	writeTemplateFile(t, dir, "alpha.json", body)
+
+	src, err := NewLocal(dir)
+	if err != nil {
+		t.Fatalf("NewLocal failed: %v", err)
+	}
+
+	raw, ok, err := src.GetTemplate(context.Background(), "alpha")
+	if err != nil || !ok {
+		t.Fatalf("expected alpha to be loaded (ok=%v, err=%v)", ok, err)
+	}
+
+	// Verify the returned bytes round-trip through JSON unmarshal.
+	var got map[string]any
+	if err := json.Unmarshal(raw, &got); err != nil {
+		t.Fatalf("returned template is not valid JSON: %v", err)
+	}
+	if _, ok := got["schema"]; !ok {
+		t.Errorf("expected schema field in returned template, got %v", got)
+	}
+}
+
+func TestLocal_SkipsNonJSONFiles(t *testing.T) {
+	dir := t.TempDir()
+	writeTemplateFile(t, dir, "alpha.json", `{"schema":{"type":"object"}}`)
+	writeTemplateFile(t, dir, "readme.txt", `this is not a template`)
+	writeTemplateFile(t, dir, "beta.yaml", `schema: {}`)
+
+	src, err := NewLocal(dir)
+	if err != nil {
+		t.Fatalf("NewLocal failed: %v", err)
+	}
+
+	if _, ok, _ := src.GetTemplate(context.Background(), "alpha"); !ok {
+		t.Errorf("expected alpha to be loaded")
+	}
+	// IDs should be derived from .json filenames only, never from .txt/.yaml.
+	if _, ok, _ := src.GetTemplate(context.Background(), "readme"); ok {
+		t.Errorf("readme.txt should have been skipped")
+	}
+	if _, ok, _ := src.GetTemplate(context.Background(), "beta"); ok {
+		t.Errorf("beta.yaml should have been skipped")
+	}
+}
+
+func TestLocal_GetTemplateMiss(t *testing.T) {
+	dir := t.TempDir()
+	writeTemplateFile(t, dir, "alpha.json", `{"schema":{"type":"object"}}`)
+
+	src, err := NewLocal(dir)
+	if err != nil {
+		t.Fatalf("NewLocal failed: %v", err)
+	}
+
+	_, ok, err := src.GetTemplate(context.Background(), "does-not-exist")
+	if ok {
+		t.Errorf("expected GetTemplate miss to return ok=false")
+	}
+	if err != nil {
+		t.Errorf("expected GetTemplate miss to return nil error, got %v", err)
+	}
+}
+
+func TestLocal_ErrorOnInvalidJSON(t *testing.T) {
+	dir := t.TempDir()
+	writeTemplateFile(t, dir, "broken.json", `{this is not valid json`)
+
+	_, err := NewLocal(dir)
+	if err == nil {
+		t.Fatalf("expected error when loading invalid JSON, got nil")
+	}
+}
+
+func TestLocal_ErrorOnMissingDir(t *testing.T) {
+	root := t.TempDir()
+	_, err := NewLocal(filepath.Join(root, "does-not-exist"))
+	if err == nil {
+		t.Fatalf("expected error when templates directory is missing, got nil")
+	}
+}
+
+func TestLocal_Close(t *testing.T) {
+	dir := t.TempDir()
+	writeTemplateFile(t, dir, "alpha.json", `{"schema":{}}`)
+	src, err := NewLocal(dir)
+	if err != nil {
+		t.Fatalf("NewLocal failed: %v", err)
+	}
+	if err := src.Close(); err != nil {
+		t.Errorf("Close returned unexpected error: %v", err)
+	}
+}
+
+func TestLocal_ErrorOnUnreadableFile(t *testing.T) {
+	if os.Getuid() == 0 {
+		t.Skip("running as root; chmod restrictions do not apply")
+	}
+	dir := t.TempDir()
+	path := filepath.Join(dir, "locked.json")
+	if err := os.WriteFile(path, []byte(`{"schema":{}}`), 0o644); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+	if err := os.Chmod(path, 0o000); err != nil {
+		t.Fatalf("Chmod: %v", err)
+	}
+	t.Cleanup(func() { _ = os.Chmod(path, 0o644) })
+
+	_, err := NewLocal(dir)
+	if err == nil {
+		t.Fatal("expected error for unreadable file, got nil")
+	}
+}
+
+func TestLocal_IgnoresSubdirectories(t *testing.T) {
+	dir := t.TempDir()
+	// A nested directory under dir should be ignored, not recursed into.
+	if err := os.MkdirAll(filepath.Join(dir, "nested"), 0o755); err != nil {
+		t.Fatalf("failed to create nested dir: %v", err)
+	}
+	writeTemplateFile(t, dir, "nested/should_be_ignored.json", `{"schema":{}}`)
+	writeTemplateFile(t, dir, "top.json", `{"schema":{"type":"object"}}`)
+
+	src, err := NewLocal(dir)
+	if err != nil {
+		t.Fatalf("NewLocal failed: %v", err)
+	}
+
+	if _, ok, _ := src.GetTemplate(context.Background(), "top"); !ok {
+		t.Errorf("expected top to be loaded")
+	}
+	if _, ok, _ := src.GetTemplate(context.Background(), "should_be_ignored"); ok {
+		t.Errorf("nested file should not be discovered")
+	}
+	if _, ok, _ := src.GetTemplate(context.Background(), "nested/should_be_ignored"); ok {
+		t.Errorf("nested file should not be discovered under any key")
+	}
+}

--- a/backend/pkg/templatesource/local_test.go
+++ b/backend/pkg/templatesource/local_test.go
@@ -119,6 +119,25 @@ func TestLocal_ErrorOnMissingDir(t *testing.T) {
 	}
 }
 
+func TestLocal_ErrorOnEmptyDir(t *testing.T) {
+	dir := t.TempDir()
+	_, err := NewLocal(dir)
+	if err == nil {
+		t.Fatalf("expected error for directory with no .json files, got nil")
+	}
+}
+
+func TestLocal_ErrorOnDirWithNoJSONFiles(t *testing.T) {
+	dir := t.TempDir()
+	writeTemplateFile(t, dir, "readme.txt", "not a template")
+	writeTemplateFile(t, dir, "config.yaml", "key: value")
+
+	_, err := NewLocal(dir)
+	if err == nil {
+		t.Fatalf("expected error when directory contains no .json files, got nil")
+	}
+}
+
 func TestLocal_Close(t *testing.T) {
 	dir := t.TempDir()
 	writeTemplateFile(t, dir, "alpha.json", `{"schema":{}}`)

--- a/backend/pkg/templatesource/source.go
+++ b/backend/pkg/templatesource/source.go
@@ -1,9 +1,8 @@
-// Package templatesource resolves JSON template blobs by ID. It exposes a
-// Source interface with two implementations: a local-folder reader and a
-// GitHub-manifest-backed loader. The package returns opaque bytes and never
-// inspects the JSON shape, so it can serve forms, workflow definitions, or
-// any other manifest-keyed artifact. It is intentionally free of any
-// OGA-specific config or env coupling so it can be reused by other services.
+// Package templatesource resolves JSON blobs by ID. It exposes a Source
+// interface with two implementations: a local-folder reader and a
+// GitHub-manifest-backed loader. Each implementation validates that blobs are
+// syntactically valid JSON but never inspects the document structure, leaving
+// interpretation entirely to the caller.
 package templatesource
 
 import (

--- a/backend/pkg/templatesource/source.go
+++ b/backend/pkg/templatesource/source.go
@@ -1,0 +1,25 @@
+// Package templatesource resolves JSON template blobs by ID. It exposes a
+// Source interface with two implementations: a local-folder reader and a
+// GitHub-manifest-backed loader. The package returns opaque bytes and never
+// inspects the JSON shape, so it can serve forms, workflow definitions, or
+// any other manifest-keyed artifact. It is intentionally free of any
+// OGA-specific config or env coupling so it can be reused by other services.
+package templatesource
+
+import (
+	"context"
+	"encoding/json"
+)
+
+// Source resolves templates by ID.
+//
+// Return contract:
+//   - (bytes, true, nil)   — template found and returned.
+//   - (nil,   false, nil)  — the ID is not known to this source. Callers should
+//     treat this as "skip and continue without the template".
+//   - (nil,   false, err)  — fetch or parse failed for an otherwise-known ID.
+//     Callers should warn-log and continue without the template.
+type Source interface {
+	GetTemplate(ctx context.Context, id string) (json.RawMessage, bool, error)
+	Close() error
+}


### PR DESCRIPTION
## Summary

Introduces `backend/pkg/templatesource` — a small, self-contained package that resolves JSON template blobs by ID. It is intentionally free of OGA-specific config or env coupling so it can be reused by other services.

Two implementations are provided:
- **`NewLocal`** — reads `.json` files from a directory into memory at startup (development / offline use).
- **`NewGitHub`** — fetches `manifest.json` from a GitHub repository at startup (fail-fast), then lazily fetches and caches individual template files on demand with optional background manifest refresh.

## Type of Change

- [x] New feature (non-breaking change which adds functionality)

## Changes Made

- `source.go` — defines the `Source` interface with a documented three-state return contract (`found / not-found / error`).
- `local.go` — `NewLocal` implementation: reads all `.json` files from a directory, validates JSON at load time, skips subdirectories and non-JSON files.
- `github.go` — `NewGitHub` implementation: manifest-driven loader with lazy per-template fetching, in-memory cache keyed by repo-relative path (so manifest refreshes automatically invalidate stale paths), `sync.RWMutex` for concurrent safety, `io.LimitReader` cap (10 MiB) to guard against runaway responses, and idempotent `Close` via `sync.Once`.
- `local_test.go` / `github_test.go` — full test suite using `net/http/httptest`; no real network calls required.
- `README.md` — usage examples, `GitHubConfig` field reference, and `Source` contract documentation.

## Testing

- [x] I have tested this change locally
- [x] I have added unit tests for new functionality
- [x] I have tested edge cases
- [x] All existing tests pass

**Coverage: 98.2%** (`go test ./pkg/templatesource/... -covermode=atomic`)

Key scenarios covered:
- Local: valid load, raw JSON round-trip, non-JSON file skipping, subdirectory exclusion, missing dir, invalid JSON, unreadable file, `Close`.
- GitHub: happy path + cache hit, unknown ID, missing manifest (fail-fast), invalid manifest JSON (fail-fast), missing `byId` field, template fetch error, invalid template JSON, manifest refresh cache invalidation, background refresh ticking, background refresh error logging, invalid `BaseURL`, default `BaseURL` fallback, concurrent close idempotency.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have checked that there are no merge conflicts

## Related Issues

Related to #513 <!-- OGA form source wiring -->

## Additional Notes

The two remaining uncovered statements (≈1.8%) are the concurrency double-check cache path in `GetTemplate` (requires a precise goroutine race to trigger deterministically) and the `http.NewRequestWithContext` failure path (unreachable in normal operation since URLs are constructed via validated `url.JoinPath`).