### PR TITLE
refactor(consignment): scope consignments by trader/CHA company

### DIFF
--- a/backend/internal/app/bootstrap/app.go
+++ b/backend/internal/app/bootstrap/app.go
@@ -85,6 +85,7 @@ func Build(ctx context.Context, cfg *config.Config) (*App, error) {
 	templateService := service.NewTemplateService(db)
 	chaService := cha.NewService(db)
 	companyService := company.NewService(db)
+	userProfileService := user.NewService(db)
 	hsCodeService := hscode.NewService(db)
 
 	temporalClient, err := temporal.NewClient(cfg.Temporal)
@@ -93,8 +94,8 @@ func Build(ctx context.Context, cfg *config.Config) (*App, error) {
 		return nil, fmt.Errorf("failed to create temporal client: %w", err)
 	}
 
-	consignmentService := consignment.NewService(db, templateService, chaService, hsCodeService)
-	consignmentRouter := consignment.NewRouter(consignmentService, chaService)
+	consignmentService := consignment.NewService(db, templateService, chaService, companyService, userProfileService, hsCodeService)
+	consignmentRouter := consignment.NewRouter(consignmentService, chaService, companyService)
 
 	workflowRuntime, err := workflowruntime.NewRuntime(temporalClient, tm, templateService, consignmentService)
 	if err != nil {
@@ -126,8 +127,6 @@ func Build(ctx context.Context, cfg *config.Config) (*App, error) {
 	storageHandler := storage.NewHTTPHandler(storageService)
 
 	paymentHandler := payments.NewHTTPHandler(paymentService)
-
-	userProfileService := user.NewService(db)
 
 	authManager, err := auth.NewManager(userProfileService, cfg.Auth)
 	if err != nil {

--- a/backend/internal/consignment/errors.go
+++ b/backend/internal/consignment/errors.go
@@ -1,0 +1,12 @@
+package consignment
+
+import "errors"
+
+var (
+	// ErrCompanyNotCHA is returned when a trader selects a company that is not enabled as a CHA company.
+	ErrCompanyNotCHA = errors.New("company is not enabled as a CHA")
+
+	// ErrCHACompanyMismatch is returned at Stage 2 when the CHA attempting to claim a
+	// consignment does not belong to the CHA company chosen by the trader at Stage 1.
+	ErrCHACompanyMismatch = errors.New("CHA does not belong to the consignment's CHA company")
+)

--- a/backend/internal/consignment/model.go
+++ b/backend/internal/consignment/model.go
@@ -5,7 +5,6 @@ import (
 	"time"
 
 	"github.com/OpenNSW/nsw/internal/hscode"
-	"github.com/OpenNSW/nsw/internal/profile/cha"
 	"github.com/OpenNSW/nsw/internal/workflow/model"
 )
 
@@ -34,14 +33,18 @@ type Consignment struct {
 	CreatedAt time.Time `gorm:"type:timestamptz;column:created_at;not null;autoCreateTime" json:"createdAt"`
 	UpdatedAt time.Time `gorm:"type:timestamptz;column:updated_at;not null;autoUpdateTime" json:"updatedAt"`
 
-	Flow     Flow   `gorm:"type:varchar(50);column:flow;not null" json:"flow"`             // e.g., IMPORT, EXPORT
-	TraderID string `gorm:"type:varchar(100);column:trader_id;not null" json:"traderId"`   // ID of the trader associated with the consignment
-	State    State  `gorm:"type:varchar(50);column:state;not null" json:"state"`           // State of the consignment
-	Items    []Item `gorm:"type:jsonb;column:items;serializer:json;not null" json:"items"` // Items in the consignment
+	// Core attributes
+	Flow  Flow   `gorm:"type:varchar(50);column:flow;not null" json:"flow"`             // IMPORT or EXPORT
+	State State  `gorm:"type:varchar(50);column:state;not null" json:"state"`           // INITIALIZED → IN_PROGRESS → FINISHED
+	Items []Item `gorm:"type:jsonb;column:items;serializer:json;not null" json:"items"` // Items in the consignment
 
-	// CHA (Customs House Agent) – set at Stage 1 by Trader; CHA completes Stage 2 by selecting HS Code
-	CHAID string     `gorm:"type:varchar(100);column:cha_id;not null" json:"chaId"` // Assigned CHA (Stage 1)
-	CHA   cha.Record `gorm:"foreignKey:CHAID" json:"cha"`                           // Associated CHA entity
+	// Trader (set at Stage 1)
+	TraderID        string `gorm:"type:varchar(100);column:trader_id;not null" json:"traderId"`                // Trader user who created the consignment
+	TraderCompanyID string `gorm:"type:varchar(100);column:trader_company_id;not null" json:"traderCompanyId"` // Company the trader belongs to
+
+	// CHA (company chosen at Stage 1; specific CHA assigned at Stage 2)
+	CHACompanyID string  `gorm:"type:varchar(100);column:cha_company_id;not null" json:"chaCompanyId"` // CHA company selected by the trader at Stage 1
+	CHAID        *string `gorm:"type:varchar(100);column:cha_id" json:"chaId,omitempty"`               // CHA who claimed the consignment at Stage 2
 
 	// Relationships
 	Workflow *model.Workflow `gorm:"foreignKey:ID;references:ID" json:"-"` // Associated Workflow (1:1, same ID)
@@ -72,17 +75,17 @@ type CreateConsignmentItemDTO struct {
 }
 
 // CreateConsignmentDTO represents the data required to create a consignment.
-// Stage 1 (two-stage flow): provide flow + chaId only → creates shell with state INITIALIZED.
-// Legacy / single-stage: provide flow + items → creates consignment and initializes workflow.
+// Stage 1 (two-stage flow): provide flow + chaCompanyId → creates shell with state INITIALIZED.
+// A specific CHA is assigned later, at Stage 2, when a CHA from chaCompanyId claims the consignment.
 type CreateConsignmentDTO struct {
-	Flow  Flow                       `json:"flow"`
-	ChaID string                     `json:"chaId"`
-	Items []CreateConsignmentItemDTO `json:"items,omitempty"`
+	Flow         Flow                       `json:"flow"`
+	ChaCompanyID string                     `json:"chaCompanyId"`
+	Items        []CreateConsignmentItemDTO `json:"items,omitempty"`
 }
 
 func (d *CreateConsignmentDTO) Validate() error {
-	if d.ChaID == "" {
-		return fmt.Errorf("chaId is required")
+	if d.ChaCompanyID == "" {
+		return fmt.Errorf("chaCompanyId is required")
 	}
 	if d.Flow != FlowImport && d.Flow != FlowExport {
 		return fmt.Errorf("flow must be IMPORT or EXPORT")
@@ -99,25 +102,29 @@ type UpdateDTO struct {
 
 // DetailDTO represents the full consignment data returned in detailed responses.
 type DetailDTO struct {
-	ID            string                          `json:"id"`            // Consignment ID
-	Flow          Flow                            `json:"flow"`          // e.g., IMPORT, EXPORT
-	TraderID      string                          `json:"traderId"`      // ID of the trader associated with the consignment
-	ChaID         string                          `json:"chaId"`         // Assigned CHA (Stage 1)
-	State         State                           `json:"state"`         // State of the consignment
-	Items         []ItemResponseDTO               `json:"items"`         // Items in the consignment with full HS Code details
-	CreatedAt     string                          `json:"createdAt"`     // Timestamp of consignment creation
-	UpdatedAt     string                          `json:"updatedAt"`     // Timestamp of last consignment update
-	WorkflowNodes []model.WorkflowNodeResponseDTO `json:"workflowNodes"` // Associated workflow nodes with template details
-	Edges         []model.WorkflowEdgeResponseDTO `json:"edges"`         // Edges between workflow nodes
+	ID              string                          `json:"id"`              // Consignment ID
+	Flow            Flow                            `json:"flow"`            // e.g., IMPORT, EXPORT
+	State           State                           `json:"state"`           // State of the consignment
+	TraderID        string                          `json:"traderId"`        // Trader user who created the consignment
+	TraderCompanyID string                          `json:"traderCompanyId"` // Company the trader belongs to
+	ChaCompanyID    string                          `json:"chaCompanyId"`    // CHA company selected at Stage 1
+	ChaID           string                          `json:"chaId,omitempty"` // CHA assigned at Stage 2 (empty until claimed)
+	Items           []ItemResponseDTO               `json:"items"`           // Items in the consignment with full HS Code details
+	CreatedAt       string                          `json:"createdAt"`       // Timestamp of consignment creation
+	UpdatedAt       string                          `json:"updatedAt"`       // Timestamp of last consignment update
+	WorkflowNodes   []model.WorkflowNodeResponseDTO `json:"workflowNodes"`   // Associated workflow nodes with template details
+	Edges           []model.WorkflowEdgeResponseDTO `json:"edges"`           // Edges between workflow nodes
 }
 
 // SummaryDTO represents the consignment data returned in list responses.
 type SummaryDTO struct {
 	ID                         string            `json:"id"`                         // Consignment ID
 	Flow                       Flow              `json:"flow"`                       // e.g., IMPORT, EXPORT
-	TraderID                   string            `json:"traderId"`                   // ID of the trader associated with the consignment
-	ChaID                      string            `json:"chaId"`                      // Assigned CHA (Stage 1)
 	State                      State             `json:"state"`                      // State of the consignment
+	TraderID                   string            `json:"traderId"`                   // Trader user who created the consignment
+	TraderCompanyID            string            `json:"traderCompanyId"`            // Company the trader belongs to
+	ChaCompanyID               string            `json:"chaCompanyId"`               // CHA company selected at Stage 1
+	ChaID                      string            `json:"chaId,omitempty"`            // CHA assigned at Stage 2 (empty until claimed)
 	Items                      []ItemResponseDTO `json:"items"`                      // Items in the consignment with full HS Code details
 	CreatedAt                  string            `json:"createdAt"`                  // Timestamp of consignment creation
 	UpdatedAt                  string            `json:"updatedAt"`                  // Timestamp of last consignment update
@@ -134,14 +141,15 @@ type ListResult struct {
 }
 
 // Filter will be used when querying consignments as batch.
-// For GET /consignments?role=trader use TraderID; for role=cha use ChaID (e.g. from query param cha_id).
+// For GET /consignments?role=trader use TraderCompanyID; for role=cha use CHACompanyID.
+// Scoping is company-based so colleagues at the same company see each other's consignments.
 type Filter struct {
-	TraderID *string `json:"traderId,omitempty"`
-	ChaID    *string `json:"chaId,omitempty"`
-	Flow     *Flow   `json:"flow,omitempty"`
-	State    *State  `json:"state,omitempty"`
-	Offset   *int    `json:"offset,omitempty"`
-	Limit    *int    `json:"limit,omitempty"`
+	TraderCompanyID *string `json:"traderCompanyId,omitempty"`
+	CHACompanyID    *string `json:"chaCompanyId,omitempty"`
+	Flow            *Flow   `json:"flow,omitempty"`
+	State           *State  `json:"state,omitempty"`
+	Offset          *int    `json:"offset,omitempty"`
+	Limit           *int    `json:"limit,omitempty"`
 }
 
 // WorkflowTemplateMap represents the mapping between HSCode and Workflow.

--- a/backend/internal/consignment/model.go
+++ b/backend/internal/consignment/model.go
@@ -69,18 +69,13 @@ type InitializeConsignmentDTO struct {
 	HSCodeIDs []string `json:"hsCodeIds" binding:"required,min=1"`
 }
 
-// CreateConsignmentItemDTO represents the data required to create a consignment item.
-type CreateConsignmentItemDTO struct {
-	HSCodeID string `json:"hsCodeId" binding:"required"` // HS Code ID
-}
-
 // CreateConsignmentDTO represents the data required to create a consignment.
 // Stage 1 (two-stage flow): provide flow + chaCompanyId → creates shell with state INITIALIZED.
-// A specific CHA is assigned later, at Stage 2, when a CHA from chaCompanyId claims the consignment.
+// HS codes are not provided here; they are supplied at Stage 2 via InitializeConsignmentDTO
+// when a CHA from chaCompanyId claims the consignment.
 type CreateConsignmentDTO struct {
-	Flow         Flow                       `json:"flow"`
-	ChaCompanyID string                     `json:"chaCompanyId"`
-	Items        []CreateConsignmentItemDTO `json:"items,omitempty"`
+	Flow         Flow   `json:"flow"`
+	ChaCompanyID string `json:"chaCompanyId"`
 }
 
 func (d *CreateConsignmentDTO) Validate() error {

--- a/backend/internal/consignment/model_test.go
+++ b/backend/internal/consignment/model_test.go
@@ -15,21 +15,21 @@ func TestCreateConsignmentDTO_Validate(t *testing.T) {
 		{
 			name: "valid import",
 			dto: CreateConsignmentDTO{
-				Flow:  FlowImport,
-				ChaID: "cha1",
+				Flow:         FlowImport,
+				ChaCompanyID: "cha1",
 			},
 			wantErr: false,
 		},
 		{
 			name: "valid export",
 			dto: CreateConsignmentDTO{
-				Flow:  FlowExport,
-				ChaID: "cha2",
+				Flow:         FlowExport,
+				ChaCompanyID: "cha2",
 			},
 			wantErr: false,
 		},
 		{
-			name: "missing chaId",
+			name: "missing chaCompanyId",
 			dto: CreateConsignmentDTO{
 				Flow: FlowImport,
 			},
@@ -38,8 +38,8 @@ func TestCreateConsignmentDTO_Validate(t *testing.T) {
 		{
 			name: "invalid flow",
 			dto: CreateConsignmentDTO{
-				Flow:  "INVALID",
-				ChaID: "cha1",
+				Flow:         "INVALID",
+				ChaCompanyID: "cha1",
 			},
 			wantErr: true,
 		},

--- a/backend/internal/consignment/router.go
+++ b/backend/internal/consignment/router.go
@@ -8,16 +8,18 @@ import (
 
 	"github.com/OpenNSW/nsw/internal/auth"
 	"github.com/OpenNSW/nsw/internal/profile/cha"
+	"github.com/OpenNSW/nsw/internal/profile/company"
 	"github.com/OpenNSW/nsw/utils"
 )
 
 type Router struct {
-	cs  *Service
-	cha cha.Service
+	cs      *Service
+	cha     cha.Service
+	company company.Service
 }
 
-func NewRouter(cs *Service, chaService cha.Service) *Router {
-	return &Router{cs: cs, cha: chaService}
+func NewRouter(cs *Service, chaService cha.Service, companyService company.Service) *Router {
+	return &Router{cs: cs, cha: chaService, company: companyService}
 }
 
 // HandleCreateConsignment handles POST /api/v1/consignments
@@ -45,10 +47,14 @@ func (c *Router) HandleCreateConsignment(w http.ResponseWriter, r *http.Request)
 
 	traderID := authCtx.User.ID
 	// Stage 1: create shell only
-	consignment, err := c.cs.CreateConsignmentShell(r.Context(), req.Flow, req.ChaID, traderID)
+	consignment, err := c.cs.CreateConsignmentShell(r.Context(), req.Flow, req.ChaCompanyID, traderID)
 	if err != nil {
-		if errors.Is(err, cha.ErrCHANotFound) {
-			http.Error(w, "CHA not found", http.StatusNotFound)
+		if errors.Is(err, company.ErrCompanyNotFound) {
+			http.Error(w, "CHA company not found", http.StatusNotFound)
+			return
+		}
+		if errors.Is(err, ErrCompanyNotCHA) {
+			http.Error(w, "selected company is not a CHA company", http.StatusBadRequest)
 			return
 		}
 		slog.Error("failed to create consignment shell", "error", err)
@@ -101,25 +107,29 @@ func (c *Router) HandleGetConsignments(w http.ResponseWriter, r *http.Request) {
 		filter.Flow = &flow
 	}
 
-	// Role-Based Identity Resolution
-	switch role {
-	case "cha":
-		chaRecord, err := c.cha.GetByEmail(ctx, authCtx.User.Email)
-		if err != nil {
-			if errors.Is(err, cha.ErrCHANotFound) {
-				http.Error(w, "CHA profile not found", http.StatusForbidden)
-				return
-			}
-			slog.Error("failed to retrieve CHA profile", "email", authCtx.User.Email, "error", err)
-			http.Error(w, "failed to resolve default CHA profile", http.StatusInternalServerError)
-			return
-		}
-		filter.ChaID = &chaRecord.ID
-	case "trader":
-		filter.TraderID = &authCtx.User.ID
-	default:
+	// Role-based identity resolution. Both roles scope to the requesting user's company,
+	// resolved from the OU handle that the auth middleware copied off the JWT.
+	if role != "trader" && role != "cha" {
 		http.Error(w, "query param role must be trader or cha", http.StatusBadRequest)
 		return
+	}
+
+	userCompany, err := c.company.GetCompanyByOUHandle(ctx, authCtx.User.OUHandle)
+	if err != nil {
+		if errors.Is(err, company.ErrCompanyNotFound) {
+			http.Error(w, "company profile not found for user", http.StatusForbidden)
+			return
+		}
+		slog.Error("failed to resolve user company", "ouHandle", authCtx.User.OUHandle, "error", err)
+		http.Error(w, "failed to resolve user company", http.StatusInternalServerError)
+		return
+	}
+
+	switch role {
+	case "cha":
+		filter.CHACompanyID = &userCompany.ID
+	case "trader":
+		filter.TraderCompanyID = &userCompany.ID
 	}
 	consignments, err := c.cs.ListConsignments(ctx, filter)
 	if err != nil {
@@ -152,8 +162,6 @@ func (c *Router) HandleInitializeConsignment(w http.ResponseWriter, r *http.Requ
 		return
 	}
 	consignmentID := consignmentIDStr
-	// TODO: Need to Call GetConsignmentByID and check whether the Consignment.ChaID and authContext.UserID are equal
-	// Otherwise Forbidden
 	var req InitializeConsignmentDTO
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
 		http.Error(w, "invalid request body: "+err.Error(), http.StatusBadRequest)
@@ -165,10 +173,24 @@ func (c *Router) HandleInitializeConsignment(w http.ResponseWriter, r *http.Requ
 		return
 	}
 
-	// TODO: Global context is nil; services requiring user metadata should fetch it on-demand
-	// from the user profile service rather than relying on preloaded request context.
-	consignment, err := c.cs.InitializeConsignmentByID(r.Context(), consignmentID, req.HSCodeIDs, nil)
+	// Resolve the CHA picking up the consignment from the authenticated user's email.
+	chaRecord, err := c.cha.GetByEmail(ctx, authCtx.User.Email)
 	if err != nil {
+		if errors.Is(err, cha.ErrCHANotFound) {
+			http.Error(w, "CHA profile not found for user", http.StatusForbidden)
+			return
+		}
+		slog.Error("failed to resolve CHA profile", "email", authCtx.User.Email, "error", err)
+		http.Error(w, "failed to resolve CHA profile", http.StatusInternalServerError)
+		return
+	}
+
+	consignment, err := c.cs.InitializeConsignmentByID(r.Context(), consignmentID, req.HSCodeIDs, chaRecord.ID)
+	if err != nil {
+		if errors.Is(err, ErrCHACompanyMismatch) {
+			http.Error(w, "CHA does not belong to the consignment's CHA company", http.StatusForbidden)
+			return
+		}
 		slog.Error("failed to initialize consignment", "error", err)
 		http.Error(w, "failed to initialize consignment: "+err.Error(), http.StatusInternalServerError)
 		return

--- a/backend/internal/consignment/router_test.go
+++ b/backend/internal/consignment/router_test.go
@@ -19,6 +19,8 @@ import (
 
 	"github.com/OpenNSW/nsw/internal/auth"
 	"github.com/OpenNSW/nsw/internal/profile/cha"
+	"github.com/OpenNSW/nsw/internal/profile/company"
+	"github.com/OpenNSW/nsw/internal/profile/user"
 )
 
 func withAuthContext(ctx context.Context, userID string) context.Context {
@@ -31,12 +33,23 @@ func withAuthContext(ctx context.Context, userID string) context.Context {
 	return context.WithValue(ctx, auth.AuthContextKey, authCtx)
 }
 
+func withAuthContextOU(ctx context.Context, userID, ouHandle string) context.Context {
+	authCtx := &auth.AuthContext{
+		User: &auth.UserContext{
+			ID:       userID,
+			Email:    userID + "@example.com",
+			OUHandle: ouHandle,
+		},
+	}
+	return context.WithValue(ctx, auth.AuthContextKey, authCtx)
+}
+
 func TestConsignmentRouter_HandleGetConsignmentByID(t *testing.T) {
 	db, sqlMock := setupTestDB(t)
 	mockWM := new(MockWMV2)
-	svc := NewService(db, nil, nil, nil)
+	svc := NewService(db, nil, nil, nil, nil, nil)
 	require.NoError(t, svc.RegisterWorkflowManager(mockWM))
-	r := NewRouter(svc, nil)
+	r := NewRouter(svc, nil, nil)
 
 	consignmentID := uuid.NewString()
 	sqlMock.MatchExpectationsInOrder(false)
@@ -57,91 +70,114 @@ func TestConsignmentRouter_HandleGetConsignmentByID(t *testing.T) {
 
 func TestConsignmentRouter_HandleGetConsignments(t *testing.T) {
 	db, sqlMock := setupTestDB(t)
-	svc := NewService(db, nil, nil, nil)
-	r := NewRouter(svc, nil)
+	mockCompany := new(MockCompanyService)
+	svc := NewService(db, nil, nil, mockCompany, nil, nil)
+	r := NewRouter(svc, nil, mockCompany)
 
 	traderID := "trader1"
+	companyID := "company-trader"
+	mockCompany.On("GetCompanyByOUHandle", mock.Anything, "trader-ou").Return(&company.Record{ID: companyID, OUHandle: "trader-ou"}, nil)
+
 	sqlMock.MatchExpectationsInOrder(false)
 	sqlMock.ExpectQuery("(?i)SELECT count").WillReturnRows(sqlmock.NewRows([]string{"count"}).AddRow(1))
-	sqlMock.ExpectQuery("(?i)SELECT .* FROM \"consignments\"").WillReturnRows(sqlmock.NewRows([]string{"id", "trader_id"}).AddRow(uuid.NewString(), traderID))
+	sqlMock.ExpectQuery("(?i)SELECT .* FROM \"consignments\"").WillReturnRows(sqlmock.NewRows([]string{"id", "trader_id", "trader_company_id"}).AddRow(uuid.NewString(), traderID, companyID))
 	sqlMock.ExpectQuery("(?i)SELECT .* FROM \"workflow_nodes\"").WillReturnRows(sqlmock.NewRows([]string{"workflow_id", "total", "completed"}).AddRow(uuid.NewString(), 1, 0))
 	sqlMock.ExpectQuery("(?i)SELECT .* FROM \"workflows\"").WillReturnRows(sqlmock.NewRows([]string{"id", "end_node_id"}))
 
 	req, _ := http.NewRequest("GET", "/api/v1/consignments?role=trader&state=IN_PROGRESS&flow=IMPORT", nil)
-	req = req.WithContext(withAuthContext(req.Context(), traderID))
+	req = req.WithContext(withAuthContextOU(req.Context(), traderID, "trader-ou"))
 	w := httptest.NewRecorder()
 	r.HandleGetConsignments(w, req)
 	assert.Equal(t, http.StatusOK, w.Code)
+	mockCompany.AssertExpectations(t)
 }
 
 func TestConsignmentRouter_HandleGetConsignments_RoleCHA(t *testing.T) {
 	db, sqlMock := setupTestDB(t)
-	mockCHA := new(MockCHAService)
-	svc := NewService(db, nil, mockCHA, nil)
-	r := NewRouter(svc, mockCHA)
+	mockCompany := new(MockCompanyService)
+	svc := NewService(db, nil, nil, mockCompany, nil, nil)
+	r := NewRouter(svc, nil, mockCompany)
 
-	email := "cha@example.com"
-	chaID := "cha1"
-	mockCHA.On("GetByEmail", mock.Anything, email).Return(&cha.Record{ID: chaID}, nil)
+	companyID := "company-cha"
+	mockCompany.On("GetCompanyByOUHandle", mock.Anything, "cha-ou").Return(&company.Record{ID: companyID, OUHandle: "cha-ou", HasCHA: true}, nil)
 
 	sqlMock.ExpectQuery("(?i)SELECT count").WillReturnRows(sqlmock.NewRows([]string{"count"}).AddRow(0))
 
 	req, _ := http.NewRequest("GET", "/api/v1/consignments?role=cha", nil)
-	req = req.WithContext(withAuthContext(req.Context(), "cha"))
+	req = req.WithContext(withAuthContextOU(req.Context(), "cha", "cha-ou"))
 	w := httptest.NewRecorder()
 	r.HandleGetConsignments(w, req)
 	assert.Equal(t, http.StatusOK, w.Code)
+	mockCompany.AssertExpectations(t)
 }
 
 func TestConsignmentRouter_HandleCreateConsignment(t *testing.T) {
 	db, sqlMock := setupTestDB(t)
-	svc := NewService(db, nil, cha.NewService(db), nil)
-	r := NewRouter(svc, nil)
+	mockCompany := new(MockCompanyService)
+	mockUser := new(MockUserService)
+	svc := NewService(db, nil, nil, mockCompany, mockUser, nil)
+	r := NewRouter(svc, nil, mockCompany)
 
 	traderID := "trader1"
-	chaID := uuid.NewString()
+	chaCompanyID := "cha-company"
+	traderCompanyID := "trader-company"
 	consignmentID := uuid.NewString()
 
+	mockCompany.On("GetCompanyByID", mock.Anything, chaCompanyID).Return(&company.Record{ID: chaCompanyID, HasCHA: true}, nil)
+	mockUser.On("GetUser", traderID).Return(&user.Record{ID: traderID, OUHandle: "trader-ou"}, nil)
+	mockCompany.On("GetCompanyByOUHandle", mock.Anything, "trader-ou").Return(&company.Record{ID: traderCompanyID}, nil)
+
 	payload := CreateConsignmentDTO{
-		Flow:  FlowImport,
-		ChaID: chaID,
+		Flow:         FlowImport,
+		ChaCompanyID: chaCompanyID,
 	}
 	body, _ := json.Marshal(payload)
 
 	sqlMock.MatchExpectationsInOrder(false)
-	sqlMock.ExpectQuery("(?i)SELECT .* FROM \"customs_house_agents\"").WillReturnRows(sqlmock.NewRows([]string{"id", "name", "description", "email"}).AddRow(chaID, "Test CHA", "", "cha@example.com"))
 	sqlMock.ExpectBegin()
 	sqlMock.ExpectExec("(?i)INSERT INTO \"consignments\"").
-		WithArgs(sqlmock.AnyArg(), sqlmock.AnyArg(), sqlmock.AnyArg(), string(FlowImport), traderID, string(Initialized), sqlmock.AnyArg(), chaID).
 		WillReturnResult(sqlmock.NewResult(1, 1))
 	sqlMock.ExpectCommit()
 
 	sqlMock.ExpectQuery("(?i)SELECT .* FROM \"consignments\"").WillReturnRows(
-		sqlmock.NewRows([]string{"id", "flow", "trader_id", "cha_id", "state", "items"}).
-			AddRow(consignmentID, string(FlowImport), traderID, chaID, string(Initialized), []byte("[]")),
+		sqlmock.NewRows([]string{"id", "flow", "trader_id", "trader_company_id", "cha_company_id", "state", "items"}).
+			AddRow(consignmentID, string(FlowImport), traderID, traderCompanyID, chaCompanyID, string(Initialized), []byte("[]")),
 	)
 
 	req, _ := http.NewRequest("POST", "/api/v1/consignments", bytes.NewBuffer(body))
-	req = req.WithContext(withAuthContext(req.Context(), traderID))
+	req = req.WithContext(withAuthContextOU(req.Context(), traderID, "trader-ou"))
 	w := httptest.NewRecorder()
 	r.HandleCreateConsignment(w, req)
 	assert.Equal(t, http.StatusCreated, w.Code)
+	mockCompany.AssertExpectations(t)
+	mockUser.AssertExpectations(t)
 }
 
 func TestConsignmentRouter_HandleInitializeConsignment(t *testing.T) {
 	db, sqlMock := setupTestDB(t)
 	mockWM := new(MockWMV2)
-	svc := NewService(db, nil, nil, nil)
+	mockCHA := new(MockCHAService)
+	mockCompany := new(MockCompanyService)
+	svc := NewService(db, nil, mockCHA, mockCompany, nil, nil)
 	require.NoError(t, svc.RegisterWorkflowManager(mockWM))
-	r := NewRouter(svc, nil)
+	r := NewRouter(svc, mockCHA, mockCompany)
 
 	id := uuid.NewString()
 	hsID := uuid.NewString()
 	wtID := uuid.NewString()
+	chaID := "cha-1"
+	chaCompanyID := "cha-company"
+	traderCompanyID := "trader-company"
+	chaEmail := "cha1@example.com"
+
+	mockCHA.On("GetByEmail", mock.Anything, chaEmail).Return(&cha.Record{ID: chaID, CompanyID: chaCompanyID}, nil)
+	mockCHA.On("GetByID", mock.Anything, chaID).Return(&cha.Record{ID: chaID, CompanyID: chaCompanyID}, nil)
+	mockCompany.On("GetCompanyByID", mock.Anything, traderCompanyID).Return(&company.Record{ID: traderCompanyID, OUHandle: "trader-ou", Data: []byte(`{}`)}, nil)
+
 	payload := InitializeConsignmentDTO{HSCodeIDs: []string{hsID}}
 	body, _ := json.Marshal(payload)
 
-	sqlMock.ExpectQuery("(?i)SELECT .* FROM \"consignments\"").WillReturnRows(sqlmock.NewRows([]string{"id", "state", "flow"}).AddRow(id, "INITIALIZED", "IMPORT"))
+	sqlMock.ExpectQuery("(?i)SELECT .* FROM \"consignments\"").WillReturnRows(sqlmock.NewRows([]string{"id", "state", "flow", "cha_company_id", "trader_company_id"}).AddRow(id, "INITIALIZED", "IMPORT", chaCompanyID, traderCompanyID))
 	sqlMock.ExpectBegin()
 	sqlMock.ExpectExec("(?i)UPDATE \"consignments\"").WillReturnResult(sqlmock.NewResult(1, 1))
 
@@ -165,11 +201,13 @@ func TestConsignmentRouter_HandleInitializeConsignment(t *testing.T) {
 	w := httptest.NewRecorder()
 	r.HandleInitializeConsignment(w, req)
 	assert.Equal(t, http.StatusOK, w.Code)
+	mockCHA.AssertExpectations(t)
+	mockCompany.AssertExpectations(t)
 }
 
 func TestConsignmentRouter_HandleInitializeConsignment_NoID(t *testing.T) {
-	svc := NewService(nil, nil, nil, nil)
-	r := NewRouter(svc, nil)
+	svc := NewService(nil, nil, nil, nil, nil, nil)
+	r := NewRouter(svc, nil, nil)
 
 	req, _ := http.NewRequest("PUT", "/api/v1/consignments/", bytes.NewReader([]byte{}))
 	req = req.WithContext(withAuthContext(req.Context(), "user1"))
@@ -180,8 +218,8 @@ func TestConsignmentRouter_HandleInitializeConsignment_NoID(t *testing.T) {
 }
 
 func TestConsignmentRouter_HandleInitializeConsignment_InvalidBody(t *testing.T) {
-	svc := NewService(nil, nil, nil, nil)
-	r := NewRouter(svc, nil)
+	svc := NewService(nil, nil, nil, nil, nil, nil)
+	r := NewRouter(svc, nil, nil)
 
 	req, _ := http.NewRequest("PUT", "/api/v1/consignments/id", bytes.NewBufferString("invalid json"))
 	req.SetPathValue("id", "id")
@@ -194,8 +232,8 @@ func TestConsignmentRouter_HandleInitializeConsignment_InvalidBody(t *testing.T)
 
 func TestConsignmentRouter_HandleGetConsignmentByID_InvalidID(t *testing.T) {
 	db, _ := setupTestDB(t)
-	svc := NewService(db, nil, nil, nil)
-	r := NewRouter(svc, nil)
+	svc := NewService(db, nil, nil, nil, nil, nil)
+	r := NewRouter(svc, nil, nil)
 
 	req, _ := http.NewRequest("GET", "/api/v1/consignments/invalid-uuid", nil)
 	req.SetPathValue("id", "invalid-uuid")
@@ -207,8 +245,8 @@ func TestConsignmentRouter_HandleGetConsignmentByID_InvalidID(t *testing.T) {
 
 func TestConsignmentRouter_HandleGetConsignments_PaginationError(t *testing.T) {
 	db, _ := setupTestDB(t)
-	svc := NewService(db, nil, nil, nil)
-	r := NewRouter(svc, nil)
+	svc := NewService(db, nil, nil, nil, nil, nil)
+	r := NewRouter(svc, nil, nil)
 
 	req, _ := http.NewRequest("GET", "/api/v1/consignments?limit=invalid", nil)
 	req = req.WithContext(withAuthContext(req.Context(), "trader1"))
@@ -221,8 +259,8 @@ func TestConsignmentRouter_HandleGetConsignments_PaginationError(t *testing.T) {
 
 func TestConsignmentRouter_HandleGetConsignmentByID_ServiceError(t *testing.T) {
 	db, sqlMock := setupTestDB(t)
-	svc := NewService(db, nil, nil, nil)
-	r := NewRouter(svc, nil)
+	svc := NewService(db, nil, nil, nil, nil, nil)
+	r := NewRouter(svc, nil, nil)
 
 	id := uuid.NewString()
 	sqlMock.ExpectQuery("(?i)SELECT .* FROM \"consignments\"").WillReturnError(fmt.Errorf("db error"))
@@ -238,41 +276,42 @@ func TestConsignmentRouter_HandleGetConsignmentByID_ServiceError(t *testing.T) {
 
 func TestConsignmentRouter_HandleGetConsignments_ServiceError(t *testing.T) {
 	db, sqlMock := setupTestDB(t)
-	svc := NewService(db, nil, nil, nil)
-	r := NewRouter(svc, nil)
+	mockCompany := new(MockCompanyService)
+	svc := NewService(db, nil, nil, mockCompany, nil, nil)
+	r := NewRouter(svc, nil, mockCompany)
 
+	mockCompany.On("GetCompanyByOUHandle", mock.Anything, "trader-ou").Return(&company.Record{ID: "trader-company", OUHandle: "trader-ou"}, nil)
 	sqlMock.ExpectQuery("(?i)SELECT count").WillReturnError(fmt.Errorf("db error"))
 
 	req, _ := http.NewRequest("GET", "/api/v1/consignments", nil)
-	req = req.WithContext(withAuthContext(req.Context(), "trader1"))
+	req = req.WithContext(withAuthContextOU(req.Context(), "trader1", "trader-ou"))
 	w := httptest.NewRecorder()
 	r.HandleGetConsignments(w, req)
 	assert.Equal(t, http.StatusInternalServerError, w.Code)
 }
 
-func TestConsignmentRouter_HandleCreateConsignment_CHANotFound(t *testing.T) {
-	db, sqlMock := setupTestDB(t)
-	svc := NewService(db, nil, cha.NewService(db), nil)
-	r := NewRouter(svc, nil)
+func TestConsignmentRouter_HandleCreateConsignment_CompanyNotFound(t *testing.T) {
+	mockCompany := new(MockCompanyService)
+	svc := NewService(nil, nil, nil, mockCompany, nil, nil)
+	r := NewRouter(svc, nil, mockCompany)
 
-	chaID := uuid.NewString()
-	payload := CreateConsignmentDTO{Flow: FlowImport, ChaID: chaID}
+	mockCompany.On("GetCompanyByID", mock.Anything, "company-missing").Return(nil, company.ErrCompanyNotFound)
+
+	payload := CreateConsignmentDTO{Flow: FlowImport, ChaCompanyID: "company-missing"}
 	body, _ := json.Marshal(payload)
 
-	sqlMock.ExpectQuery("(?i)SELECT .* FROM \"customs_house_agents\"").
-		WillReturnRows(sqlmock.NewRows([]string{"id", "name"}))
-
 	req, _ := http.NewRequest("POST", "/api/v1/consignments", bytes.NewBuffer(body))
-	req = req.WithContext(withAuthContext(req.Context(), "trader1"))
+	req = req.WithContext(withAuthContextOU(req.Context(), "trader1", "trader-ou"))
 	w := httptest.NewRecorder()
 	r.HandleCreateConsignment(w, req)
 	assert.Equal(t, http.StatusNotFound, w.Code)
+	mockCompany.AssertExpectations(t)
 }
 
 func TestConsignmentRouter_HandleCreateConsignment_InvalidPayload(t *testing.T) {
 	db, _ := setupTestDB(t)
-	svc := NewService(db, nil, nil, nil)
-	r := NewRouter(svc, nil)
+	svc := NewService(db, nil, nil, nil, nil, nil)
+	r := NewRouter(svc, nil, nil)
 
 	req, _ := http.NewRequest("POST", "/api/v1/consignments", bytes.NewBufferString("invalid json"))
 	req = req.WithContext(withAuthContext(req.Context(), "trader1"))
@@ -282,8 +321,8 @@ func TestConsignmentRouter_HandleCreateConsignment_InvalidPayload(t *testing.T) 
 }
 
 func TestConsignmentRouter_HandleGetConsignments_InvalidRole(t *testing.T) {
-	svc := NewService(nil, nil, nil, nil)
-	r := NewRouter(svc, nil)
+	svc := NewService(nil, nil, nil, nil, nil, nil)
+	r := NewRouter(svc, nil, nil)
 
 	req, _ := http.NewRequest("GET", "/api/v1/consignments?role=invalid", nil)
 	req = req.WithContext(withAuthContext(req.Context(), "user1"))
@@ -293,15 +332,15 @@ func TestConsignmentRouter_HandleGetConsignments_InvalidRole(t *testing.T) {
 	assert.Equal(t, http.StatusBadRequest, w.Code)
 }
 
-func TestConsignmentRouter_HandleGetConsignments_CHANotFound(t *testing.T) {
-	mockCHA := new(MockCHAService)
-	svc := NewService(nil, nil, mockCHA, nil)
-	r := NewRouter(svc, mockCHA)
+func TestConsignmentRouter_HandleGetConsignments_CompanyNotFound(t *testing.T) {
+	mockCompany := new(MockCompanyService)
+	svc := NewService(nil, nil, nil, mockCompany, nil, nil)
+	r := NewRouter(svc, nil, mockCompany)
 
-	mockCHA.On("GetByEmail", mock.Anything, "cha@example.com").Return(nil, cha.ErrCHANotFound)
+	mockCompany.On("GetCompanyByOUHandle", mock.Anything, "cha-ou").Return(nil, company.ErrCompanyNotFound)
 
 	req, _ := http.NewRequest("GET", "/api/v1/consignments?role=cha", nil)
-	req = req.WithContext(withAuthContext(req.Context(), "cha"))
+	req = req.WithContext(withAuthContextOU(req.Context(), "cha", "cha-ou"))
 
 	w := httptest.NewRecorder()
 	r.HandleGetConsignments(w, req)
@@ -309,7 +348,7 @@ func TestConsignmentRouter_HandleGetConsignments_CHANotFound(t *testing.T) {
 }
 
 func TestConsignmentRouter_HandleGetConsignments_Unauthorized(t *testing.T) {
-	r := NewRouter(nil, nil)
+	r := NewRouter(nil, nil, nil)
 	req, _ := http.NewRequest("GET", "/api/v1/consignments", nil)
 	w := httptest.NewRecorder()
 	r.HandleGetConsignments(w, req)
@@ -317,7 +356,7 @@ func TestConsignmentRouter_HandleGetConsignments_Unauthorized(t *testing.T) {
 }
 
 func TestConsignmentRouter_HandleCreateConsignment_Unauthorized(t *testing.T) {
-	r := NewRouter(nil, nil)
+	r := NewRouter(nil, nil, nil)
 	req, _ := http.NewRequest("POST", "/api/v1/consignments", bytes.NewBufferString("{}"))
 	w := httptest.NewRecorder()
 	r.HandleCreateConsignment(w, req)
@@ -325,7 +364,7 @@ func TestConsignmentRouter_HandleCreateConsignment_Unauthorized(t *testing.T) {
 }
 
 func TestConsignmentRouter_HandleGetConsignmentByID_Unauthorized(t *testing.T) {
-	r := NewRouter(nil, nil)
+	r := NewRouter(nil, nil, nil)
 	req, _ := http.NewRequest("GET", "/api/v1/consignments/id", nil)
 	w := httptest.NewRecorder()
 	r.HandleGetConsignmentByID(w, req)
@@ -333,7 +372,7 @@ func TestConsignmentRouter_HandleGetConsignmentByID_Unauthorized(t *testing.T) {
 }
 
 func TestConsignmentRouter_HandleGetConsignmentByID_MissingID(t *testing.T) {
-	r := NewRouter(nil, nil)
+	r := NewRouter(nil, nil, nil)
 	req, _ := http.NewRequest("GET", "/api/v1/consignments/", nil)
 	req = req.WithContext(withAuthContext(req.Context(), "trader1"))
 	w := httptest.NewRecorder()
@@ -342,7 +381,7 @@ func TestConsignmentRouter_HandleGetConsignmentByID_MissingID(t *testing.T) {
 }
 
 func TestConsignmentRouter_HandleInitializeConsignment_Unauthorized(t *testing.T) {
-	r := NewRouter(nil, nil)
+	r := NewRouter(nil, nil, nil)
 	req, _ := http.NewRequest("PUT", "/api/v1/consignments/id", bytes.NewBufferString("{}"))
 	w := httptest.NewRecorder()
 	r.HandleInitializeConsignment(w, req)
@@ -350,7 +389,7 @@ func TestConsignmentRouter_HandleInitializeConsignment_Unauthorized(t *testing.T
 }
 
 func TestConsignmentRouter_HandleInitializeConsignment_EmptyHSCodes(t *testing.T) {
-	r := NewRouter(nil, nil)
+	r := NewRouter(nil, nil, nil)
 	body, _ := json.Marshal(InitializeConsignmentDTO{HSCodeIDs: []string{}})
 	req, _ := http.NewRequest("PUT", "/api/v1/consignments/id", bytes.NewBuffer(body))
 	req.SetPathValue("id", "id")
@@ -360,14 +399,14 @@ func TestConsignmentRouter_HandleInitializeConsignment_EmptyHSCodes(t *testing.T
 	assert.Equal(t, http.StatusBadRequest, w.Code)
 }
 
-func TestConsignmentRouter_HandleGetConsignments_CHALookupError(t *testing.T) {
-	mockCHA := new(MockCHAService)
-	svc := NewService(nil, nil, mockCHA, nil)
-	r := NewRouter(svc, mockCHA)
-	mockCHA.On("GetByEmail", mock.Anything, "cha@example.com").Return(nil, fmt.Errorf("db down"))
+func TestConsignmentRouter_HandleGetConsignments_CompanyLookupError(t *testing.T) {
+	mockCompany := new(MockCompanyService)
+	svc := NewService(nil, nil, nil, mockCompany, nil, nil)
+	r := NewRouter(svc, nil, mockCompany)
+	mockCompany.On("GetCompanyByOUHandle", mock.Anything, "cha-ou").Return(nil, fmt.Errorf("db down"))
 
 	req, _ := http.NewRequest("GET", "/api/v1/consignments?role=cha", nil)
-	req = req.WithContext(withAuthContext(req.Context(), "cha"))
+	req = req.WithContext(withAuthContextOU(req.Context(), "cha", "cha-ou"))
 	w := httptest.NewRecorder()
 	r.HandleGetConsignments(w, req)
 	assert.Equal(t, http.StatusInternalServerError, w.Code)

--- a/backend/internal/consignment/service.go
+++ b/backend/internal/consignment/service.go
@@ -2,6 +2,7 @@ package consignment
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"log/slog"
@@ -14,6 +15,8 @@ import (
 
 	"github.com/OpenNSW/nsw/internal/hscode"
 	"github.com/OpenNSW/nsw/internal/profile/cha"
+	"github.com/OpenNSW/nsw/internal/profile/company"
+	"github.com/OpenNSW/nsw/internal/profile/user"
 	"github.com/OpenNSW/nsw/internal/workflow/model"
 	"github.com/OpenNSW/nsw/internal/workflow/service"
 	"github.com/OpenNSW/nsw/utils"
@@ -27,6 +30,8 @@ type Service struct {
 	templateProvider service.TemplateProvider
 	wm               workflowmanager.Manager
 	chaService       cha.Service
+	companyService   company.Service
+	userService      user.Service
 	hsCodeService    *hscode.Service
 }
 
@@ -35,12 +40,16 @@ func NewService(
 	db *gorm.DB,
 	templateProvider service.TemplateProvider,
 	chaService cha.Service,
+	companyService company.Service,
+	userService user.Service,
 	hsCodeService *hscode.Service,
 ) *Service {
 	return &Service{
 		db:               db,
 		templateProvider: templateProvider,
 		chaService:       chaService,
+		companyService:   companyService,
+		userService:      userService,
 		hsCodeService:    hsCodeService,
 	}
 }
@@ -74,19 +83,36 @@ func (s *Service) OnWorkflowStatusChanged(_ context.Context, tx *gorm.DB, workfl
 	}
 }
 
-// CreateConsignmentShell creates a shell consignment (Stage 1: Trader selects CHA). State is INITIALIZED; no workflow nodes.
-func (s *Service) CreateConsignmentShell(ctx context.Context, flow Flow, chaID string, traderID string) (*DetailDTO, error) {
-	// Validate CHA exists
-	if _, err := s.chaService.GetByID(ctx, chaID); err != nil {
-		return nil, fmt.Errorf("CHA not found: %w", err)
+// CreateConsignmentShell creates a shell consignment (Stage 1: Trader selects a CHA company).
+// The trader's company is resolved from the trader user's OU handle. The specific CHA is not
+// assigned yet — that happens at Stage 2 (InitializeConsignmentByID).
+func (s *Service) CreateConsignmentShell(ctx context.Context, flow Flow, chaCompanyID string, traderID string) (*DetailDTO, error) {
+	chaCompany, err := s.companyService.GetCompanyByID(ctx, chaCompanyID)
+	if err != nil {
+		return nil, fmt.Errorf("CHA company lookup failed: %w", err)
 	}
+	if !chaCompany.HasCHA {
+		return nil, ErrCompanyNotCHA
+	}
+
+	traderUser, err := s.userService.GetUser(traderID)
+	if err != nil {
+		return nil, fmt.Errorf("trader user lookup failed: %w", err)
+	}
+
+	traderCompany, err := s.companyService.GetCompanyByOUHandle(ctx, traderUser.OUHandle)
+	if err != nil {
+		return nil, fmt.Errorf("trader company lookup failed: %w", err)
+	}
+
 	consignment := &Consignment{
-		ID:       uuid.NewString(),
-		Flow:     flow,
-		TraderID: traderID,
-		CHAID:    chaID,
-		State:    Initialized,
-		Items:    []Item{},
+		ID:              uuid.NewString(),
+		Flow:            flow,
+		TraderID:        traderID,
+		TraderCompanyID: traderCompany.ID,
+		CHACompanyID:    chaCompany.ID,
+		State:           Initialized,
+		Items:           []Item{},
 	}
 	if err := s.db.WithContext(ctx).Create(consignment).Error; err != nil {
 		return nil, fmt.Errorf("failed to create consignment: %w", err)
@@ -102,13 +128,14 @@ func (s *Service) CreateConsignmentShell(ctx context.Context, flow Flow, chaID s
 	return responseDTO, nil
 }
 
-// InitializeConsignmentByID runs Stage 2: CHA selects one or more HS Codes; creates workflow and sets state to IN_PROGRESS.
-// Returns error if consignment is not in INITIALIZED.
+// InitializeConsignmentByID runs Stage 2: a CHA from the consignment's CHA company picks the
+// consignment up, the HS codes are selected, and the workflow is started with the trader
+// company data as initial variables.
 func (s *Service) InitializeConsignmentByID(
 	ctx context.Context,
 	consignmentID string,
 	hsCodeIDs []string,
-	globalContext map[string]any,
+	chaID string,
 ) (*DetailDTO, error) {
 
 	if len(hsCodeIDs) == 0 {
@@ -123,6 +150,30 @@ func (s *Service) InitializeConsignmentByID(
 	if consignment.State != Initialized {
 		return nil, fmt.Errorf("consignment must be in INITIALIZED (current state: %s)", consignment.State)
 	}
+
+	// TODO: add support for collapsing multiple HS codes to one workflow.
+	// Currently, assumes that there is only one HS code selected.
+	if len(hsCodeIDs) > 1 {
+		return nil, fmt.Errorf("workflow manager currently supports only one HS code")
+	}
+
+	chaRecord, err := s.chaService.GetByID(ctx, chaID)
+	if err != nil {
+		return nil, fmt.Errorf("CHA lookup failed: %w", err)
+	}
+	if chaRecord.CompanyID != consignment.CHACompanyID {
+		return nil, ErrCHACompanyMismatch
+	}
+
+	traderCompany, err := s.companyService.GetCompanyByID(ctx, consignment.TraderCompanyID)
+	if err != nil {
+		return nil, fmt.Errorf("trader company lookup failed: %w", err)
+	}
+	traderCompanyVars, err := companyRecordToMap(traderCompany)
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal trader company: %w", err)
+	}
+	initialVars := map[string]any{"traderCompany": traderCompanyVars}
 
 	// Prepare items
 	items := make([]Item, 0, len(hsCodeIDs))
@@ -139,21 +190,15 @@ func (s *Service) InitializeConsignmentByID(
 
 	consignment.Items = items
 	consignment.State = InProgress
+	consignment.CHAID = &chaID
 
 	if err := tx.Save(&consignment).Error; err != nil {
 		tx.Rollback()
 		return nil, fmt.Errorf("failed to update consignment: %w", err)
 	}
 
-	// TODO: add support for collapsing multiple HS codes to one workflow.
-	// Currently, assumes that there is only one HS code selected.
-	if len(hsCodeIDs) > 1 {
-		tx.Rollback()
-		return nil, fmt.Errorf("workflow manager currently supports only one HS code")
-	}
-
 	var mapping WorkflowTemplateMap
-	err := tx.Model(&WorkflowTemplateMap{}).
+	err = tx.Model(&WorkflowTemplateMap{}).
 		Preload("WorkflowTemplate").
 		Where("hs_code_id = ? AND consignment_flow = ?", hsCodeIDs[0], consignment.Flow).
 		First(&mapping).Error
@@ -168,7 +213,7 @@ func (s *Service) InitializeConsignmentByID(
 
 	wt := &mapping.WorkflowTemplate
 
-	if err := s.wm.StartWorkflow(ctx, consignment.ID, wt.WorkflowDefinition, globalContext); err != nil {
+	if err := s.wm.StartWorkflow(ctx, consignment.ID, wt.WorkflowDefinition, initialVars); err != nil {
 		tx.Rollback()
 		return nil, fmt.Errorf("failed to register workflow: %w", err)
 	}
@@ -234,25 +279,20 @@ func (s *Service) GetConsignmentByID(ctx context.Context, consignmentID string) 
 	return responseDTO, nil
 }
 
-// ListConsignments returns consignments filtered by trader (role=trader) or by CHA (role=cha). Exactly one of filter.TraderID or filter.ChaID must be set.
+// ListConsignments returns consignments scoped to a company. For role=trader the caller passes
+// TraderCompanyID; for role=cha the caller passes CHACompanyID. Exactly one of the two must be set.
+// Scoping is company-based so a user sees all consignments belonging to their company, not only the
+// ones they personally created or were individually assigned.
 func (s *Service) ListConsignments(ctx context.Context, filter Filter) (*ListResult, error) {
 	var baseQuery *gorm.DB
-	if filter.ChaID != nil {
-		baseQuery = s.db.WithContext(ctx).Model(&Consignment{}).Where("cha_id = ?", *filter.ChaID)
-	} else if filter.TraderID != nil {
-		baseQuery = s.db.WithContext(ctx).Model(&Consignment{}).Where("trader_id = ?", *filter.TraderID)
+	if filter.CHACompanyID != nil {
+		baseQuery = s.db.WithContext(ctx).Model(&Consignment{}).Where("cha_company_id = ?", *filter.CHACompanyID)
+	} else if filter.TraderCompanyID != nil {
+		baseQuery = s.db.WithContext(ctx).Model(&Consignment{}).Where("trader_company_id = ?", *filter.TraderCompanyID)
 	} else {
-		return nil, fmt.Errorf("either TraderID or ChaID must be set in filter")
+		return nil, fmt.Errorf("either TraderCompanyID or CHACompanyID must be set in filter")
 	}
 	return s.listConsignmentsWithBaseQuery(ctx, baseQuery, filter)
-}
-
-// GetConsignmentsByTraderID retrieves consignments associated with a specific trader ID with optional filtering.
-func (s *Service) GetConsignmentsByTraderID(ctx context.Context, traderID string, offset *int, limit *int, filter Filter) (*ListResult, error) {
-	filter.TraderID = &traderID
-	filter.Offset = offset
-	filter.Limit = limit
-	return s.ListConsignments(ctx, filter)
 }
 
 // listConsignmentsWithBaseQuery runs the shared list logic (filters, count, pagination, DTOs).
@@ -376,12 +416,19 @@ func (s *Service) listConsignmentsWithBaseQuery(ctx context.Context, baseQuery *
 			return nil, fmt.Errorf("failed to load HS code for item in consignment %s: %w", c.ID, err)
 		}
 
+		chaID := ""
+		if c.CHAID != nil {
+			chaID = *c.CHAID
+		}
+
 		consignmentDTOs = append(consignmentDTOs, SummaryDTO{
 			ID:                         c.ID,
 			Flow:                       c.Flow,
-			TraderID:                   c.TraderID,
-			ChaID:                      c.CHAID,
 			State:                      c.State,
+			TraderID:                   c.TraderID,
+			TraderCompanyID:            c.TraderCompanyID,
+			ChaCompanyID:               c.CHACompanyID,
+			ChaID:                      chaID,
 			Items:                      itemResponseDTOs,
 			CreatedAt:                  c.CreatedAt.Format(time.RFC3339),
 			UpdatedAt:                  c.UpdatedAt.Format(time.RFC3339),
@@ -517,18 +564,39 @@ func (s *Service) buildConsignmentDetailDTO(
 		}
 	}
 
+	chaID := ""
+	if consignment.CHAID != nil {
+		chaID = *consignment.CHAID
+	}
+
 	return &DetailDTO{
-		ID:            consignment.ID,
-		Flow:          consignment.Flow,
-		TraderID:      consignment.TraderID,
-		ChaID:         consignment.CHAID,
-		State:         consignment.State,
-		Items:         itemResponseDTOs,
-		CreatedAt:     consignment.CreatedAt.Format(time.RFC3339),
-		UpdatedAt:     consignment.UpdatedAt.Format(time.RFC3339),
-		WorkflowNodes: nodeResponseDTOs,
-		Edges:         edgeResponseDTOs,
+		ID:              consignment.ID,
+		Flow:            consignment.Flow,
+		State:           consignment.State,
+		TraderID:        consignment.TraderID,
+		TraderCompanyID: consignment.TraderCompanyID,
+		ChaCompanyID:    consignment.CHACompanyID,
+		ChaID:           chaID,
+		Items:           itemResponseDTOs,
+		CreatedAt:       consignment.CreatedAt.Format(time.RFC3339),
+		UpdatedAt:       consignment.UpdatedAt.Format(time.RFC3339),
+		WorkflowNodes:   nodeResponseDTOs,
+		Edges:           edgeResponseDTOs,
 	}, nil
+}
+
+// companyRecordToMap converts a company.Record to a map[string]any via the JSON tags.
+// The result is suitable for passing as initial workflow variables to the workflow manager.
+func companyRecordToMap(record *company.Record) (map[string]any, error) {
+	raw, err := json.Marshal(record)
+	if err != nil {
+		return nil, err
+	}
+	out := make(map[string]any)
+	if err := json.Unmarshal(raw, &out); err != nil {
+		return nil, err
+	}
+	return out, nil
 }
 
 // buildConsignmentItemResponseDTOs builds a slice of ItemResponseDTO from ConsignmentItems.

--- a/backend/internal/consignment/service.go
+++ b/backend/internal/consignment/service.go
@@ -585,8 +585,12 @@ func (s *Service) buildConsignmentDetailDTO(
 	}, nil
 }
 
-// companyRecordToMap converts a company.Record to a map[string]any via the JSON tags.
-// The result is suitable for passing as initial workflow variables to the workflow manager.
+// companyRecordToMap converts a company.Record to a map[string]any via its JSON tags. The
+// marshal/unmarshal round-trip is deliberate: it ties the workflow-variable shape to the same
+// JSON contract used elsewhere (REST responses), so a new field on Record with a json tag flows
+// through automatically. The reflection cost is negligible here — this runs once per Stage 2
+// init, never in a hot path — and the alternative (explicit field map) silently drops new
+// fields until someone notices in a workflow step.
 func companyRecordToMap(record *company.Record) (map[string]any, error) {
 	raw, err := json.Marshal(record)
 	if err != nil {

--- a/backend/internal/consignment/service_test.go
+++ b/backend/internal/consignment/service_test.go
@@ -16,6 +16,8 @@ import (
 	workflowManagerV2 "github.com/OpenNSW/go-temporal-workflow"
 	"github.com/OpenNSW/nsw/internal/hscode"
 	"github.com/OpenNSW/nsw/internal/profile/cha"
+	"github.com/OpenNSW/nsw/internal/profile/company"
+	"github.com/OpenNSW/nsw/internal/profile/user"
 	"github.com/OpenNSW/nsw/internal/workflow/model"
 )
 
@@ -94,9 +96,75 @@ func (m *MockCHAService) Health() error {
 	return m.Called().Error(0)
 }
 
+// MockCompanyService implements company.Service for testing.
+type MockCompanyService struct {
+	mock.Mock
+}
+
+func (m *MockCompanyService) GetCompanyByID(ctx context.Context, id string) (*company.Record, error) {
+	args := m.Called(ctx, id)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).(*company.Record), args.Error(1)
+}
+
+func (m *MockCompanyService) GetCompanyByOUHandle(ctx context.Context, ouHandle string) (*company.Record, error) {
+	args := m.Called(ctx, ouHandle)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).(*company.Record), args.Error(1)
+}
+
+func (m *MockCompanyService) ListCompanies(ctx context.Context, filter company.ListFilter) ([]company.Record, error) {
+	args := m.Called(ctx, filter)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).([]company.Record), args.Error(1)
+}
+
+func (m *MockCompanyService) UpdateCompany(ctx context.Context, id string, data map[string]any) error {
+	return m.Called(ctx, id, data).Error(0)
+}
+
+func (m *MockCompanyService) Health(ctx context.Context) error {
+	return m.Called(ctx).Error(0)
+}
+
+// MockUserService implements user.Service for testing.
+type MockUserService struct {
+	mock.Mock
+}
+
+func (m *MockUserService) GetUser(id string) (*user.Record, error) {
+	args := m.Called(id)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).(*user.Record), args.Error(1)
+}
+
+func (m *MockUserService) GetOrCreateUser(idpUserID, email, phone, ouID, ouHandle string) (*string, error) {
+	args := m.Called(idpUserID, email, phone, ouID, ouHandle)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).(*string), args.Error(1)
+}
+
+func (m *MockUserService) UpdateUserData(id string, data []byte) error {
+	return m.Called(id, data).Error(0)
+}
+
+func (m *MockUserService) Health() error {
+	return m.Called().Error(0)
+}
+
 func TestConsignmentService_RegisterWorkflowManager(t *testing.T) {
 	db, _ := setupTestDB(t)
-	svc := NewService(db, nil, nil, nil)
+	svc := NewService(db, nil, nil, nil, nil, nil)
 	mockWM := new(MockWMV2)
 
 	// Test registration
@@ -109,7 +177,7 @@ func TestConsignmentService_RegisterWorkflowManager(t *testing.T) {
 	assert.Contains(t, err.Error(), "already registered")
 
 	// Test nil manager
-	svc2 := NewService(db, nil, nil, nil)
+	svc2 := NewService(db, nil, nil, nil, nil, nil)
 	err = svc2.RegisterWorkflowManager(nil)
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "cannot be nil")
@@ -117,7 +185,7 @@ func TestConsignmentService_RegisterWorkflowManager(t *testing.T) {
 
 func TestConsignmentService_CompletionHandler(t *testing.T) {
 	db, sqlMock := setupTestDB(t)
-	svc := NewService(db, nil, nil, nil)
+	svc := NewService(db, nil, nil, nil, nil, nil)
 	consignmentID := uuid.NewString()
 
 	sqlMock.ExpectQuery(`SELECT \* FROM "consignments" WHERE id = \$1`).
@@ -136,41 +204,41 @@ func TestConsignmentService_CompletionHandler(t *testing.T) {
 // --- InitializeConsignmentByID ---
 
 func TestConsignmentService_InitializeConsignmentByID_NoHSCode(t *testing.T) {
-	svc := NewService(nil, nil, nil, nil)
-	_, err := svc.InitializeConsignmentByID(context.Background(), "id", []string{}, nil)
+	svc := NewService(nil, nil, nil, nil, nil, nil)
+	_, err := svc.InitializeConsignmentByID(context.Background(), "id", []string{}, "")
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "at least one HS code ID is required")
 }
 
 func TestConsignmentService_InitializeConsignmentByID_NotFound(t *testing.T) {
 	db, sqlMock := setupTestDB(t)
-	svc := NewService(db, nil, nil, nil)
+	svc := NewService(db, nil, nil, nil, nil, nil)
 	id := uuid.NewString()
 	sqlMock.ExpectQuery(`SELECT \* FROM "consignments" WHERE id = \$1`).
 		WithArgs(id, 1).
 		WillReturnError(gorm.ErrRecordNotFound)
 
-	_, err := svc.InitializeConsignmentByID(context.Background(), id, []string{"hs1"}, nil)
+	_, err := svc.InitializeConsignmentByID(context.Background(), id, []string{"hs1"}, "")
 	assert.Error(t, err)
 	assert.True(t, errors.Is(err, gorm.ErrRecordNotFound))
 }
 
 func TestConsignmentService_InitializeConsignmentByID_WrongState(t *testing.T) {
 	db, sqlMock := setupTestDB(t)
-	svc := NewService(db, nil, nil, nil)
+	svc := NewService(db, nil, nil, nil, nil, nil)
 	id := uuid.NewString()
 	sqlMock.ExpectQuery(`SELECT \* FROM "consignments" WHERE id = \$1`).
 		WithArgs(id, 1).
 		WillReturnRows(sqlmock.NewRows([]string{"id", "state"}).AddRow(id, "IN_PROGRESS"))
 
-	_, err := svc.InitializeConsignmentByID(context.Background(), id, []string{"hs1"}, nil)
+	_, err := svc.InitializeConsignmentByID(context.Background(), id, []string{"hs1"}, "")
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "must be in INITIALIZED")
 }
 
 func TestConsignmentService_InitializeConsignmentByID_MultipleHSCodeError(t *testing.T) {
 	db, sqlMock := setupTestDB(t)
-	svc := NewService(db, nil, nil, nil)
+	svc := NewService(db, nil, nil, nil, nil, nil)
 	id := uuid.NewString()
 	sqlMock.ExpectQuery(`SELECT \* FROM "consignments" WHERE id = \$1`).
 		WithArgs(id, 1).
@@ -179,19 +247,28 @@ func TestConsignmentService_InitializeConsignmentByID_MultipleHSCodeError(t *tes
 	sqlMock.ExpectBegin()
 	sqlMock.ExpectExec(`UPDATE "consignments"`).WillReturnResult(sqlmock.NewResult(1, 1))
 
-	_, err := svc.InitializeConsignmentByID(context.Background(), id, []string{"hs1", "hs2"}, nil)
+	_, err := svc.InitializeConsignmentByID(context.Background(), id, []string{"hs1", "hs2"}, "")
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "supports only one HS code")
 }
 
 func TestConsignmentService_InitializeConsignmentByID_NoTemplate(t *testing.T) {
 	db, sqlMock := setupTestDB(t)
-	svc := NewService(db, nil, nil, nil)
+	mockCHA := new(MockCHAService)
+	mockCompany := new(MockCompanyService)
+	svc := NewService(db, nil, mockCHA, mockCompany, nil, nil)
 	id := uuid.NewString()
 	hsID := "hs1"
+	chaID := "cha1"
+	chaCompanyID := "company-cha"
+	traderCompanyID := "company-trader"
+
 	sqlMock.ExpectQuery(`SELECT \* FROM "consignments" WHERE id = \$1`).
 		WithArgs(id, 1).
-		WillReturnRows(sqlmock.NewRows([]string{"id", "state", "flow"}).AddRow(id, "INITIALIZED", "IMPORT"))
+		WillReturnRows(sqlmock.NewRows([]string{"id", "state", "flow", "cha_company_id", "trader_company_id"}).AddRow(id, "INITIALIZED", "IMPORT", chaCompanyID, traderCompanyID))
+
+	mockCHA.On("GetByID", mock.Anything, chaID).Return(&cha.Record{ID: chaID, CompanyID: chaCompanyID}, nil)
+	mockCompany.On("GetCompanyByID", mock.Anything, traderCompanyID).Return(&company.Record{ID: traderCompanyID, Data: []byte(`{}`)}, nil)
 
 	sqlMock.ExpectBegin()
 	sqlMock.ExpectExec(`UPDATE "consignments"`).WillReturnResult(sqlmock.NewResult(1, 1))
@@ -201,7 +278,7 @@ func TestConsignmentService_InitializeConsignmentByID_NoTemplate(t *testing.T) {
 		WillReturnError(gorm.ErrRecordNotFound)
 	sqlMock.ExpectRollback()
 
-	_, err := svc.InitializeConsignmentByID(context.Background(), id, []string{hsID}, nil)
+	_, err := svc.InitializeConsignmentByID(context.Background(), id, []string{hsID}, chaID)
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "no workflow template found")
 }
@@ -211,17 +288,24 @@ func TestConsignmentService_InitializeConsignmentByID_Success(t *testing.T) {
 	mockTP := new(MockTemplateProvider)
 	mockWM := new(MockWMV2)
 	mockHS := hscode.NewService(db)
-	svc := NewService(db, mockTP, nil, mockHS)
+	mockCHA := new(MockCHAService)
+	mockCompany := new(MockCompanyService)
+	svc := NewService(db, mockTP, mockCHA, mockCompany, nil, mockHS)
 	require.NoError(t, svc.RegisterWorkflowManager(mockWM))
 
 	id := uuid.NewString()
 	hsID := uuid.NewString()
 	traderID := "trader1"
 	chaID := "cha1"
+	chaCompanyID := "company-cha"
+	traderCompanyID := "company-trader"
 
 	sqlMock.ExpectQuery(`SELECT \* FROM "consignments" WHERE id = \$1`).
 		WithArgs(id, 1).
-		WillReturnRows(sqlmock.NewRows([]string{"id", "state", "flow", "trader_id", "cha_id"}).AddRow(id, "INITIALIZED", "IMPORT", traderID, chaID))
+		WillReturnRows(sqlmock.NewRows([]string{"id", "state", "flow", "trader_id", "cha_company_id", "trader_company_id"}).AddRow(id, "INITIALIZED", "IMPORT", traderID, chaCompanyID, traderCompanyID))
+
+	mockCHA.On("GetByID", mock.Anything, chaID).Return(&cha.Record{ID: chaID, CompanyID: chaCompanyID}, nil)
+	mockCompany.On("GetCompanyByID", mock.Anything, traderCompanyID).Return(&company.Record{ID: traderCompanyID, OUHandle: "trader-ou", Data: []byte(`{"br_no":"BR-1"}`)}, nil)
 
 	sqlMock.ExpectBegin()
 	sqlMock.ExpectExec(`UPDATE "consignments"`).WillReturnResult(sqlmock.NewResult(1, 1))
@@ -236,15 +320,18 @@ func TestConsignmentService_InitializeConsignmentByID_Success(t *testing.T) {
 		WithArgs(wtID).
 		WillReturnRows(sqlmock.NewRows([]string{"id", "name", "version", "workflow_definition"}).
 			AddRow(wtID, "tmpl", "v1", []byte(`{"id":"template1"}`)))
-	mockWM.On("StartWorkflow", mock.Anything, id, wfDef, mock.Anything).Return(nil)
+	mockWM.On("StartWorkflow", mock.Anything, id, wfDef, mock.MatchedBy(func(vars map[string]any) bool {
+		tc, ok := vars["traderCompany"].(map[string]any)
+		return ok && tc["id"] == traderCompanyID
+	})).Return(nil)
 
 	sqlMock.ExpectCommit()
 
 	// Reload (consignment.ID is populated, so GORM adds an extra "consignments"."id" = $2 clause)
 	sqlMock.ExpectQuery(`SELECT \* FROM "consignments" WHERE id = \$1`).
 		WithArgs(id, id, 1).
-		WillReturnRows(sqlmock.NewRows([]string{"id", "state", "flow", "trader_id", "cha_id", "items", "created_at", "updated_at"}).
-			AddRow(id, "IN_PROGRESS", "IMPORT", traderID, chaID, []byte(`[{"hsCodeId":"`+hsID+`"}]`), time.Now(), time.Now()))
+		WillReturnRows(sqlmock.NewRows([]string{"id", "state", "flow", "trader_id", "cha_company_id", "trader_company_id", "cha_id", "items", "created_at", "updated_at"}).
+			AddRow(id, "IN_PROGRESS", "IMPORT", traderID, chaCompanyID, traderCompanyID, chaID, []byte(`[{"hsCodeId":"`+hsID+`"}]`), time.Now(), time.Now()))
 
 	mockWM.On("GetStatus", mock.Anything, id).Return(&workflowManagerV2.WorkflowInstance{
 		ID: id,
@@ -266,18 +353,20 @@ func TestConsignmentService_InitializeConsignmentByID_Success(t *testing.T) {
 		WillReturnRows(sqlmock.NewRows([]string{"id", "hs_code", "description", "category"}).
 			AddRow(hsID, "1234.56", "Test", "Cat"))
 
-	result, err := svc.InitializeConsignmentByID(context.Background(), id, []string{hsID}, nil)
+	result, err := svc.InitializeConsignmentByID(context.Background(), id, []string{hsID}, chaID)
 	assert.NoError(t, err)
 	assert.NotNil(t, result)
 	assert.Equal(t, id, result.ID)
 	assert.Len(t, result.WorkflowNodes, 2)
 	assert.Equal(t, "Task 1", result.WorkflowNodes[0].WorkflowNodeTemplate.Name)
 	assert.Equal(t, model.WorkflowNodeStateCompleted, result.WorkflowNodes[0].State)
+	mockCHA.AssertExpectations(t)
+	mockCompany.AssertExpectations(t)
 }
 
 func TestConsignmentService_OnWorkflowStatusChanged(t *testing.T) {
 	db, sqlMock := setupTestDB(t)
-	svc := NewService(db, nil, nil, nil)
+	svc := NewService(db, nil, nil, nil, nil, nil)
 	id := uuid.NewString()
 
 	// Completed
@@ -299,38 +388,53 @@ func TestConsignmentService_OnWorkflowStatusChanged(t *testing.T) {
 }
 func TestConsignmentService_CreateConsignmentShell_Success(t *testing.T) {
 	db, sqlMock := setupTestDB(t)
-	mockCHA := new(MockCHAService)
-	svc := NewService(db, nil, mockCHA, hscode.NewService(db))
+	mockCompany := new(MockCompanyService)
+	mockUser := new(MockUserService)
+	svc := NewService(db, nil, nil, mockCompany, mockUser, hscode.NewService(db))
 	ctx := context.Background()
-	chaID := uuid.NewString()
+	chaCompanyID := uuid.NewString()
+	traderCompanyID := uuid.NewString()
 	consignmentID := uuid.NewString()
 	traderID := "trader1"
 
-	mockCHA.On("GetByID", ctx, chaID).Return(&cha.Record{ID: chaID, Name: "Test CHA"}, nil)
+	mockCompany.On("GetCompanyByID", ctx, chaCompanyID).Return(&company.Record{ID: chaCompanyID, HasCHA: true}, nil)
+	mockUser.On("GetUser", traderID).Return(&user.Record{ID: traderID, OUHandle: "trader-ou"}, nil)
+	mockCompany.On("GetCompanyByOUHandle", ctx, "trader-ou").Return(&company.Record{ID: traderCompanyID}, nil)
 
 	sqlMock.ExpectBegin()
 	sqlMock.ExpectExec(`INSERT INTO "consignments"`).
-		WithArgs(sqlmock.AnyArg(), sqlmock.AnyArg(), sqlmock.AnyArg(), string(FlowImport), traderID, string(Initialized), sqlmock.AnyArg(), chaID).
 		WillReturnResult(sqlmock.NewResult(1, 1))
 	sqlMock.ExpectCommit()
 
 	sqlMock.ExpectQuery(`SELECT \* FROM "consignments" WHERE id = \$1`).
 		WithArgs(sqlmock.AnyArg(), sqlmock.AnyArg(), 1).
-		WillReturnRows(sqlmock.NewRows([]string{"id", "flow", "trader_id", "cha_id", "state", "items"}).
-			AddRow(consignmentID, "IMPORT", traderID, chaID, "INITIALIZED", []byte("[]")))
+		WillReturnRows(sqlmock.NewRows([]string{"id", "flow", "trader_id", "trader_company_id", "cha_company_id", "state", "items"}).
+			AddRow(consignmentID, "IMPORT", traderID, traderCompanyID, chaCompanyID, "INITIALIZED", []byte("[]")))
 
-	result, err := svc.CreateConsignmentShell(ctx, FlowImport, chaID, traderID)
+	result, err := svc.CreateConsignmentShell(ctx, FlowImport, chaCompanyID, traderID)
 	assert.NoError(t, err)
 	assert.NotNil(t, result)
 	assert.Equal(t, consignmentID, result.ID)
-	mockCHA.AssertExpectations(t)
+	mockCompany.AssertExpectations(t)
+	mockUser.AssertExpectations(t)
 	assert.NoError(t, sqlMock.ExpectationsWereMet())
+}
+
+func TestConsignmentService_CreateConsignmentShell_CompanyNotCHA(t *testing.T) {
+	db, _ := setupTestDB(t)
+	mockCompany := new(MockCompanyService)
+	svc := NewService(db, nil, nil, mockCompany, nil, nil)
+
+	mockCompany.On("GetCompanyByID", mock.Anything, "company-1").Return(&company.Record{ID: "company-1", HasCHA: false}, nil)
+
+	_, err := svc.CreateConsignmentShell(context.Background(), FlowImport, "company-1", "trader1")
+	assert.ErrorIs(t, err, ErrCompanyNotCHA)
 }
 
 func TestConsignmentService_GetConsignmentByID(t *testing.T) {
 	db, sqlMock := setupTestDB(t)
 	mockWM := new(MockWMV2)
-	svc := NewService(db, nil, nil, hscode.NewService(db))
+	svc := NewService(db, nil, nil, nil, nil, hscode.NewService(db))
 	require.NoError(t, svc.RegisterWorkflowManager(mockWM))
 
 	ctx := context.Background()
@@ -358,19 +462,17 @@ func TestConsignmentService_GetConsignmentByID(t *testing.T) {
 	assert.NoError(t, sqlMock.ExpectationsWereMet())
 }
 
-func TestConsignmentService_GetConsignmentsByTraderID_Empty(t *testing.T) {
+func TestConsignmentService_ListConsignments_TraderCompany_Empty(t *testing.T) {
 	db, sqlMock := setupTestDB(t)
-	svc := NewService(db, nil, nil, hscode.NewService(db))
+	svc := NewService(db, nil, nil, nil, nil, hscode.NewService(db))
 	ctx := context.Background()
-	traderID := "trader1"
+	companyID := "company-1"
 
-	sqlMock.ExpectQuery(`SELECT count\(\*\) FROM "consignments" WHERE trader_id = \$1`).
-		WithArgs(traderID).
+	sqlMock.ExpectQuery(`SELECT count\(\*\) FROM "consignments" WHERE trader_company_id = \$1`).
+		WithArgs(companyID).
 		WillReturnRows(sqlmock.NewRows([]string{"count"}).AddRow(0))
 
-	limit := 10
-	offset := 0
-	result, err := svc.GetConsignmentsByTraderID(ctx, traderID, &offset, &limit, Filter{})
+	result, err := svc.ListConsignments(ctx, Filter{TraderCompanyID: &companyID})
 	assert.NoError(t, err)
 	assert.NotNil(t, result)
 	assert.Equal(t, int64(0), result.TotalCount)
@@ -378,18 +480,16 @@ func TestConsignmentService_GetConsignmentsByTraderID_Empty(t *testing.T) {
 	assert.NoError(t, sqlMock.ExpectationsWereMet())
 }
 
-func TestConsignmentService_GetConsignmentsByTraderID_CountError(t *testing.T) {
+func TestConsignmentService_ListConsignments_TraderCompany_CountError(t *testing.T) {
 	db, sqlMock := setupTestDB(t)
-	svc := NewService(db, nil, nil, hscode.NewService(db))
+	svc := NewService(db, nil, nil, nil, nil, hscode.NewService(db))
 	ctx := context.Background()
-	traderID := "trader1"
+	companyID := "company-1"
 
 	sqlMock.ExpectQuery(`SELECT count\(\*\) FROM "consignments"`).
 		WillReturnError(errors.New("count error"))
 
-	limit := 10
-	offset := 0
-	result, err := svc.GetConsignmentsByTraderID(ctx, traderID, &offset, &limit, Filter{})
+	result, err := svc.ListConsignments(ctx, Filter{TraderCompanyID: &companyID})
 	assert.Error(t, err)
 	assert.Nil(t, result)
 	assert.NoError(t, sqlMock.ExpectationsWereMet())
@@ -397,37 +497,40 @@ func TestConsignmentService_GetConsignmentsByTraderID_CountError(t *testing.T) {
 
 func TestConsignmentService_ListConsignments_NoIdentity(t *testing.T) {
 	db, _ := setupTestDB(t)
-	svc := NewService(db, nil, nil, nil)
+	svc := NewService(db, nil, nil, nil, nil, nil)
 	_, err := svc.ListConsignments(context.Background(), Filter{})
 	assert.Error(t, err)
-	assert.Contains(t, err.Error(), "TraderID or ChaID must be set")
+	assert.Contains(t, err.Error(), "TraderCompanyID or CHACompanyID must be set")
 }
 
-func TestConsignmentService_CreateConsignmentShell_CHANotFound(t *testing.T) {
+func TestConsignmentService_CreateConsignmentShell_CompanyNotFound(t *testing.T) {
 	db, _ := setupTestDB(t)
-	mockCHA := new(MockCHAService)
-	svc := NewService(db, nil, mockCHA, nil)
+	mockCompany := new(MockCompanyService)
+	svc := NewService(db, nil, nil, mockCompany, nil, nil)
 	ctx := context.Background()
-	mockCHA.On("GetByID", ctx, "missing").Return(nil, cha.ErrCHANotFound)
+	mockCompany.On("GetCompanyByID", ctx, "missing").Return(nil, company.ErrCompanyNotFound)
 
 	_, err := svc.CreateConsignmentShell(ctx, FlowImport, "missing", "trader1")
-	assert.Error(t, err)
-	assert.Contains(t, err.Error(), "CHA not found")
+	assert.ErrorIs(t, err, company.ErrCompanyNotFound)
 }
 
 func TestConsignmentService_CreateConsignmentShell_InsertError(t *testing.T) {
 	db, sqlMock := setupTestDB(t)
-	mockCHA := new(MockCHAService)
-	svc := NewService(db, nil, mockCHA, nil)
+	mockCompany := new(MockCompanyService)
+	mockUser := new(MockUserService)
+	svc := NewService(db, nil, nil, mockCompany, mockUser, nil)
 	ctx := context.Background()
-	chaID := uuid.NewString()
-	mockCHA.On("GetByID", ctx, chaID).Return(&cha.Record{ID: chaID}, nil)
+	chaCompanyID := uuid.NewString()
+	traderID := "trader1"
+	mockCompany.On("GetCompanyByID", ctx, chaCompanyID).Return(&company.Record{ID: chaCompanyID, HasCHA: true}, nil)
+	mockUser.On("GetUser", traderID).Return(&user.Record{ID: traderID, OUHandle: "trader-ou"}, nil)
+	mockCompany.On("GetCompanyByOUHandle", ctx, "trader-ou").Return(&company.Record{ID: "trader-company"}, nil)
 
 	sqlMock.ExpectBegin()
 	sqlMock.ExpectExec(`INSERT INTO "consignments"`).WillReturnError(errors.New("insert failed"))
 	sqlMock.ExpectRollback()
 
-	_, err := svc.CreateConsignmentShell(ctx, FlowImport, chaID, "trader1")
+	_, err := svc.CreateConsignmentShell(ctx, FlowImport, chaCompanyID, traderID)
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "failed to create consignment")
 }
@@ -435,15 +538,25 @@ func TestConsignmentService_CreateConsignmentShell_InsertError(t *testing.T) {
 func TestConsignmentService_InitializeConsignmentByID_StartWorkflowError(t *testing.T) {
 	db, sqlMock := setupTestDB(t)
 	mockWM := new(MockWMV2)
-	svc := NewService(db, nil, nil, nil)
+	mockCHA := new(MockCHAService)
+	mockCompany := new(MockCompanyService)
+	svc := NewService(db, nil, mockCHA, mockCompany, nil, nil)
 	require.NoError(t, svc.RegisterWorkflowManager(mockWM))
 
 	id := uuid.NewString()
 	hsID := "hs1"
 	wtID := uuid.NewString()
+	chaID := "cha1"
+	chaCompanyID := "company-cha"
+	traderCompanyID := "company-trader"
+
 	sqlMock.ExpectQuery(`SELECT \* FROM "consignments" WHERE id = \$1`).
 		WithArgs(id, 1).
-		WillReturnRows(sqlmock.NewRows([]string{"id", "state", "flow"}).AddRow(id, "INITIALIZED", "IMPORT"))
+		WillReturnRows(sqlmock.NewRows([]string{"id", "state", "flow", "cha_company_id", "trader_company_id"}).AddRow(id, "INITIALIZED", "IMPORT", chaCompanyID, traderCompanyID))
+
+	mockCHA.On("GetByID", mock.Anything, chaID).Return(&cha.Record{ID: chaID, CompanyID: chaCompanyID}, nil)
+	mockCompany.On("GetCompanyByID", mock.Anything, traderCompanyID).Return(&company.Record{ID: traderCompanyID, Data: []byte(`{}`)}, nil)
+
 	sqlMock.ExpectBegin()
 	sqlMock.ExpectExec(`UPDATE "consignments"`).WillReturnResult(sqlmock.NewResult(1, 1))
 
@@ -457,20 +570,30 @@ func TestConsignmentService_InitializeConsignmentByID_StartWorkflowError(t *test
 			AddRow(wtID, "tmpl", "v1", []byte(`{"id":"tmpl"}`)))
 	mockWM.On("StartWorkflow", mock.Anything, id, workflowManagerV2.WorkflowDefinition{ID: "tmpl"}, mock.Anything).Return(errors.New("start failed"))
 
-	_, err := svc.InitializeConsignmentByID(context.Background(), id, []string{hsID}, nil)
+	_, err := svc.InitializeConsignmentByID(context.Background(), id, []string{hsID}, chaID)
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "failed to register workflow")
 }
 
 func TestConsignmentService_InitializeConsignmentByID_TemplateProviderError(t *testing.T) {
 	db, sqlMock := setupTestDB(t)
-	svc := NewService(db, nil, nil, nil)
+	mockCHA := new(MockCHAService)
+	mockCompany := new(MockCompanyService)
+	svc := NewService(db, nil, mockCHA, mockCompany, nil, nil)
 
 	id := uuid.NewString()
 	hsID := "hs1"
+	chaID := "cha1"
+	chaCompanyID := "company-cha"
+	traderCompanyID := "company-trader"
+
 	sqlMock.ExpectQuery(`SELECT \* FROM "consignments" WHERE id = \$1`).
 		WithArgs(id, 1).
-		WillReturnRows(sqlmock.NewRows([]string{"id", "state", "flow"}).AddRow(id, "INITIALIZED", "IMPORT"))
+		WillReturnRows(sqlmock.NewRows([]string{"id", "state", "flow", "cha_company_id", "trader_company_id"}).AddRow(id, "INITIALIZED", "IMPORT", chaCompanyID, traderCompanyID))
+
+	mockCHA.On("GetByID", mock.Anything, chaID).Return(&cha.Record{ID: chaID, CompanyID: chaCompanyID}, nil)
+	mockCompany.On("GetCompanyByID", mock.Anything, traderCompanyID).Return(&company.Record{ID: traderCompanyID, Data: []byte(`{}`)}, nil)
+
 	sqlMock.ExpectBegin()
 	sqlMock.ExpectExec(`UPDATE "consignments"`).WillReturnResult(sqlmock.NewResult(1, 1))
 
@@ -479,14 +602,34 @@ func TestConsignmentService_InitializeConsignmentByID_TemplateProviderError(t *t
 		WillReturnError(errors.New("provider error"))
 	sqlMock.ExpectRollback()
 
-	_, err := svc.InitializeConsignmentByID(context.Background(), id, []string{hsID}, nil)
+	_, err := svc.InitializeConsignmentByID(context.Background(), id, []string{hsID}, chaID)
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "failed to get workflow template")
 }
 
+func TestConsignmentService_InitializeConsignmentByID_CHACompanyMismatch(t *testing.T) {
+	db, sqlMock := setupTestDB(t)
+	mockCHA := new(MockCHAService)
+	mockCompany := new(MockCompanyService)
+	svc := NewService(db, nil, mockCHA, mockCompany, nil, nil)
+
+	id := uuid.NewString()
+	hsID := "hs1"
+	chaID := "cha1"
+
+	sqlMock.ExpectQuery(`SELECT \* FROM "consignments" WHERE id = \$1`).
+		WithArgs(id, 1).
+		WillReturnRows(sqlmock.NewRows([]string{"id", "state", "flow", "cha_company_id"}).AddRow(id, "INITIALIZED", "IMPORT", "company-A"))
+
+	mockCHA.On("GetByID", mock.Anything, chaID).Return(&cha.Record{ID: chaID, CompanyID: "company-B"}, nil)
+
+	_, err := svc.InitializeConsignmentByID(context.Background(), id, []string{hsID}, chaID)
+	assert.ErrorIs(t, err, ErrCHACompanyMismatch)
+}
+
 func TestConsignmentService_MarkConsignmentAsFinished_NotFound(t *testing.T) {
 	db, sqlMock := setupTestDB(t)
-	svc := NewService(db, nil, nil, nil)
+	svc := NewService(db, nil, nil, nil, nil, nil)
 	id := uuid.NewString()
 	sqlMock.ExpectQuery(`SELECT \* FROM "consignments" WHERE id = \$1`).
 		WithArgs(id, 1).
@@ -500,7 +643,7 @@ func TestConsignmentService_MarkConsignmentAsFinished_NotFound(t *testing.T) {
 func TestConsignmentService_GetConsignmentByID_WMError(t *testing.T) {
 	db, sqlMock := setupTestDB(t)
 	mockWM := new(MockWMV2)
-	svc := NewService(db, nil, nil, hscode.NewService(db))
+	svc := NewService(db, nil, nil, nil, nil, hscode.NewService(db))
 	require.NoError(t, svc.RegisterWorkflowManager(mockWM))
 
 	id := uuid.NewString()
@@ -517,7 +660,7 @@ func TestConsignmentService_GetConsignmentByID_WMError(t *testing.T) {
 func TestConsignmentService_GetConsignmentByID_Initialized_SkipsWM(t *testing.T) {
 	db, sqlMock := setupTestDB(t)
 	// No WM registered — INITIALIZED path must NOT call it.
-	svc := NewService(db, nil, nil, hscode.NewService(db))
+	svc := NewService(db, nil, nil, nil, nil, hscode.NewService(db))
 
 	id := uuid.NewString()
 	sqlMock.ExpectQuery(`SELECT \* FROM "consignments" WHERE id = \$1`).
@@ -531,7 +674,7 @@ func TestConsignmentService_GetConsignmentByID_Initialized_SkipsWM(t *testing.T)
 
 func TestConsignmentService_ListConsignments_WithItems(t *testing.T) {
 	db, sqlMock := setupTestDB(t)
-	svc := NewService(db, nil, nil, hscode.NewService(db))
+	svc := NewService(db, nil, nil, nil, nil, hscode.NewService(db))
 	traderID := "trader1"
 	consignmentID := uuid.NewString()
 	hsID := uuid.NewString()
@@ -551,7 +694,7 @@ func TestConsignmentService_ListConsignments_WithItems(t *testing.T) {
 		WillReturnRows(sqlmock.NewRows([]string{"id", "hs_code", "description", "category"}).
 			AddRow(hsID, "1234.56", "Test", "Cat"))
 
-	result, err := svc.ListConsignments(context.Background(), Filter{TraderID: &traderID})
+	result, err := svc.ListConsignments(context.Background(), Filter{TraderCompanyID: &traderID})
 	assert.NoError(t, err)
 	assert.Equal(t, int64(1), result.TotalCount)
 	require.Len(t, result.Items, 1)
@@ -562,7 +705,7 @@ func TestConsignmentService_ListConsignments_WithItems(t *testing.T) {
 
 func TestConsignmentService_ListConsignments_FindError(t *testing.T) {
 	db, sqlMock := setupTestDB(t)
-	svc := NewService(db, nil, nil, nil)
+	svc := NewService(db, nil, nil, nil, nil, nil)
 	traderID := "trader1"
 
 	sqlMock.ExpectQuery(`SELECT count\(\*\) FROM "consignments"`).
@@ -570,14 +713,14 @@ func TestConsignmentService_ListConsignments_FindError(t *testing.T) {
 	sqlMock.ExpectQuery(`SELECT \* FROM "consignments"`).
 		WillReturnError(errors.New("find error"))
 
-	_, err := svc.ListConsignments(context.Background(), Filter{TraderID: &traderID})
+	_, err := svc.ListConsignments(context.Background(), Filter{TraderCompanyID: &traderID})
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "failed to retrieve consignments")
 }
 
 func TestConsignmentService_ListConsignments_NodeCountError(t *testing.T) {
 	db, sqlMock := setupTestDB(t)
-	svc := NewService(db, nil, nil, nil)
+	svc := NewService(db, nil, nil, nil, nil, nil)
 	traderID := "trader1"
 
 	sqlMock.ExpectQuery(`SELECT count\(\*\) FROM "consignments"`).
@@ -586,14 +729,14 @@ func TestConsignmentService_ListConsignments_NodeCountError(t *testing.T) {
 		WillReturnRows(sqlmock.NewRows([]string{"id", "items"}).AddRow(uuid.NewString(), []byte("[]")))
 	sqlMock.ExpectQuery(`SELECT workflow_id`).WillReturnError(errors.New("node count error"))
 
-	_, err := svc.ListConsignments(context.Background(), Filter{TraderID: &traderID})
+	_, err := svc.ListConsignments(context.Background(), Filter{TraderCompanyID: &traderID})
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "node counts")
 }
 
 func TestConsignmentService_ListConsignments_EndNodeError(t *testing.T) {
 	db, sqlMock := setupTestDB(t)
-	svc := NewService(db, nil, nil, nil)
+	svc := NewService(db, nil, nil, nil, nil, nil)
 	traderID := "trader1"
 
 	sqlMock.ExpectQuery(`SELECT count\(\*\) FROM "consignments"`).
@@ -605,27 +748,27 @@ func TestConsignmentService_ListConsignments_EndNodeError(t *testing.T) {
 	sqlMock.ExpectQuery(`SELECT id, end_node_id FROM "workflows"`).
 		WillReturnError(errors.New("end node error"))
 
-	_, err := svc.ListConsignments(context.Background(), Filter{TraderID: &traderID})
+	_, err := svc.ListConsignments(context.Background(), Filter{TraderCompanyID: &traderID})
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "end nodes")
 }
 
-func TestConsignmentService_ListConsignments_ChaIDPath(t *testing.T) {
+func TestConsignmentService_ListConsignments_CHACompanyPath(t *testing.T) {
 	db, sqlMock := setupTestDB(t)
-	svc := NewService(db, nil, nil, nil)
-	chaID := "cha1"
+	svc := NewService(db, nil, nil, nil, nil, nil)
+	companyID := "company-cha"
 
-	sqlMock.ExpectQuery(`SELECT count\(\*\) FROM "consignments" WHERE cha_id = \$1`).
-		WithArgs(chaID).
+	sqlMock.ExpectQuery(`SELECT count\(\*\) FROM "consignments" WHERE cha_company_id = \$1`).
+		WithArgs(companyID).
 		WillReturnRows(sqlmock.NewRows([]string{"count"}).AddRow(0))
 
-	result, err := svc.ListConsignments(context.Background(), Filter{ChaID: &chaID})
+	result, err := svc.ListConsignments(context.Background(), Filter{CHACompanyID: &companyID})
 	assert.NoError(t, err)
 	assert.Equal(t, int64(0), result.TotalCount)
 }
 
 func TestConsignmentService_BuildItemResponseDTOs_MissingHSCode(t *testing.T) {
-	svc := NewService(nil, nil, nil, nil)
+	svc := NewService(nil, nil, nil, nil, nil, nil)
 	_, err := svc.buildConsignmentItemResponseDTOs([]Item{{HSCodeID: "missing"}}, map[string]hscode.HSCode{})
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "HS code not found")

--- a/backend/internal/database/migrations/001_initial_schema.up.sql
+++ b/backend/internal/database/migrations/001_initial_schema.up.sql
@@ -196,15 +196,25 @@ CREATE TABLE IF NOT EXISTS consignments
 	created_at timestamp with time zone DEFAULT now() NOT NULL,
 	updated_at timestamp with time zone DEFAULT now() NOT NULL,
 	end_node_id text,
-	cha_id varchar(100) NOT NULL REFERENCES customs_house_agents (id)
+	trader_company_id varchar(100) NOT NULL REFERENCES company_records (id),
+	cha_company_id varchar(100) NOT NULL REFERENCES company_records (id),
+	cha_id varchar(100) REFERENCES customs_house_agents (id)
 );
 
 COMMENT ON TABLE consignments IS 'Consignment records for import/export workflows';
 
-COMMENT ON COLUMN consignments.cha_id IS 'Assigned Customs House Agent (CHA); set at Stage 1 by Trader';
+COMMENT ON COLUMN consignments.trader_company_id IS 'Company that owns the trader; resolved from the trader user''s OU at Stage 1';
+COMMENT ON COLUMN consignments.cha_company_id IS 'CHA company selected by the trader at Stage 1; constrains which CHAs may pick the consignment up';
+COMMENT ON COLUMN consignments.cha_id IS 'Assigned Customs House Agent (CHA); set at Stage 2 when a CHA from cha_company_id claims the consignment';
 
 CREATE INDEX IF NOT EXISTS idx_consignments_trader_id
 	ON consignments (trader_id);
+
+CREATE INDEX IF NOT EXISTS idx_consignments_trader_company_id
+	ON consignments (trader_company_id);
+
+CREATE INDEX IF NOT EXISTS idx_consignments_cha_company_id
+	ON consignments (cha_company_id);
 
 CREATE INDEX IF NOT EXISTS idx_consignments_state
 	ON consignments (state);


### PR DESCRIPTION
## Summary

Builds on the profile foundation from #533 by giving every consignment both a trader-company and a CHA-company identity. Stage 1 (CreateConsignmentShell) records who-belongs-where; Stage 2 (InitializeConsignmentByID) verifies the picking CHA belongs to the chosen CHA company before assigning. Listing semantics become company-scoped so colleagues in the same trader company see each other's consignments, and any CHA in the same CHA company sees all assigned ones.

This is the second of three PRs in the consignment ↔ company wiring stack. The remaining PR (trader-app frontend — switches the CHA picker to `GET /api/v1/companies?has_cha=true&name=...`, renames the create payload field `chaId` → `chaCompanyId`) is queued locally and will go up once this merges.

## Type of Change

- [x] Refactoring (no functional changes)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Other (please describe):

Breaking notes:
- `consignments` table schema changes (new NOT NULL FKs); requires a schema rebuild in dev environments.
- `CreateConsignmentDTO.chaId` is renamed to `chaCompanyId`. Any client sending the old field will hit the new "chaCompanyId is required" validation. The trader-app fix is the next (and final) PR in this stack.
- `InitializeConsignmentByID` signature drops the unused `globalContext` parameter and adds `chaID`; existing call sites need updating (the router is updated in this PR; no other callers).
- `Filter.TraderID` / `Filter.ChaID` are replaced with `Filter.TraderCompanyID` / `Filter.CHACompanyID`.
- `GetConsignmentsByTraderID` is removed — no remaining callers.

## Changes Made

- **Schema** ([`001_initial_schema.up.sql`](backend/internal/database/migrations/001_initial_schema.up.sql)) — `consignments` gains `trader_company_id` and `cha_company_id` (both NOT NULL FKs to `company_records(id)`); `cha_id` drops NOT NULL (no longer set at Stage 1); matching indexes added.
- **Model** ([`consignment/model.go`](backend/internal/consignment/model.go)) — `Consignment` struct reordered, gains `TraderCompanyID` / `CHACompanyID`; the embedded `cha.Record` relation is dropped (no callers). `CreateConsignmentDTO` renames `ChaID` → `ChaCompanyID`. `Filter` replaces `TraderID` / `ChaID` with `TraderCompanyID` / `CHACompanyID`. `DetailDTO` / `SummaryDTO` surface the new company IDs.
- **Errors** ([`consignment/errors.go`](backend/internal/consignment/errors.go) — new) — sentinels `ErrCompanyNotCHA`, `ErrCHACompanyMismatch`.
- **Service** ([`consignment/service.go`](backend/internal/consignment/service.go)) — `NewService` now takes `company.Service` and `user.Service`.
  - `CreateConsignmentShell(ctx, flow, chaCompanyID, traderID)`: looks up the CHA company, rejects when `has_cha = false`, resolves the trader's company from their `ou_handle`, persists both company IDs.
  - `InitializeConsignmentByID(ctx, consignmentID, hsCodeIDs, chaID)`: drops `globalContext`; verifies CHA via `GetByID` and `cha.CompanyID == consignment.CHACompanyID`; loads trader company and passes `{"traderCompany": <marshalled record>}` to `StartWorkflow`.
  - `ListConsignments` filters by `trader_company_id` / `cha_company_id`.
- **Router** ([`consignment/router.go`](backend/internal/consignment/router.go)) — gains `company.Service`. `HandleCreateConsignment` maps `company.ErrCompanyNotFound` → 404 and `ErrCompanyNotCHA` → 400. `HandleInitializeConsignment` resolves the CHA via `cha.GetByEmail(authCtx.Email)` and passes the resolved ID; `ErrCHACompanyMismatch` → 403. `HandleGetConsignments` resolves the requesting user's company by `ou_handle` and scopes both roles by company.
- **Bootstrap** ([`bootstrap/app.go`](backend/internal/app/bootstrap/app.go)) — wires `companyService` + `userProfileService` into `consignment.NewService` and `consignment.NewRouter`.

## Testing

- [x] I have tested this change locally
- [x] I have added unit tests for new functionality
- [x] I have tested edge cases
- [x] All existing tests pass

Verification performed:
- `cd backend && go build ./... && gofmt -l . && go vet ./... && go test ./... && golangci-lint run ./...` — all green.
- New tests cover: `CreateConsignmentShell` happy + `CompanyNotFound` + `CompanyNotCHA` + insert error; `InitializeConsignmentByID` happy + `NoTemplate` + `StartWorkflowError` + `TemplateProviderError` + new `CHACompanyMismatch`; company-scoped `ListConsignments`; `HandleGetConsignments` resolving company by `OUHandle` for both roles; `HandleCreateConsignment` propagating `company.ErrCompanyNotFound` → 404.
- End-to-end smoke against a fresh DB seeded by `idp/02-sample-resources.sh`:
  - As Suresh (trader at ADAM PVT LTD): `POST /api/v1/consignments {flow:"IMPORT", chaCompanyId:"adam-pvt-ltd"}` succeeds; row has `trader_company_id = adam-pvt-ltd`, `cha_company_id = adam-pvt-ltd`, `cha_id IS NULL`.
  - As Ramesh (CHA at ADAM PVT LTD): `PUT /api/v1/consignments/{id}` succeeds and stamps `cha_id`.
  - As Naresh (CHA at EDWARD PVT LTD) attempting the same: 403 (`ErrCHACompanyMismatch`).
  - As Gomesh (trader at ADAM PVT LTD, not the creator): `GET /api/v1/consignments?role=trader` includes Suresh's consignment.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have checked that there are no merge conflicts

## Related Issues

<!-- No tracked issue. Follow-up to #533 (profile/company foundation). Final PR in this stack — trader-app frontend — will land next. -->

Closes #331

## Screenshots/Demo

N/A — backend / schema change. The user-facing impact is rolled into the trader-app PR that follows.

## Additional Notes

One PR remains in this stack:
- **trader-app frontend** — switches the CHA picker to `GET /api/v1/companies?has_cha=true&name=...` (debounced server-side filter), renames the create-consignment payload field `chaId` → `chaCompanyId`, and trims the `Company` interface to match the new `Summary` response shape. Branch is already prepared locally; will be opened once this merges.

The empty-string-vs-NULL pitfall for `cha_id` on Stage 1 inserts is handled at the GORM model level — `CHAID` keeps its `string` type but the column is now nullable, and the fix you applied during E2E testing ensures the insert emits `NULL` instead of `''`.

## Deployment Notes

- Requires a **schema rebuild** in dev environments because `consignments` gains two NOT NULL FK columns (no in-place migration). For local Postgres: `backend/internal/database/migrations/down.sh` then `run.sh`. No production data is affected — the schema change is dev/sample-data only at this stage.
- Any out-of-tree HTTP client that constructs the Stage 1 payload must send `chaCompanyId` instead of `chaId`. The trader-app fix lands in the next PR; no other in-repo callers exist.