### PR TITLE
Allow portal setup without Corepack

### DIFF
--- a/portals/Makefile
+++ b/portals/Makefile
@@ -26,15 +26,20 @@ help:
 	@echo "  make type-check     - Run TypeScript type checking"
 	@echo ""
 
-# Setup pnpm via corepack (reads version from package.json packageManager field)
+# Setup pnpm using the existing install first, then corepack as a fallback.
 setup:
 	@echo "🔧 Setting up development environment..."
-	@command -v corepack >/dev/null 2>&1 || { \
-		echo "❌ corepack not found — install Node.js 22+ (see docs/SETUP_WORKSPACE.md)"; \
+	@if command -v pnpm >/dev/null 2>&1; then \
+		echo "✅ pnpm already available"; \
+	elif command -v corepack >/dev/null 2>&1; then \
+		corepack enable pnpm; \
+		echo "✅ pnpm available via corepack"; \
+	else \
+		echo "❌ pnpm and corepack not found — install Node.js 22.18.0+ or pnpm 11.1.2 (see docs/SETUP_WORKSPACE.md)"; \
 		exit 1; \
-	}
-	@corepack enable
-	@echo "✅ pnpm available via corepack"
+	fi
+	@pnpm --version
+	@echo "✅ pnpm available"
 	@$(MAKE) install
 	@echo "✅ Setup complete!"
 

--- a/portals/docs/SETUP_WORKSPACE.md
+++ b/portals/docs/SETUP_WORKSPACE.md
@@ -74,10 +74,10 @@ node --version
 
 ### Step 4: Install pnpm
 
-pnpm will be automatically installed via **Corepack** (built into Node.js):
+You can use **Corepack** or an existing global `pnpm` install:
 
 ```bash
-# Enable Corepack (already included in Node 22+)
+# Enable Corepack (already included in Node 22+) if pnpm is not already installed
 corepack enable
 
 # Verify pnpm installation


### PR DESCRIPTION
## Summary
Allow `make setup` in `portals/` to use an existing global `pnpm` install before falling back to Corepack, so setup works on machines where `corepack` is unavailable.

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Documentation update

## Changes Made
- Updated `portals/Makefile` to prefer an existing `pnpm` binary and only enable Corepack if needed.
- Updated `portals/docs/SETUP_WORKSPACE.md` to reflect the supported bootstrap paths.

## Testing
- [x] I have tested this change locally
- [ ] I have added unit tests for new functionality
- [ ] I have tested edge cases
- [x] All existing tests pass

## Additional Notes
Validated with `cd /Users/saknarajapakshe/Documents/nsw/portals && make setup`.