### PR TITLE
chore: migrate dev tooling from oga/oga-app to nsw-agency

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -7,14 +7,6 @@
 IDP_PORT=8090
 BACKEND_PORT=8080
 TRADER_APP_PORT=5173
-OGA_APP_NPQS_PORT=5174
-OGA_APP_FCAU_PORT=5175
-OGA_APP_IRD_PORT=5176
-OGA_APP_CDA_PORT=5177
-OGA_NPQS_PORT=8081
-OGA_FCAU_PORT=8082
-OGA_IRD_PORT=8083
-OGA_CDA_PORT=8084
 
 # -------------------------------------------------------------------
 # Backend (Go + PostgreSQL)
@@ -35,9 +27,11 @@ SERVER_DEBUG=true
 SERVER_LOG_LEVEL=info
 
 # Include all local frontend origins used in development.
+# Ports 5174-5177 are used by nsw-agency portal frontends.
 CORS_ALLOWED_ORIGINS=http://localhost:3000,http://localhost:5173,http://localhost:5174,http://localhost:5175,http://localhost:5176,http://localhost:5177
 
 # Auth settings used by backend token validation.
+# AUTH_CLIENT_IDS includes both trader portal and agency M2M client IDs.
 AUTH_ISSUER=https://localhost:8090
 AUTH_JWKS_URL=https://localhost:8090/oauth2/jwks
 AUTH_CLIENT_IDS=TRADER_PORTAL_APP,FCAU_TO_NSW,NPQS_TO_NSW,IRD_TO_NSW,CDA_TO_NSW
@@ -56,65 +50,5 @@ TRADER_IDP_CLIENT_ID=TRADER_PORTAL_APP
 TRADER_IDP_TRADER_GROUP_NAME=Traders
 TRADER_IDP_CHA_GROUP_NAME=CHA
 
-
-NPQS_IDP_CLIENT_ID=OGA_PORTAL_APP_NPQS
-FCAU_IDP_CLIENT_ID=OGA_PORTAL_APP_FCAU
-IRD_IDP_CLIENT_ID=OGA_PORTAL_APP_IRD
-CDA_IDP_CLIENT_ID=OGA_PORTAL_APP_CDA
-
 # Feature flags
 SHOW_AUTOFILL_BUTTON=true
-
-# -------------------------------------------------------------------
-# OGA backends (two local instances)
-# -------------------------------------------------------------------
-OGA_FORMS_PATH=./data/forms
-OGA_DEFAULT_FORM_ID=default
-OGA_ALLOWED_ORIGINS=http://localhost:5174,http://localhost:5175,http://localhost:5176,http://localhost:5177
-
-# Database driver: sqlite | postgres
-OGA_DB_DRIVER=sqlite
-
-# SQLite settings (used if OGA_DB_DRIVER=sqlite)
-OGA_NPQS_DB_PATH=./npqs.db
-OGA_FCAU_DB_PATH=./fcau.db
-OGA_IRD_DB_PATH=./ird.db
-OGA_CDA_DB_PATH=./cda.db
-
-# PostgreSQL settings (used if OGA_DB_DRIVER=postgres)
-# Each OGA instance can use a different database or the same one.
-OGA_DB_HOST=localhost
-OGA_DB_PORT=5432
-OGA_DB_USER=postgres
-OGA_DB_PASSWORD=changeme
-OGA_DB_NAME=oga_db
-OGA_DB_SSLMODE=disable
-# OGA frontend branding config names
-OGA_APP_NPQS_BRANDING=npqs
-OGA_APP_FCAU_BRANDING=fcau
-OGA_APP_IRD_BRANDING=ird
-OGA_APP_CDA_BRANDING=cda
-
-# -------------------------------------------------------------------
-# OGA -> NSW outbound OAuth2 (required)
-# -------------------------------------------------------------------
-# Client IDs are created by idp/02-sample-resources.sh
-OGA_NSW_NPQS_CLIENT_ID=NPQS_TO_NSW
-OGA_NSW_FCAU_CLIENT_ID=FCAU_TO_NSW
-OGA_NSW_IRD_CLIENT_ID=IRD_TO_NSW
-OGA_NSW_CDA_CLIENT_ID=CDA_TO_NSW
-
-# Secrets match local IDP bootstrap defaults
-OGA_NSW_NPQS_CLIENT_SECRET=1234
-OGA_NSW_FCAU_CLIENT_SECRET=1234
-OGA_NSW_IRD_CLIENT_SECRET=1234
-OGA_NSW_CDA_CLIENT_SECRET=1234
-
-# Token endpoint for client credentials grant
-OGA_NSW_TOKEN_URL=https://localhost:8090/oauth2/token
-
-# Optional scopes (comma-separated)
-OGA_NSW_SCOPES=
-
-# DEV-ONLY: set to true to skip TLS verification for OAuth2 token endpoint (useful if IDP is using self-signed certs)
-OGA_NSW_TOKEN_INSECURE_SKIP_VERIFY=true

--- a/README.md
+++ b/README.md
@@ -39,8 +39,8 @@ NSW offers powerful capabilities that streamline international trade processes:
 |---------|--------|
 | **Core Workflow Engine (CWE)** – BPMN 2.0 based process orchestration managing process states without awareness of OGA-specific data schemas | In Progress |
 | **NSW Core Portal** – Single entry point for Traders to initiate consignments and track global status | In Progress |
-| **Tea Board Service Module** – Independent, pluggable unit with OGA-specific logic, database, and officer portal for Tea exports | In Progress |
-| **Coconut Board Service Module** – Independent, pluggable unit with OGA-specific logic, database, and officer portal for Coconut products | In Progress |
+| **Tea Board Agency Module** – Independent, pluggable unit with agency-specific logic, database, and officer portal for Tea exports | In Progress |
+| **Coconut Board Agency Module** – Independent, pluggable unit with agency-specific logic, database, and officer portal for Coconut products | In Progress |
 | **One-Time Verification** – Pre-consignment document injection (Business Registration, TIN, Environmental Protection License) | In Progress |
 | **Automated Notifications** – Email and SMS alerts via Postal service background worker | Planned |
 | **ASYCUDA Interface** – Automated handoff to Customs system upon completion of all OGA approvals | Planned |
