### PR TITLE
feat(trader-app): switch CHA picker to /api/v1/companies; rename chaId → chaCompanyId

### DIFF
--- a/portals/apps/trader-app/src/components/CHAPicker/CHASearch.tsx
+++ b/portals/apps/trader-app/src/components/CHAPicker/CHASearch.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useState } from 'react'
+import { useState } from 'react'
 import { Text, Box, Flex, Spinner, TextField, ScrollArea, IconButton, Badge } from '@radix-ui/themes'
 import { MagnifyingGlassIcon, Cross2Icon } from '@radix-ui/react-icons'
 
@@ -10,19 +10,23 @@ export type CHAOption = {
 interface CHASearchProps {
   value: CHAOption | null
   onChange: (cha: CHAOption | null) => void
+  // Server-filtered results for the current searchQuery. The parent is responsible
+  // for refetching this list (debounced) whenever searchQuery changes.
   options: readonly CHAOption[]
   searchQuery: string
   onSearchQueryChange: (query: string) => void
+  loading?: boolean
 }
 
-export function CHASearch({ value, onChange, options, searchQuery, onSearchQueryChange }: CHASearchProps) {
+export function CHASearch({
+  value,
+  onChange,
+  options,
+  searchQuery,
+  onSearchQueryChange,
+  loading = false,
+}: CHASearchProps) {
   const [isFocused, setIsFocused] = useState(false)
-
-  const filtered = useMemo(() => {
-    const q = searchQuery.trim().toLowerCase()
-    if (!q) return []
-    return options.filter((o) => o.name.toLowerCase().includes(q))
-  }, [options, searchQuery])
 
   const handleSelect = (cha: CHAOption) => {
     onSearchQueryChange(cha.name)
@@ -36,13 +40,12 @@ export function CHASearch({ value, onChange, options, searchQuery, onSearchQuery
   }
 
   const showDropdown = isFocused && searchQuery.length > 0
-  const loading = false
 
   return (
     <Box position="relative">
       <TextField.Root
         size="2"
-        placeholder="Search by CHA (e.g., Spectra, Advantis)..."
+        placeholder="Search company (e.g., ADAM, EDWARD)..."
         value={searchQuery}
         onChange={(e) => {
           const val = e.target.value
@@ -80,20 +83,20 @@ export function CHASearch({ value, onChange, options, searchQuery, onSearchQuery
           mt="1"
           className="bg-white border border-gray-200 rounded-md shadow-lg z-10 overflow-hidden"
         >
-          {filtered.length === 0 ? (
+          {options.length === 0 ? (
             <Flex align="center" justify="center" py="5" direction="column" gap="1">
               <Text size="2" color="gray">
-                No CHAs found for "{searchQuery}"
+                {loading ? 'Searching…' : `No companies found for "${searchQuery}"`}
               </Text>
             </Flex>
           ) : (
             <ScrollArea style={{ maxHeight: '280px' }}>
               <Box py="1">
-                {filtered.map((cha) => {
-                  const isSelected = value?.id === cha.id
+                {options.map((company) => {
+                  const isSelected = value?.id === company.id
                   return (
                     <Flex
-                      key={cha.id}
+                      key={company.id}
                       px="3"
                       py="2"
                       gap="3"
@@ -103,7 +106,7 @@ export function CHASearch({ value, onChange, options, searchQuery, onSearchQuery
                       }`}
                       onMouseDown={(e) => {
                         e.preventDefault()
-                        handleSelect(cha)
+                        handleSelect(company)
                       }}
                     >
                       <Box pt="1">
@@ -112,10 +115,10 @@ export function CHASearch({ value, onChange, options, searchQuery, onSearchQuery
                       <Box style={{ flex: 1, minWidth: 0 }}>
                         <Flex align="center" gap="2" mb="1">
                           <Text size="2" weight="medium">
-                            {cha.name}
+                            {company.name}
                           </Text>
                           <Badge size="1" color="blue" variant="soft">
-                            CHA
+                            CHA Company
                           </Badge>
                         </Flex>
                       </Box>

--- a/portals/apps/trader-app/src/screens/ConsignmentScreen.tsx
+++ b/portals/apps/trader-app/src/screens/ConsignmentScreen.tsx
@@ -2,8 +2,9 @@ import { useState, useEffect, useRef, type ChangeEvent } from 'react'
 import { useNavigate } from 'react-router-dom'
 import { Badge, Box, Button, Dialog, Flex, IconButton, Select, Spinner, Text, TextField } from '@radix-ui/themes'
 import { MagnifyingGlassIcon, PlusIcon, Cross2Icon, InfoCircledIcon } from '@radix-ui/react-icons'
-import type { ConsignmentSummary, TradeFlow, ConsignmentState, CHA } from '../services/types/consignment.ts'
-import { createConsignment, getAllConsignments, getCHAs } from '../services/consignment.ts'
+import type { ConsignmentSummary, TradeFlow, ConsignmentState } from '../services/types/consignment.ts'
+import { createConsignment, getAllConsignments } from '../services/consignment.ts'
+import { getCompanies } from '../services/company.ts'
 import { useApi } from '../services/ApiContext'
 import { useRole } from '../services/RoleContext'
 import { getStateColor, formatState, formatDateTime } from '../utils/consignmentUtils'
@@ -16,26 +17,56 @@ const RadixText = Text
 
 type NewConsignmentData = {
   flow: TradeFlow | null
-  chaId: string
+  chaCompanyId: string
 }
 
 interface NewConsignmentDialogProps {
   open: boolean
   onOpenChange: (open: boolean) => void
-  chaOptions: CHAOption[]
   creating: boolean
   onCreate: (data: NewConsignmentData) => Promise<void>
 }
 
-function NewConsignmentDialog({ open, onOpenChange, chaOptions, creating, onCreate }: NewConsignmentDialogProps) {
+function NewConsignmentDialog({ open, onOpenChange, creating, onCreate }: NewConsignmentDialogProps) {
+  const api = useApi()
   const [newConsignmentData, setNewConsignmentData] = useState<NewConsignmentData>({
     flow: null,
-    chaId: '',
+    chaCompanyId: '',
   })
   const [currentCHASearchQuery, setCurrentCHASearchQuery] = useState('')
+  const [chaOptions, setChaOptions] = useState<CHAOption[]>([])
+  const [chaLoading, setChaLoading] = useState(false)
+
+  // Debounced server-side search via /api/v1/companies?has_cha=true&name=<query>.
+  // Each keystroke schedules a fetch 300ms later; a fresh keystroke cancels the previous one.
+  useEffect(() => {
+    if (!open) return
+    let cancelled = false
+    const handle = setTimeout(() => {
+      setChaLoading(true)
+      void getCompanies({ hasCha: true, name: currentCHASearchQuery }, api)
+        .then((companies) => {
+          if (cancelled) return
+          setChaOptions(companies.map((c) => ({ id: c.id, name: c.name })))
+        })
+        .catch((err: unknown) => {
+          if (cancelled) return
+          console.error('Failed to fetch companies:', err)
+          setChaOptions([])
+        })
+        .finally(() => {
+          if (cancelled) return
+          setChaLoading(false)
+        })
+    }, 300)
+    return () => {
+      cancelled = true
+      clearTimeout(handle)
+    }
+  }, [open, currentCHASearchQuery, api])
 
   const handleCreate = () => {
-    if (newConsignmentData.flow && newConsignmentData.chaId) {
+    if (newConsignmentData.flow && newConsignmentData.chaCompanyId) {
       void onCreate(newConsignmentData)
     }
   }
@@ -151,18 +182,19 @@ function NewConsignmentDialog({ open, onOpenChange, chaOptions, creating, onCrea
               </RadixText>
               <CHASearch
                 options={chaOptions}
-                value={chaOptions.find((c) => c.id === newConsignmentData.chaId) ?? null}
+                value={chaOptions.find((c) => c.id === newConsignmentData.chaCompanyId) ?? null}
                 searchQuery={currentCHASearchQuery}
-                onChange={(cha) => {
-                  setNewConsignmentData((prev) => ({ ...prev, chaId: cha?.id ?? '' }))
+                onChange={(company) => {
+                  setNewConsignmentData((prev) => ({ ...prev, chaCompanyId: company?.id ?? '' }))
                 }}
                 onSearchQueryChange={setCurrentCHASearchQuery}
+                loading={chaLoading}
               />
-              {!newConsignmentData.chaId && currentCHASearchQuery.trim().length > 0 && (
+              {!newConsignmentData.chaCompanyId && currentCHASearchQuery.trim().length > 0 && (
                 <Flex align="center" gap="1" mt="2">
                   <InfoCircledIcon color="red" />
                   <Text size="1" color="red">
-                    Please select a CHA from the list.
+                    Please select a CHA company from the list.
                   </Text>
                 </Flex>
               )}
@@ -178,7 +210,7 @@ function NewConsignmentDialog({ open, onOpenChange, chaOptions, creating, onCrea
           </Dialog.Close>
           <Button
             onClick={handleCreate}
-            disabled={!newConsignmentData.flow || !newConsignmentData.chaId || creating}
+            disabled={!newConsignmentData.flow || !newConsignmentData.chaCompanyId || creating}
             loading={creating}
           >
             {creating ? 'Creating...' : 'Create'}
@@ -193,7 +225,6 @@ export function ConsignmentScreen() {
   const navigate = useNavigate()
   const api = useApi()
   const [consignments, setConsignments] = useState<ConsignmentSummary[]>([])
-  const [chaOptions, setChaOptions] = useState<CHAOption[]>([])
 
   const [totalCount, setTotalCount] = useState(0)
   const [loading, setLoading] = useState(true)
@@ -224,7 +255,7 @@ export function ConsignmentScreen() {
       const response = await createConsignment(
         {
           flow: data.flow,
-          chaId: data.chaId,
+          chaCompanyId: data.chaCompanyId,
         },
         api,
       )
@@ -237,19 +268,6 @@ export function ConsignmentScreen() {
       setCreating(false)
     }
   }
-
-  useEffect(() => {
-    async function fetchCHAs() {
-      try {
-        const data = await getCHAs(api)
-        const options: CHAOption[] = data.map((c: CHA) => ({ id: c.id, name: c.name }))
-        setChaOptions(options)
-      } catch (error) {
-        console.error('Failed to fetch CHAs:', error)
-      }
-    }
-    void fetchCHAs()
-  }, [api])
 
   useEffect(() => {
     async function fetchConsignments() {
@@ -329,7 +347,6 @@ export function ConsignmentScreen() {
       <NewConsignmentDialog
         open={pickerOpen}
         onOpenChange={handleNewOpenChange}
-        chaOptions={chaOptions}
         creating={creating}
         onCreate={handleCreateShell}
       />

--- a/portals/apps/trader-app/src/screens/ConsignmentScreen.tsx
+++ b/portals/apps/trader-app/src/screens/ConsignmentScreen.tsx
@@ -33,14 +33,27 @@ function NewConsignmentDialog({ open, onOpenChange, creating, onCreate }: NewCon
     flow: null,
     chaCompanyId: '',
   })
+  const [selectedCHA, setSelectedCHA] = useState<CHAOption | null>(null)
   const [currentCHASearchQuery, setCurrentCHASearchQuery] = useState('')
   const [chaOptions, setChaOptions] = useState<CHAOption[]>([])
   const [chaLoading, setChaLoading] = useState(false)
 
-  // Debounced server-side search via /api/v1/companies?has_cha=true&name=<query>.
-  // Each keystroke schedules a fetch 300ms later; a fresh keystroke cancels the previous one.
   useEffect(() => {
-    if (!open) return
+    if (!open) {
+      setNewConsignmentData({ flow: null, chaCompanyId: '' })
+      setSelectedCHA(null)
+      setCurrentCHASearchQuery('')
+      setChaOptions([])
+      setChaLoading(false)
+      return
+    }
+
+    if (!currentCHASearchQuery.trim()) {
+      setChaOptions([])
+      setChaLoading(false)
+      return
+    }
+
     let cancelled = false
     const handle = setTimeout(() => {
       setChaLoading(true)
@@ -182,9 +195,10 @@ function NewConsignmentDialog({ open, onOpenChange, creating, onCreate }: NewCon
               </RadixText>
               <CHASearch
                 options={chaOptions}
-                value={chaOptions.find((c) => c.id === newConsignmentData.chaCompanyId) ?? null}
+                value={selectedCHA}
                 searchQuery={currentCHASearchQuery}
                 onChange={(company) => {
+                  setSelectedCHA(company)
                   setNewConsignmentData((prev) => ({ ...prev, chaCompanyId: company?.id ?? '' }))
                 }}
                 onSearchQueryChange={setCurrentCHASearchQuery}

--- a/portals/apps/trader-app/src/services/company.ts
+++ b/portals/apps/trader-app/src/services/company.ts
@@ -1,0 +1,23 @@
+import type { Company, CompanyListFilter, CompanyListResult } from './types/company'
+import { defaultApiClient, type ApiClient, type QueryParams } from './api'
+
+// getCompanies queries GET /api/v1/companies with optional has_cha and name filters.
+// Returns the items list directly — callers that need pagination metadata can switch to
+// getCompaniesResult below once the backend implements offset/limit.
+export async function getCompanies(
+  filter: CompanyListFilter = {},
+  apiClient: ApiClient = defaultApiClient,
+): Promise<Company[]> {
+  const result = await getCompaniesResult(filter, apiClient)
+  return result.items
+}
+
+export async function getCompaniesResult(
+  filter: CompanyListFilter = {},
+  apiClient: ApiClient = defaultApiClient,
+): Promise<CompanyListResult> {
+  const params: QueryParams = {}
+  if (filter.hasCha !== undefined) params.has_cha = String(filter.hasCha)
+  if (filter.name && filter.name.trim()) params.name = filter.name.trim()
+  return apiClient.get<CompanyListResult>('/companies', params)
+}

--- a/portals/apps/trader-app/src/services/consignment.ts
+++ b/portals/apps/trader-app/src/services/consignment.ts
@@ -5,7 +5,6 @@ import type {
   CreateConsignmentResponse,
   ConsignmentState,
   TradeFlow,
-  CHA,
 } from './types/consignment'
 import { defaultApiClient, type ApiClient } from './api'
 
@@ -36,10 +35,6 @@ export async function getConsignment(id: string, apiClient: ApiClient = defaultA
     }
     throw error
   }
-}
-
-export async function getCHAs(apiClient: ApiClient = defaultApiClient): Promise<CHA[]> {
-  return apiClient.get<CHA[]>('/chas')
 }
 
 export async function getAllConsignments(

--- a/portals/apps/trader-app/src/services/types/company.ts
+++ b/portals/apps/trader-app/src/services/types/company.ts
@@ -1,0 +1,24 @@
+// Company is the trimmed projection returned by GET /api/v1/companies.
+// Matches the backend `company.Summary` shape (id / name / hasCha) — storage-only fields
+// (ou_handle, data, timestamps) are intentionally dropped at the HTTP boundary.
+export interface Company {
+  id: string
+  name: string
+  hasCha: boolean
+}
+
+export interface CompanyListFilter {
+  hasCha?: boolean
+  name?: string
+}
+
+// CompanyListResult mirrors the backend `company.ListResult` envelope.
+// The envelope is pagination-shaped from day one even though the server currently returns
+// the full list — adding offset/limit later is non-breaking. Note the field is `total`
+// (not `totalCount`) to match the backend contract.
+export interface CompanyListResult {
+  items: Company[]
+  total: number
+  offset: number
+  limit: number
+}

--- a/portals/apps/trader-app/src/services/types/consignment.ts
+++ b/portals/apps/trader-app/src/services/types/consignment.ts
@@ -85,7 +85,7 @@ export interface CreateConsignmentItemRequest {
 export interface CreateConsignmentRequest {
   flow: TradeFlow
   items?: CreateConsignmentItemRequest[]
-  chaId?: string
+  chaCompanyId?: string
 }
 
 export type CreateConsignmentResponse = ConsignmentDetail


### PR DESCRIPTION
## Summary

Final PR in the consignment ↔ company wiring stack (after #533 — merged — and #539 — open). Switches the trader-app's CHA picker from `GET /api/v1/chas` to `GET /api/v1/companies?has_cha=true&name=...` with debounced server-side filtering, and renames the create-consignment payload field `chaId` → `chaCompanyId` to match the backend DTO.

## Type of Change

- [x] New feature (non-breaking change which adds functionality)
- [x] Refactoring (no functional changes)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Other (please describe):

Breaking note: this PR depends on the backend rename in #539 (`CreateConsignmentDTO.ChaID` → `ChaCompanyID`). It must merge **after** #539; if it lands first, the trader-app will send `chaCompanyId` to a backend that still expects `chaId` and Stage 1 will 400.

## Changes Made

- **`services/types/company.ts`** (new) — `Company { id, name, hasCha }` matches the backend `company.Summary` projection (storage-only fields are dropped at the HTTP boundary). `CompanyListResult` envelope `{ items, total, offset, limit }` mirrors the backend `company.ListResult`. Note the field is `total` (not `totalCount`) to match the contract.
- **`services/company.ts`** (new) — `getCompanies({ hasCha, name }?)` returns `Company[]` (the picker's existing call shape). `getCompaniesResult(...)` returns the full envelope for callers that need pagination metadata later.
- **`services/consignment.ts`** — drops the now-unused `getCHAs` helper.
- **`services/types/consignment.ts`** — `CreateConsignmentRequest.chaId` → `chaCompanyId` to match the backend DTO landing in #539.
- **`components/CHAPicker/CHASearch.tsx`** — file/component name kept; drop the client-side `useMemo` filter (server filters now), add a `loading` prop, update the placeholder (`"Search company…"`), and the dropdown copy (`"No companies found"` / `"CHA Company"` badge).
- **`screens/ConsignmentScreen.tsx`** — `NewConsignmentDialog` now owns the picker fetch. A 300ms-debounced `getCompanies({ hasCha: true, name })` runs whenever the search query (or open state) changes, with stale-request cancellation. Field rename throughout (`chaId` → `chaCompanyId`); dead screen-level CHA fetch effect removed; `chaOptions` prop dropped from the dialog.

## Testing

- [x] I have tested this change locally
- [ ] I have added unit tests for new functionality
- [x] I have tested edge cases
- [x] All existing tests pass

Verification performed:
- `pnpm tsc -b` (or `node_modules/.bin/tsc -b`) — clean.
- End-to-end against a locally-running backend with #533 + #539 applied:
  - Log in as Suresh (trader at ADAM PVT LTD), click "New Consignment", focus the picker, type "ada" → ADAM PVT LTD appears (server-side filtered via `?name=ada`).
  - Select ADAM PVT LTD, pick IMPORT, submit → POST sends `{ flow:"IMPORT", chaCompanyId:"adam-pvt-ltd" }`; backend row has `cha_company_id = adam-pvt-ltd` and `cha_id IS NULL`.
  - Typing a non-matching query ("zzz") shows the "No companies found" empty state with the loading spinner during the debounce.

No new unit tests added — the trader-app has minimal component-test coverage today and adding the first one for this picker is out of scope. Manual verification stands in.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have checked that there are no merge conflicts

## Related Issues

<!-- Final PR in the wiring stack. Backend siblings: #533 (merged) and #539 (open). -->

## Screenshots/Demo

(no screenshot attached — straightforward picker swap; UI shape unchanged, only the data source and the empty-state copy differ)

## Additional Notes

- **Merge order matters**: please land this after #539. Until then, the runtime payload field `chaCompanyId` won't match the backend's expected `chaId` and Stage 1 creation will fail.
- The picker keeps its `CHAPicker/CHASearch` file and component names deliberately — the user-facing concept ("pick a CHA") is unchanged; only the underlying entity is now a CHA *company*. Renaming the directory would have churned every import on the trader-app side for no semantic gain.
- The envelope-aware `getCompaniesResult` is exposed (alongside the simpler `getCompanies`) so future callers that want `total`/`offset`/`limit` don't have to refactor the helper when backend pagination lands.

## Deployment Notes

- Frontend-only change. Build the trader-app with the usual pipeline; no backend / IdP / migrations action needed.
- If #539 has not yet shipped to the same environment, expect Stage 1 creates to fail until it does — coordinate the trader-app deploy with the backend deploy.