### PR TITLE
feat(idp): add ou scope and ouHandle claim to ID token

### DIFF
--- a/idp/02-sample-resources.sh
+++ b/idp/02-sample-resources.sh
@@ -278,7 +278,8 @@ create_spa_application() {
                     "profile",
                     "email",
                     "group",
-                    "role"
+                    "role",
+                    "ou"
                 ],
                 "userInfo": {
                     "userAttributes": [
@@ -303,7 +304,8 @@ create_spa_application() {
                         "groups"
                     ],
                     "ou": [
-                        "ouId"
+                        "ouId",
+                        "ouHandle"
                     ],
                     "role": [
                         "roles"


### PR DESCRIPTION
## Summary

Adds the `ou` scope to the IDP configuration and exposes `ouHandle` alongside the existing `ouId` in the ID token's OU claims. This allows frontend applications to access both the OU identifier and OU handle directly from the token.

## Type of Change

- [x] New feature (non-breaking change which adds functionality)

## Changes Made

- `idp/02-sample-resources.sh`: Added `"ou"` to the SPA application's requested scopes array; added `"ouHandle"` to the `ou` claims block so both `ouId` and `ouHandle` are emitted in the ID token
- `.env.example`: Added `ou` to `IDP_SCOPES` so local dev environments include the scope by default
- `portals/apps/trader-app/src/main.tsx`: Simplified `IDP_SCOPES` assignment using optional chaining, removing the stale hardcoded fallback that predated the env-driven scope list

## Testing

- [x] I have tested this change locally
- [ ] I have added unit tests for new functionality
- [ ] I have tested edge cases
- [x] All existing tests pass

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings
- [x] I have checked that there are no merge conflicts

## Related Issues

<!-- Link relevant issues if applicable -->

## Additional Notes

The `main.tsx` fallback removal is safe because `VITE_IDP_SCOPES` is always expected to be set via the env config. If the env var is absent, `AsgardeoProvider` will receive `undefined` for `scopes` — verify the library's behaviour for this case if needed.

## Deployment Notes

Re-run `idp/02-sample-resources.sh` against any existing IDP instance to apply the updated scope and claims configuration.