@@ -141,6 +141,38 @@ Pull requests to `main` run Docker image validation through `.github/workflows/d
 - It runs only when relevant Docker build contexts change (`backend/**`, `oga/**`, `portals/**`) or when the workflow file changes.
 - It validates builds only and does **not** push/publish images.
 - Image publishing belongs to release CD workflows and is intentionally out of scope for this CI workflow.
+
+## Getting Started
+
+The full local dev setup runs two repos side-by-side: **nsw** (this repo) starts the core platform, and **nsw-agency** starts the agency portals.
+
+**Prerequisites:** Go, pnpm, Docker, Temporal CLI
+
+```bash
+# 1. Copy env file and adjust values
+cp .env.example .env
+
+# Terminal 1 – NSW core (IDP, Temporal, backend, trader-app)
+./start-dev.sh              # normal start
+./start-dev.sh --clean-run  # wipe DB + Docker volumes, re-migrate, then start
+
+# Terminal 2 – Agency portals (NPQS, FCAU, IRD, CDA)
+cd ../nsw-agency
+./start-dev.sh all              # normal start
+./start-dev.sh all --clean-run  # wipe agency DBs, then start
+```
+
+| Service | URL |
+|---------|-----|
+| Trader portal | http://localhost:5173 |
+| NSW backend API | http://localhost:8080 |
+| IDP | https://localhost:8090 |
+| NPQS agency portal | http://localhost:5174 |
+| FCAU agency portal | http://localhost:5175 |
+| IRD agency portal  | http://localhost:5176 |
+| CDA agency portal  | http://localhost:5177 |
+
+See [docs/DEPLOYMENT.md](docs/DEPLOYMENT.md) for Docker and Kubernetes deployment options.
 
 ## Contributing
 

--- a/backend/internal/database/migrations/004_insert_seed_workflow_node_templates.up.sql
+++ b/backend/internal/database/migrations/004_insert_seed_workflow_node_templates.up.sql
@@ -222,7 +222,7 @@ VALUES
         'Final Processing',
         'Final processing step — unlocks when both certificates are completed, or customs was fast-tracked',
         'WAIT_FOR_EVENT',
-        '{
+        ('{
             "display": {
                 "title": "Waiting for ship to leave from port",
                 "description": "The task will be completed when the ship leaves the port. This is an external event that we are waiting for."
@@ -242,6 +242,6 @@ VALUES
                     }
                 }
             }
-        }'
+        }')::jsonb
     ) ON CONFLICT (id) DO NOTHING;
 

--- a/backend/internal/database/migrations/004_insert_seed_workflow_node_templates.up.sql
+++ b/backend/internal/database/migrations/004_insert_seed_workflow_node_templates.up.sql
@@ -228,7 +228,7 @@ VALUES
                 "description": "The task will be completed when the ship leaves the port. This is an external event that we are waiting for."
             },
             "submission": {
-                "url": "http://localhost:8081/api/oga/inject",
+                "url": ' || to_jsonb((:'NPQS_OGA_SUBMISSION_URL')::text)::text || ',
                 "request": {
                     "taskCode": "ship_departure_v1",
                     "template": {

--- a/backend/internal/database/migrations/run.ps1
+++ b/backend/internal/database/migrations/run.ps1
@@ -33,10 +33,10 @@ foreach ($Var in $RequiredVars) {
 $MigrationDbHost = if ($env:MIGRATION_DB_HOST) { $env:MIGRATION_DB_HOST } else { $env:DB_HOST }
 $MigrationDbHost = $MigrationDbHost -replace "host.docker.internal", "localhost"
 
-$NpqsOgaSubmissionUrl = if ($env:NPQS_OGA_SUBMISSION_URL) { $env:NPQS_OGA_SUBMISSION_URL } else { "http://localhost:8081/api/oga/inject" }
-$FcauOgaSubmissionUrl = if ($env:FCAU_OGA_SUBMISSION_URL) { $env:FCAU_OGA_SUBMISSION_URL } else { "http://localhost:8082/api/oga/inject" }
-$PreconsignmentOgaSubmissionUrl = if ($env:PRECONSIGNMENT_OGA_SUBMISSION_URL) { $env:PRECONSIGNMENT_OGA_SUBMISSION_URL } else { "http://localhost:8083/api/oga/inject" }
-$CdaOgaSubmissionUrl = if ($env:CDA_OGA_SUBMISSION_URL) { $env:CDA_OGA_SUBMISSION_URL } else { "http://localhost:8084/api/oga/inject" }
+$NpqsOgaSubmissionUrl = if ($env:NPQS_OGA_SUBMISSION_URL) { $env:NPQS_OGA_SUBMISSION_URL } else { "http://localhost:8081/api/v1/inject" }
+$FcauOgaSubmissionUrl = if ($env:FCAU_OGA_SUBMISSION_URL) { $env:FCAU_OGA_SUBMISSION_URL } else { "http://localhost:8082/api/v1/inject" }
+$PreconsignmentOgaSubmissionUrl = if ($env:PRECONSIGNMENT_OGA_SUBMISSION_URL) { $env:PRECONSIGNMENT_OGA_SUBMISSION_URL } else { "http://localhost:8083/api/v1/inject" }
+$CdaOgaSubmissionUrl = if ($env:CDA_OGA_SUBMISSION_URL) { $env:CDA_OGA_SUBMISSION_URL } else { "http://localhost:8084/api/v1/inject" }
 
 # Handle Clean Run
 if (${clean-run}) {

--- a/backend/internal/database/migrations/run.sh
+++ b/backend/internal/database/migrations/run.sh
@@ -27,10 +27,10 @@ done
 MIGRATION_DB_HOST="${MIGRATION_DB_HOST:-$DB_HOST}"
 MIGRATION_DB_HOST="${MIGRATION_DB_HOST//host.docker.internal/localhost}"
 
-NPQS_OGA_SUBMISSION_URL="${NPQS_OGA_SUBMISSION_URL:-http://localhost:8081/api/oga/inject}"
-FCAU_OGA_SUBMISSION_URL="${FCAU_OGA_SUBMISSION_URL:-http://localhost:8082/api/oga/inject}"
-PRECONSIGNMENT_OGA_SUBMISSION_URL="${PRECONSIGNMENT_OGA_SUBMISSION_URL:-http://localhost:8083/api/oga/inject}"
-CDA_OGA_SUBMISSION_URL="${CDA_OGA_SUBMISSION_URL:-http://localhost:8084/api/oga/inject}"
+NPQS_OGA_SUBMISSION_URL="${NPQS_OGA_SUBMISSION_URL:-http://localhost:8081/api/v1/inject}"
+FCAU_OGA_SUBMISSION_URL="${FCAU_OGA_SUBMISSION_URL:-http://localhost:8082/api/v1/inject}"
+PRECONSIGNMENT_OGA_SUBMISSION_URL="${PRECONSIGNMENT_OGA_SUBMISSION_URL:-http://localhost:8083/api/v1/inject}"
+CDA_OGA_SUBMISSION_URL="${CDA_OGA_SUBMISSION_URL:-http://localhost:8084/api/v1/inject}"
 
 if [[ "$CLEAN_RUN" == "true" ]]; then
     echo "Dropping database $DB_NAME..."

--- a/backend/internal/task/plugin/simple_form.go
+++ b/backend/internal/task/plugin/simple_form.go
@@ -98,7 +98,7 @@ type SubmissionConfig struct {
 type SimpleFormExternalServiceRequest struct {
 	TaskCode           string             `json:"taskCode"` // Code to identify task config on external service side
 	TaskID             string             `json:"taskId"`
-	WorkflowID         string             `json:"workflowId"`
+	ConsignmentID      string             `json:"consignmentId"`
 	ServiceURL         string             `json:"serviceUrl"`
 	Data               map[string]any     `json:"data"` // Submitted trader form data
 	OGAFeedbackHistory []OGAFeedbackEntry `json:"ogaFeedbackHistory,omitempty"`
@@ -442,10 +442,10 @@ func (s *SimpleForm) submitHandler(ctx context.Context, content any) (*Execution
 	}
 
 	requestPayload := SimpleFormExternalServiceRequest{
-		TaskID:     s.api.GetTaskID(),
-		WorkflowID: s.api.GetWorkflowID(),
-		ServiceURL: strings.TrimRight(s.cfg.Server.ServiceURL, "/") + TasksAPIPath,
-		Data:       formData,
+		TaskID:        s.api.GetTaskID(),
+		ConsignmentID: s.api.GetWorkflowID(),
+		ServiceURL:    strings.TrimRight(s.cfg.Server.ServiceURL, "/") + TasksAPIPath,
+		Data:          formData,
 	}
 	if s.config.Submission != nil && s.config.Submission.Request != nil {
 		requestPayload.TaskCode = s.config.Submission.Request.TaskCode

--- a/start-dev.ps1
+++ b/start-dev.ps1
@@ -50,14 +50,6 @@ foreach ($cmd in $Dependencies) {
 $IDP_PORT = if ($env:IDP_PORT) { $env:IDP_PORT } else { "8090" }
 $BACKEND_PORT = if ($env:BACKEND_PORT) { $env:BACKEND_PORT } else { "8080" }
 $TRADER_APP_PORT = if ($env:TRADER_APP_PORT) { $env:TRADER_APP_PORT } else { "5173" }
-$OGA_APP_NPQS_PORT = if ($env:OGA_APP_NPQS_PORT) { $env:OGA_APP_NPQS_PORT } else { "5174" }
-$OGA_APP_FCAU_PORT = if ($env:OGA_APP_FCAU_PORT) { $env:OGA_APP_FCAU_PORT } else { "5175" }
-$OGA_APP_IRD_PORT = if ($env:OGA_APP_IRD_PORT) { $env:OGA_APP_IRD_PORT } else { "5176" }
-$OGA_APP_CDA_PORT = if ($env:OGA_APP_CDA_PORT) { $env:OGA_APP_CDA_PORT } else { "5177" }
-$OGA_NPQS_PORT = if ($env:OGA_NPQS_PORT) { $env:OGA_NPQS_PORT } else { "8081" }
-$OGA_FCAU_PORT = if ($env:OGA_FCAU_PORT) { $env:OGA_FCAU_PORT } else { "8082" }
-$OGA_IRD_PORT = if ($env:OGA_IRD_PORT) { $env:OGA_IRD_PORT } else { "8083" }
-$OGA_CDA_PORT = if ($env:OGA_CDA_PORT) { $env:OGA_CDA_PORT } else { "8084" }
 
 # Temporal settings
 $TEMPORAL_HOST = if ($env:TEMPORAL_HOST) { $env:TEMPORAL_HOST } else { "localhost" }
@@ -83,99 +75,12 @@ $AUTH_JWKS_INSECURE_SKIP_VERIFY = if ($env:AUTH_JWKS_INSECURE_SKIP_VERIFY) { $en
 
 $IDP_PUBLIC_URL = if ($env:IDP_PUBLIC_URL) { $env:IDP_PUBLIC_URL } else { "https://localhost:$IDP_PORT" }
 $TRADER_IDP_CLIENT_ID = if ($env:TRADER_IDP_CLIENT_ID) { $env:TRADER_IDP_CLIENT_ID } else { "TRADER_PORTAL_APP" }
-$NPQS_IDP_CLIENT_ID = if ($env:NPQS_IDP_CLIENT_ID) { $env:NPQS_IDP_CLIENT_ID } else { "OGA_PORTAL_APP_NPQS" }
-$FCAU_IDP_CLIENT_ID = if ($env:FCAU_IDP_CLIENT_ID) { $env:FCAU_IDP_CLIENT_ID } else { "OGA_PORTAL_APP_FCAU" }
-$IRD_IDP_CLIENT_ID = if ($env:IRD_IDP_CLIENT_ID) { $env:IRD_IDP_CLIENT_ID } else { "OGA_PORTAL_APP_IRD" }
-$CDA_IDP_CLIENT_ID = if ($env:CDA_IDP_CLIENT_ID) { $env:CDA_IDP_CLIENT_ID } else { "OGA_PORTAL_APP_CDA" }
 $IDP_SCOPES = if ($env:IDP_SCOPES) { $env:IDP_SCOPES } else { "openid,profile,email,group,role" }
 $IDP_PLATFORM = if ($env:IDP_PLATFORM) { $env:IDP_PLATFORM } else { "AsgardeoV2" }
 $SHOW_AUTOFILL_BUTTON = if ($env:SHOW_AUTOFILL_BUTTON) { $env:SHOW_AUTOFILL_BUTTON } else { "true" }
 $TRADER_IDP_TRADER_GROUP_NAME = if ($env:TRADER_IDP_TRADER_GROUP_NAME) { $env:TRADER_IDP_TRADER_GROUP_NAME } else { "Traders" }
 $TRADER_IDP_CHA_GROUP_NAME = if ($env:TRADER_IDP_CHA_GROUP_NAME) { $env:TRADER_IDP_CHA_GROUP_NAME } else { "CHA" }
 
-$OGA_FORMS_PATH = if ($env:OGA_FORMS_PATH) { $env:OGA_FORMS_PATH } else { "./data/forms" }
-$OGA_DEFAULT_FORM_ID = if ($env:OGA_DEFAULT_FORM_ID) { $env:OGA_DEFAULT_FORM_ID } else { "default" }
-$OGA_ALLOWED_ORIGINS = if ($env:OGA_ALLOWED_ORIGINS) { $env:OGA_ALLOWED_ORIGINS } else { "*" }
-
-$OGA_DB_DRIVER = if ($env:OGA_DB_DRIVER) { $env:OGA_DB_DRIVER } else { "sqlite" }
-$OGA_DB_HOST = if ($env:OGA_DB_HOST) { $env:OGA_DB_HOST } else { "localhost" }
-$OGA_DB_PORT = if ($env:OGA_DB_PORT) { $env:OGA_DB_PORT } else { "5432" }
-$OGA_DB_USER = if ($env:OGA_DB_USER) { $env:OGA_DB_USER } else { "postgres" }
-$OGA_DB_PASSWORD = if ($env:OGA_DB_PASSWORD) { $env:OGA_DB_PASSWORD } else { "changeme" }
-$OGA_DB_NAME = if ($env:OGA_DB_NAME) { $env:OGA_DB_NAME } else { "oga_db" }
-$OGA_DB_SSLMODE = if ($env:OGA_DB_SSLMODE) { $env:OGA_DB_SSLMODE } else { "disable" }
-
-$OGA_NPQS_DB_PATH = if ($env:OGA_NPQS_DB_PATH) { $env:OGA_NPQS_DB_PATH } else { "./npqs.db" }
-$OGA_FCAU_DB_PATH = if ($env:OGA_FCAU_DB_PATH) { $env:OGA_FCAU_DB_PATH } else { "./fcau.db" }
-$OGA_IRD_DB_PATH = if ($env:OGA_IRD_DB_PATH) { $env:OGA_IRD_DB_PATH } else { "./ird.db" }
-$OGA_CDA_DB_PATH = if ($env:OGA_CDA_DB_PATH) { $env:OGA_CDA_DB_PATH } else { "./cda.db" }
-$OGA_APP_NPQS_BRANDING = if ($env:OGA_APP_NPQS_BRANDING) { $env:OGA_APP_NPQS_BRANDING } else { "npqs" }
-$OGA_APP_FCAU_BRANDING = if ($env:OGA_APP_FCAU_BRANDING) { $env:OGA_APP_FCAU_BRANDING } else { "fcau" }
-$OGA_APP_IRD_BRANDING = if ($env:OGA_APP_IRD_BRANDING) { $env:OGA_APP_IRD_BRANDING } else { "ird" }
-$OGA_APP_CDA_BRANDING = if ($env:OGA_APP_CDA_BRANDING) { $env:OGA_APP_CDA_BRANDING } else { "cda" }
-
-$OGA_NSW_NPQS_CLIENT_ID = if ($env:OGA_NSW_NPQS_CLIENT_ID) { $env:OGA_NSW_NPQS_CLIENT_ID } else { "NPQS_TO_NSW" }
-$OGA_NSW_FCAU_CLIENT_ID = if ($env:OGA_NSW_FCAU_CLIENT_ID) { $env:OGA_NSW_FCAU_CLIENT_ID } else { "FCAU_TO_NSW" }
-$OGA_NSW_IRD_CLIENT_ID = if ($env:OGA_NSW_IRD_CLIENT_ID) { $env:OGA_NSW_IRD_CLIENT_ID } else { "IRD_TO_NSW" }
-$OGA_NSW_CDA_CLIENT_ID = if ($env:OGA_NSW_CDA_CLIENT_ID) { $env:OGA_NSW_CDA_CLIENT_ID } else { "CDA_TO_NSW" }
-$OGA_NSW_NPQS_CLIENT_SECRET = if ($env:OGA_NSW_NPQS_CLIENT_SECRET) { $env:OGA_NSW_NPQS_CLIENT_SECRET } else { "1234" }
-$OGA_NSW_FCAU_CLIENT_SECRET = if ($env:OGA_NSW_FCAU_CLIENT_SECRET) { $env:OGA_NSW_FCAU_CLIENT_SECRET } else { "1234" }
-$OGA_NSW_IRD_CLIENT_SECRET = if ($env:OGA_NSW_IRD_CLIENT_SECRET) { $env:OGA_NSW_IRD_CLIENT_SECRET } else { "1234" }
-$OGA_NSW_CDA_CLIENT_SECRET = if ($env:OGA_NSW_CDA_CLIENT_SECRET) { $env:OGA_NSW_CDA_CLIENT_SECRET } else { "1234" }
-$OGA_NSW_TOKEN_URL = if ($env:OGA_NSW_TOKEN_URL) { $env:OGA_NSW_TOKEN_URL } else { "https://localhost:$IDP_PORT/oauth2/token" }
-$OGA_NSW_SCOPES = if ($env:OGA_NSW_SCOPES) { $env:OGA_NSW_SCOPES } else { "" }
-$OGA_NSW_TOKEN_INSECURE_SKIP_VERIFY = if ($env:OGA_NSW_TOKEN_INSECURE_SKIP_VERIFY) { $env:OGA_NSW_TOKEN_INSECURE_SKIP_VERIFY } else { "true" }
-
-# OGA Registry
-$OGA_INSTANCES = @(
-    @{ Name="npqs"; Port=$OGA_NPQS_PORT; DbPath=$OGA_NPQS_DB_PATH; NswClientId=$OGA_NSW_NPQS_CLIENT_ID; NswClientSecret=$OGA_NSW_NPQS_CLIENT_SECRET; AppPort=$OGA_APP_NPQS_PORT; BrandingName=$OGA_APP_NPQS_BRANDING; IdpClientId=$NPQS_IDP_CLIENT_ID; AppName="National Plant Quarantine Service (NPQS)" },
-    @{ Name="fcau"; Port=$OGA_FCAU_PORT; DbPath=$OGA_FCAU_DB_PATH; NswClientId=$OGA_NSW_FCAU_CLIENT_ID; NswClientSecret=$OGA_NSW_FCAU_CLIENT_SECRET; AppPort=$OGA_APP_FCAU_PORT; BrandingName=$OGA_APP_FCAU_BRANDING; IdpClientId=$FCAU_IDP_CLIENT_ID; AppName="Food Control Administration Unit (FCAU)" },
-    @{ Name="ird"; Port=$OGA_IRD_PORT; DbPath=$OGA_IRD_DB_PATH; NswClientId=$OGA_NSW_IRD_CLIENT_ID; NswClientSecret=$OGA_NSW_IRD_CLIENT_SECRET; AppPort=$OGA_APP_IRD_PORT; BrandingName=$OGA_APP_IRD_BRANDING; IdpClientId=$IRD_IDP_CLIENT_ID; AppName="Inland Revenue Department (IRD)" },
-    @{ Name="cda"; Port=$OGA_CDA_PORT; DbPath=$OGA_CDA_DB_PATH; NswClientId=$OGA_NSW_CDA_CLIENT_ID; NswClientSecret=$OGA_NSW_CDA_CLIENT_SECRET; AppPort=$OGA_APP_CDA_PORT; BrandingName=$OGA_APP_CDA_BRANDING; IdpClientId=$CDA_IDP_CLIENT_ID; AppName="Coconut Development Authority (CDA)" }
-)
-
-function ensure_branding_file($BrandingName, $AppName) {
-    $ConfigDir = Join-Path $ROOT_DIR "portals/apps/oga-app/public/configs"
-    $FilePath = Join-Path $ConfigDir "${BrandingName}.branding.json"
-    if (-not (Test-Path $FilePath)) {
-        New-Item -ItemType Directory -Path $ConfigDir -Force | Out-Null
-        $Content = @"
-{
-  "branding": {
-    "systemName": "NSW",
-    "appName": "$AppName",
-    "logoUrl": "",
-    "systemLogoUrl": "",
-    "favicon": "",
-    "portalName": "",
-    "description": "",
-    "heroImageUrl": "",
-    "partnerLogos": [
-      {
-        "url": "",
-        "alt": ""
-      }
-    ]
-  }
-}
-"@
-        Set-Content -Path $FilePath -Value $Content -Encoding utf8
-    }
-}
-
-
-function ensure_node_modules() {
-    $PortalsDir = Join-Path $ROOT_DIR "portals"
-    $OgaAppModules = Join-Path $PortalsDir "apps/oga-app/node_modules"
-    $TraderAppModules = Join-Path $PortalsDir "apps/trader-app/node_modules"
-
-    if ((-not (Test-Path $OgaAppModules)) -or (-not (Test-Path $TraderAppModules))) {
-        Write-Host "Missing node_modules in frontend apps. Running pnpm install in $PortalsDir..."
-        Push-Location $PortalsDir
-        pnpm install
-        Pop-Location
-    }
-}
 
 function wait_for_temporal() {
     $Retries = 30
@@ -195,39 +100,6 @@ function wait_for_temporal() {
     exit 1
 }
 
-function clean_oga_databases() {
-    Write-Host "Cleaning OGA databases (driver: $OGA_DB_DRIVER)..."
-    if ($OGA_DB_DRIVER -eq "sqlite") {
-        foreach ($Instance in $OGA_INSTANCES) {
-            $DbPath = $Instance.DbPath
-            $ResolvedPath = ""
-            if ([System.IO.Path]::IsPathRooted($DbPath)) {
-                $ResolvedPath = $DbPath
-            } else {
-                $RelativePath = $DbPath -replace '^\./', ''
-                $ResolvedPath = Join-Path $ROOT_DIR "oga/$RelativePath"
-            }
-
-            if (Test-Path $ResolvedPath) {
-                Write-Host "  Deleting SQLite DB for $($Instance.Name): $ResolvedPath"
-                Remove-Item -Path $ResolvedPath -Force
-            } else {
-                Write-Host "  SQLite DB for $($Instance.Name) not found (nothing to delete): $ResolvedPath"
-            }
-        }
-    } elseif ($OGA_DB_DRIVER -eq "postgres") {
-        if (-not (Get-Command psql -ErrorAction SilentlyContinue)) {
-            Write-Error "psql is required for Postgres DB cleaning but was not found in PATH"
-            exit 1
-        }
-        $env:PGPASSWORD = $OGA_DB_PASSWORD
-        Write-Host "  Dropping and recreating Postgres database: $OGA_DB_NAME"
-        $TermQuery = "SELECT pg_terminate_backend(pid) FROM pg_stat_activity WHERE datname = '$OGA_DB_NAME' AND pid <> pg_backend_pid();"
-        & psql -h $OGA_DB_HOST -p $OGA_DB_PORT -U $OGA_DB_USER -d postgres -c $TermQuery | Out-Null
-        & psql -h $OGA_DB_HOST -p $OGA_DB_PORT -U $OGA_DB_USER -d postgres -c "DROP DATABASE IF EXISTS `"$OGA_DB_NAME`";"
-        & psql -h $OGA_DB_HOST -p $OGA_DB_PORT -U $OGA_DB_USER -d postgres -c "CREATE DATABASE `"$OGA_DB_NAME`";"
-    }
-}
 
 $script:Jobs = @()
 
@@ -249,7 +121,6 @@ if ($CLEAN_RUN -eq "true") {
         Write-Host "Removing Temporal containers and volumes..."
         docker compose -f (Join-Path $ROOT_DIR "temporal/docker-compose.yml") down --volumes
     }
-    clean_oga_databases
 }
 
 if (${clean-run} -or ${migrations}) {
@@ -274,67 +145,6 @@ if ($RUN_TEMPORAL) {
 }
 
 Write-Host "Starting local development services..."
-
-# Start OGA Services
-ensure_node_modules
-foreach ($Instance in $OGA_INSTANCES) {
-    $OgaEnv = @{
-        OGA_PORT = $Instance.Port
-        OGA_DB_DRIVER = $OGA_DB_DRIVER
-        OGA_DB_PATH = $Instance.DbPath
-        OGA_DB_HOST = $OGA_DB_HOST
-        OGA_DB_PORT = $OGA_DB_PORT
-        OGA_DB_USER = $OGA_DB_USER
-        OGA_DB_PASSWORD = $OGA_DB_PASSWORD
-        OGA_DB_NAME = $OGA_DB_NAME
-        OGA_DB_SSLMODE = $OGA_DB_SSLMODE
-        OGA_FORMS_PATH = $OGA_FORMS_PATH
-        OGA_DEFAULT_FORM_ID = $OGA_DEFAULT_FORM_ID
-        OGA_ALLOWED_ORIGINS = $OGA_ALLOWED_ORIGINS
-        OGA_NSW_API_BASE_URL = "http://localhost:${BACKEND_PORT}/api/v1"
-        OGA_NSW_CLIENT_ID = $Instance.NswClientId
-        OGA_NSW_CLIENT_SECRET = $Instance.NswClientSecret
-        OGA_NSW_TOKEN_URL = $OGA_NSW_TOKEN_URL
-        OGA_NSW_SCOPES = $OGA_NSW_SCOPES
-        OGA_NSW_TOKEN_INSECURE_SKIP_VERIFY = $OGA_NSW_TOKEN_INSECURE_SKIP_VERIFY
-    }
-    Start-ServiceJob -Name "oga-$($Instance.Name)" -Dir (Join-Path $ROOT_DIR "oga") -EnvVars $OgaEnv -ScriptBlock {
-        param($Name, $Dir, $EnvVars)
-        foreach ($Key in $EnvVars.Keys) { Set-Item "env:$Key" $EnvVars[$Key] }
-        Set-Location $Dir
-        go run ./cmd/server 2>&1 | ForEach-Object { Write-Host "[$Name] $_" }
-    }
-    # Small delay to prevent resource contention during Go compilation
-    Start-Sleep -Seconds 2
-
-    ensure_branding_file "$($Instance.BrandingName)" "$($Instance.AppName)"
-
-    # For the first OGA instance, wait longer to allow database migrations to finish
-    # before starting other instances in parallel to avoid Postgres race conditions.
-    if ($Instance.Name -eq $OGA_INSTANCES[0].Name -and $OGA_DB_DRIVER -eq "postgres") {
-        Write-Host "Waiting for OGA database migrations to complete..."
-        Start-Sleep -Seconds 10
-    }
-
-    $OgaAppEnv = @{
-        VITE_PORT = $Instance.AppPort
-        VITE_BRANDING_NAME = $Instance.BrandingName
-        VITE_API_BASE_URL = "http://localhost:$($Instance.Port)"
-        VITE_IDP_BASE_URL = $IDP_PUBLIC_URL
-        VITE_IDP_CLIENT_ID = $Instance.IdpClientId
-        VITE_APP_URL = "http://localhost:$($Instance.AppPort)"
-        VITE_IDP_SCOPES = $IDP_SCOPES
-        VITE_IDP_PLATFORM = $IDP_PLATFORM
-    }
-    Start-ServiceJob -Name "oga-app-$($Instance.Name)" -Dir (Join-Path $ROOT_DIR "portals/apps/oga-app") -EnvVars $OgaAppEnv -ScriptBlock {
-        param($Name, $Dir, $EnvVars)
-        foreach ($Key in $EnvVars.Keys) { Set-Item "env:$Key" $EnvVars[$Key] }
-        Set-Location $Dir
-        pnpm run dev 2>&1 | ForEach-Object { Write-Host "[$Name] $_" }
-    }
-    # Small delay to prevent Vite filesystem conflicts in the shared oga-app directory
-    Start-Sleep -Seconds 2
-}
 
 # Trader App
 $TraderEnv = @{
@@ -393,10 +203,6 @@ Write-Host ""
 Write-Host "Started local services:"
 Write-Host "  - backend       -> http://localhost:$BACKEND_PORT"
 Write-Host "  - trader-app    -> http://localhost:$TRADER_APP_PORT"
-foreach ($Instance in $OGA_INSTANCES) {
-    Write-Host ("  - oga-{0,-9} -> http://localhost:{1}" -f $Instance.Name, $Instance.Port)
-    Write-Host ("  - oga-app-{0,-5} -> http://localhost:{1}" -f $Instance.Name, $Instance.AppPort)
-}
 Write-Host ""
 Write-Host "IDP running:      $RUN_IDP"
 Write-Host "Temporal running: $RUN_TEMPORAL"

--- a/start-dev.sh
+++ b/start-dev.sh
@@ -51,14 +51,6 @@ done
 IDP_PORT="${IDP_PORT:-8090}"
 BACKEND_PORT="${BACKEND_PORT:-8080}"
 TRADER_APP_PORT="${TRADER_APP_PORT:-5173}"
-OGA_APP_NPQS_PORT="${OGA_APP_NPQS_PORT:-5174}"
-OGA_APP_FCAU_PORT="${OGA_APP_FCAU_PORT:-5175}"
-OGA_APP_IRD_PORT="${OGA_APP_IRD_PORT:-5176}"
-OGA_APP_CDA_PORT="${OGA_APP_CDA_PORT:-5177}"
-OGA_NPQS_PORT="${OGA_NPQS_PORT:-8081}"
-OGA_FCAU_PORT="${OGA_FCAU_PORT:-8082}"
-OGA_IRD_PORT="${OGA_IRD_PORT:-8083}"
-OGA_CDA_PORT="${OGA_CDA_PORT:-8084}"
 
 # Temporal settings with env var fallbacks
 TEMPORAL_HOST="${TEMPORAL_HOST:-localhost}"
@@ -86,90 +78,11 @@ AUTH_JWKS_INSECURE_SKIP_VERIFY="${AUTH_JWKS_INSECURE_SKIP_VERIFY:-true}"
 # Trader App settings with defaults and fallbacks
 IDP_PUBLIC_URL="${IDP_PUBLIC_URL:-https://localhost:${IDP_PORT}}"
 TRADER_IDP_CLIENT_ID="${TRADER_IDP_CLIENT_ID:-TRADER_PORTAL_APP}"
-NPQS_IDP_CLIENT_ID="${NPQS_IDP_CLIENT_ID:-OGA_PORTAL_APP_NPQS}"
-FCAU_IDP_CLIENT_ID="${FCAU_IDP_CLIENT_ID:-OGA_PORTAL_APP_FCAU}"
-IRD_IDP_CLIENT_ID="${IRD_IDP_CLIENT_ID:-OGA_PORTAL_APP_IRD}"
-CDA_IDP_CLIENT_ID="${CDA_IDP_CLIENT_ID:-OGA_PORTAL_APP_CDA}"
 IDP_SCOPES="${IDP_SCOPES:-openid,profile,email,group,role}"
 IDP_PLATFORM="${IDP_PLATFORM:-AsgardeoV2}"
 SHOW_AUTOFILL_BUTTON="${SHOW_AUTOFILL_BUTTON:-true}"
 TRADER_IDP_TRADER_GROUP_NAME="${TRADER_IDP_TRADER_GROUP_NAME:-Traders}"
 TRADER_IDP_CHA_GROUP_NAME="${TRADER_IDP_CHA_GROUP_NAME:-CHA}"
-
-# OGA settings with defaults and fallbacks
-OGA_FORMS_PATH="${OGA_FORMS_PATH:-./data/forms}"
-OGA_DEFAULT_FORM_ID="${OGA_DEFAULT_FORM_ID:-default}"
-OGA_ALLOWED_ORIGINS="${OGA_ALLOWED_ORIGINS:-*}"
-
-OGA_DB_DRIVER="${OGA_DB_DRIVER:-sqlite}"
-OGA_DB_HOST="${OGA_DB_HOST:-localhost}"
-OGA_DB_PORT="${OGA_DB_PORT:-5432}"
-OGA_DB_USER="${OGA_DB_USER:-postgres}"
-OGA_DB_PASSWORD="${OGA_DB_PASSWORD:-changeme}"
-OGA_DB_NAME="${OGA_DB_NAME:-oga_db}"
-OGA_DB_SSLMODE="${OGA_DB_SSLMODE:-disable}"
-
-OGA_NPQS_DB_PATH="${OGA_NPQS_DB_PATH:-./npqs.db}"
-OGA_FCAU_DB_PATH="${OGA_FCAU_DB_PATH:-./fcau.db}"
-OGA_IRD_DB_PATH="${OGA_IRD_DB_PATH:-./ird.db}"
-OGA_CDA_DB_PATH="${OGA_CDA_DB_PATH:-./cda.db}"
-OGA_APP_NPQS_BRANDING="${OGA_APP_NPQS_BRANDING:-npqs}"
-OGA_APP_FCAU_BRANDING="${OGA_APP_FCAU_BRANDING:-fcau}"
-OGA_APP_IRD_BRANDING="${OGA_APP_IRD_BRANDING:-ird}"
-OGA_APP_CDA_BRANDING="${OGA_APP_CDA_BRANDING:-cda}"
-
-OGA_NSW_NPQS_CLIENT_ID="${OGA_NSW_NPQS_CLIENT_ID:-NPQS_TO_NSW}"
-OGA_NSW_FCAU_CLIENT_ID="${OGA_NSW_FCAU_CLIENT_ID:-FCAU_TO_NSW}"
-OGA_NSW_IRD_CLIENT_ID="${OGA_NSW_IRD_CLIENT_ID:-IRD_TO_NSW}"
-OGA_NSW_CDA_CLIENT_ID="${OGA_NSW_CDA_CLIENT_ID:-CDA_TO_NSW}"
-OGA_NSW_NPQS_CLIENT_SECRET="${OGA_NSW_NPQS_CLIENT_SECRET:-1234}"
-OGA_NSW_FCAU_CLIENT_SECRET="${OGA_NSW_FCAU_CLIENT_SECRET:-1234}"
-OGA_NSW_IRD_CLIENT_SECRET="${OGA_NSW_IRD_CLIENT_SECRET:-1234}"
-OGA_NSW_CDA_CLIENT_SECRET="${OGA_NSW_CDA_CLIENT_SECRET:-1234}"
-OGA_NSW_TOKEN_URL="${OGA_NSW_TOKEN_URL:-https://localhost:${IDP_PORT}/oauth2/token}"
-OGA_NSW_SCOPES="${OGA_NSW_SCOPES:-}"
-OGA_NSW_TOKEN_INSECURE_SKIP_VERIFY="${OGA_NSW_TOKEN_INSECURE_SKIP_VERIFY:-true}"
-
-# OGA instance registry
-# Each row: name | backend_port | db_path | nsw_client_id | nsw_client_secret | app_port | branding_name | idp_client_id | app_name
-OGA_INSTANCES=(
-  "npqs|$OGA_NPQS_PORT|$OGA_NPQS_DB_PATH|$OGA_NSW_NPQS_CLIENT_ID|$OGA_NSW_NPQS_CLIENT_SECRET|$OGA_APP_NPQS_PORT|$OGA_APP_NPQS_BRANDING|$NPQS_IDP_CLIENT_ID|National Plant Quarantine Service (NPQS)"
-  "fcau|$OGA_FCAU_PORT|$OGA_FCAU_DB_PATH|$OGA_NSW_FCAU_CLIENT_ID|$OGA_NSW_FCAU_CLIENT_SECRET|$OGA_APP_FCAU_PORT|$OGA_APP_FCAU_BRANDING|$FCAU_IDP_CLIENT_ID|Food Control Administration Unit (FCAU)"
-  "ird|$OGA_IRD_PORT|$OGA_IRD_DB_PATH|$OGA_NSW_IRD_CLIENT_ID|$OGA_NSW_IRD_CLIENT_SECRET|$OGA_APP_IRD_PORT|$OGA_APP_IRD_BRANDING|$IRD_IDP_CLIENT_ID|Inland Revenue Department (IRD)"
-  "cda|$OGA_CDA_PORT|$OGA_CDA_DB_PATH|$OGA_NSW_CDA_CLIENT_ID|$OGA_NSW_CDA_CLIENT_SECRET|$OGA_APP_CDA_PORT|$OGA_APP_CDA_BRANDING|$CDA_IDP_CLIENT_ID|Coconut Development Authority (CDA)"
-)
-
-ensure_branding_file() {
-  local branding_name="$1"
-  local app_name="$2"
-  local config_dir="$ROOT_DIR/portals/apps/oga-app/public/configs"
-  local file_path="${config_dir}/${branding_name}.branding.json"
-  if [[ ! -f "$file_path" ]]; then
-    mkdir -p "$config_dir"
-    cat >"$file_path" <<EOF
-{
-  "branding": {
-    "systemName": "NSW",
-    "appName": "${app_name}",
-    "logoUrl": "",
-    "systemLogoUrl": "",
-    "favicon": "",
-    "portalName": "",
-    "description": "",
-    "heroImageUrl": "",
-    "partnerLogos": [
-      {
-        "url": "",
-        "alt": ""
-      }
-    ]
-  }
-}
-EOF
-  fi
-}
-
-
 
 # ---------------------------------------------------------------------------
 # wait_for_temporal: wait until Temporal's gRPC endpoint is fully ready
@@ -198,55 +111,6 @@ wait_for_temporal() {
   exit 1
 }
 
-# ---------------------------------------------------------------------------
-# clean_oga_databases: wipe OGA databases before starting backends.
-#   SQLite  -> delete the .db file
-#   Postgres -> drop and recreate the database
-# ---------------------------------------------------------------------------
-clean_oga_databases() {
-  echo "Cleaning OGA databases (driver: $OGA_DB_DRIVER)..."
-
-  if [[ "$OGA_DB_DRIVER" == "sqlite" ]]; then
-    for entry in "${OGA_INSTANCES[@]}"; do
-      IFS='|' read -r name _ db_path _ _ _ _ _ <<< "$entry"
-
-      local resolved_path
-      if [[ "$db_path" == /* ]]; then
-        resolved_path="$db_path"
-      else
-        resolved_path="$ROOT_DIR/oga/${db_path#./}"
-      fi
-
-      if [[ -f "$resolved_path" ]]; then
-        echo "  Deleting SQLite DB for $name: $resolved_path"
-        rm -f "$resolved_path"
-      else
-        echo "  SQLite DB for $name not found (nothing to delete): $resolved_path"
-      fi
-    done
-
-  elif [[ "$OGA_DB_DRIVER" == "postgres" ]]; then
-    if ! command -v psql >/dev/null 2>&1; then
-      echo "psql is required for Postgres DB cleaning but was not found in PATH"
-      exit 1
-    fi
-
-    local psql_opts=(-h "$OGA_DB_HOST" -p "$OGA_DB_PORT" -U "$OGA_DB_USER")
-
-    echo "  Dropping and recreating Postgres database: $OGA_DB_NAME"
-    PGPASSWORD="$OGA_DB_PASSWORD" psql "${psql_opts[@]}" -d postgres -c \
-      "SELECT pg_terminate_backend(pid)
-         FROM pg_stat_activity
-        WHERE datname = '$OGA_DB_NAME'
-          AND pid <> pg_backend_pid();" \
-      >/dev/null
-    PGPASSWORD="$OGA_DB_PASSWORD" psql "${psql_opts[@]}" -d postgres -c "DROP DATABASE IF EXISTS \"$OGA_DB_NAME\";"
-    PGPASSWORD="$OGA_DB_PASSWORD" psql "${psql_opts[@]}" -d postgres -c "CREATE DATABASE \"$OGA_DB_NAME\";"
-
-  else
-    echo "Unknown OGA_DB_DRIVER '$OGA_DB_DRIVER'; skipping OGA DB clean."
-  fi
-}
 
 # ---------------------------------------------------------------------------
 # MAIN SCRIPT
@@ -310,8 +174,6 @@ if [[ "$CLEAN_RUN" == "true" ]]; then
     docker compose -f "$ROOT_DIR/temporal/docker-compose.yml" down --volumes
   fi
 
-  clean_oga_databases
-
   echo "Running backend migrations..."
   (
     cd "$ROOT_DIR/backend/internal/database/migrations"
@@ -338,45 +200,6 @@ fi
 # START NON-DOCKER SERVICES
 # ---------------------------------------------------------------------------
 echo "Starting local development services..."
-
-# OGA backends and frontends can start immediately — no Temporal dependency
-for entry in "${OGA_INSTANCES[@]}"; do
-  IFS='|' read -r name port db_path nsw_client_id nsw_client_secret app_port branding_name idp_client_id app_name<<< "$entry"
-
-  start_service "oga-${name}" "$ROOT_DIR/oga" env \
-    OGA_PORT="$port" \
-    OGA_DB_DRIVER="$OGA_DB_DRIVER" \
-    OGA_DB_PATH="$db_path" \
-    OGA_DB_HOST="$OGA_DB_HOST" \
-    OGA_DB_PORT="$OGA_DB_PORT" \
-    OGA_DB_USER="$OGA_DB_USER" \
-    OGA_DB_PASSWORD="$OGA_DB_PASSWORD" \
-    OGA_DB_NAME="$OGA_DB_NAME" \
-    OGA_DB_SSLMODE="$OGA_DB_SSLMODE" \
-    OGA_FORMS_PATH="$OGA_FORMS_PATH" \
-    OGA_DEFAULT_FORM_ID="$OGA_DEFAULT_FORM_ID" \
-    OGA_ALLOWED_ORIGINS="$OGA_ALLOWED_ORIGINS" \
-    OGA_NSW_API_BASE_URL="http://localhost:${BACKEND_PORT}/api/v1" \
-    OGA_NSW_CLIENT_ID="$nsw_client_id" \
-    OGA_NSW_CLIENT_SECRET="$nsw_client_secret" \
-    OGA_NSW_TOKEN_URL="$OGA_NSW_TOKEN_URL" \
-    OGA_NSW_SCOPES="$OGA_NSW_SCOPES" \
-    OGA_NSW_TOKEN_INSECURE_SKIP_VERIFY="$OGA_NSW_TOKEN_INSECURE_SKIP_VERIFY" \
-    go run ./cmd/server
-
-  ensure_branding_file "${branding_name}" "${app_name}"
-
-  start_service "oga-app-${name}" "$ROOT_DIR/portals/apps/oga-app" env \
-    VITE_PORT="$app_port" \
-    VITE_BRANDING_NAME="$branding_name" \
-    VITE_API_BASE_URL="http://localhost:${port}" \
-    VITE_IDP_BASE_URL="$IDP_PUBLIC_URL" \
-    VITE_IDP_CLIENT_ID="$idp_client_id" \
-    VITE_APP_URL="http://localhost:${app_port}" \
-    VITE_IDP_SCOPES="$IDP_SCOPES" \
-    VITE_IDP_PLATFORM="$IDP_PLATFORM" \
-    pnpm run dev
-done
 
 start_service "trader-app" "$ROOT_DIR/portals/apps/trader-app" env \
   VITE_API_BASE_URL="http://localhost:${BACKEND_PORT}" \
@@ -423,11 +246,6 @@ start_service "backend" "$ROOT_DIR/backend" env \
   echo "Started local services:"
   echo "  - backend       -> http://localhost:${BACKEND_PORT}"
   echo "  - trader-app    -> http://localhost:${TRADER_APP_PORT}"
-  for entry in "${OGA_INSTANCES[@]}"; do
-    IFS='|' read -r name port _ _ _ app_port _ _ <<< "$entry"
-    printf "  - oga-%-9s -> http://localhost:%s\n" "$name" "$port"
-    printf "  - oga-app-%-5s -> http://localhost:%s\n" "$name" "$app_port"
-  done
   echo
   echo "IDP running:      $RUN_IDP"
   echo "Temporal running: $RUN_TEMPORAL"


### PR DESCRIPTION
## Summary

Switches the local development setup to use the standalone [nsw-agency](https://github.com/OpenNSW/nsw-agency) repo for agency portals, replacing the legacy `oga/` + `oga-app/` modules that were previously wired into this repo's dev scripts.

**This PR must be merged together with [OpenNSW/nsw-agency#48](https://github.com/OpenNSW/nsw-agency/pull/48)**, which adds `--clean-run` and `--env-file` flags to `nsw-agency/start-dev.sh`.

The `oga/` and `portals/apps/oga-app/` directories are **not deleted** in this PR — tracked in #549.

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [x] Refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Other (please describe):

## Changes Made

### `start-dev.sh` / `start-dev.ps1`
- Removed all OGA operational wiring: port vars, `OGA_INSTANCES` array, `ensure_branding_file`, `clean_oga_databases`, commented-out OGA service start block, OGA entries in the status banner
- The scripts now start only: IDP (Docker), Temporal (Docker), NSW backend, and trader-app

### `.env.example`
- Removed OGA port vars (`OGA_APP_*_PORT`, `OGA_*_PORT`)
- Removed OGA IDP client ID vars (`NPQS_IDP_CLIENT_ID` … `CDA_IDP_CLIENT_ID`)
- Removed entire `# OGA backends` section (DB driver, SQLite paths, Postgres settings, branding names, OAuth2 credentials)
- Added comments clarifying ports 5174–5177 are used by nsw-agency portals and that `AUTH_CLIENT_IDS` includes agency M2M client IDs

### `README.md`
- Added **Getting Started** section with the two-terminal e2e workflow
- Updated feature table: "Service Module" → "Agency Module"

### Migration scripts + seed SQL
- `backend/internal/database/migrations/run.sh` / `run.ps1`: default submission URL `http://localhost:{port}/api/oga/inject` → `http://localhost:{port}/api/v1/inject`
- `backend/internal/database/migrations/004_insert_seed_workflow_node_templates.up.sql`: same URL fix for the `ship_departure_v1` node template

### `backend/internal/task/plugin/simple_form.go`
- Renamed `WorkflowID` → `ConsignmentID` (JSON tag `workflowId` → `consignmentId`) in `SimpleFormExternalServiceRequest` to match the nsw-agency `InjectRequest` schema

## Testing

### E2E test setup

```bash
# Terminal 1 – NSW core
cd nsw
./start-dev.sh --clean-run   # wipe DB + volumes, re-migrate, start

# Terminal 2 – Agency portals
cd nsw-agency
./start-dev.sh all --clean-run   # wipe agency DBs, start
```

1. Run `./start-dev.sh --clean-run` — confirm only backend, trader-app, IDP, and Temporal start; no OGA errors.
2. Run `./start-dev.sh all --clean-run` in nsw-agency — confirm NPQS/FCAU/IRD/CDA backends (8081–8084) and frontends (5174–5177) start with empty DBs.
3. Submit a trader form that routes to FCAU — confirm the inject POST hits `http://localhost:8082/api/v1/inject` and the application appears in the FCAU agency portal at `http://localhost:5175`.
4. Review the application from the agency portal — confirm the callback reaches the NSW task API and transitions the task state.

- [x] I have tested this change locally
- [ ] I have added unit tests for new functionality
- [x] I have tested edge cases
- [x] All existing tests pass

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have checked that there are no merge conflicts

## Related Issues

Related to #549 (cleanup of `oga/` and `oga-app/` — to be done after nsw-agency is confirmed stable)