### PR TITLE
fix: rename FormData field to Data in FormContent struct

### DIFF
--- a/backend/pkg/uiprojector/blueprint.go
+++ b/backend/pkg/uiprojector/blueprint.go
@@ -43,5 +43,5 @@ type Section struct {
 type FormContent struct {
 	Schema   any `json:"schema"`
 	UISchema any `json:"uiSchema,omitempty"`
-	FormData any `json:"formData,omitempty"`
+	Data     any `json:"data,omitempty"`
 }

--- a/backend/pkg/uiprojector/projector.go
+++ b/backend/pkg/uiprojector/projector.go
@@ -38,7 +38,7 @@ func (p *FormProjector) Project(ctx context.Context, templateContent []byte, dat
 	return FormContent{
 		Schema:   schema["schema"],
 		UISchema: schema["uiSchema"],
-		FormData: data,
+		Data:     data,
 	}, nil
 }
 

--- a/backend/pkg/uiprojector/projector_test.go
+++ b/backend/pkg/uiprojector/projector_test.go
@@ -24,7 +24,7 @@ func TestFormProjector_Project(t *testing.T) {
 		require.True(t, ok, "expected FormContent, got %T", out)
 		assert.Equal(t, map[string]any{"type": "object"}, fc.Schema)
 		assert.Equal(t, map[string]any{"ui:order": []any{"name"}}, fc.UISchema)
-		assert.Equal(t, data, fc.FormData)
+		assert.Equal(t, data, fc.Data)
 	})
 
 	t.Run("uiSchema is nil when absent from template", func(t *testing.T) {
@@ -35,7 +35,7 @@ func TestFormProjector_Project(t *testing.T) {
 		fc := out.(uiprojector.FormContent)
 		assert.NotNil(t, fc.Schema)
 		assert.Nil(t, fc.UISchema)
-		assert.Nil(t, fc.FormData)
+		assert.Nil(t, fc.Data)
 	})
 
 	t.Run("empty JSON object yields nil schema and uiSchema but preserves data", func(t *testing.T) {
@@ -45,7 +45,7 @@ func TestFormProjector_Project(t *testing.T) {
 		fc := out.(uiprojector.FormContent)
 		assert.Nil(t, fc.Schema)
 		assert.Nil(t, fc.UISchema)
-		assert.Equal(t, "data", fc.FormData)
+		assert.Equal(t, "data", fc.Data)
 	})
 
 	t.Run("returns error on invalid JSON", func(t *testing.T) {

--- a/backend/pkg/uiprojector/test/integration/integration_test.go
+++ b/backend/pkg/uiprojector/test/integration/integration_test.go
@@ -104,7 +104,7 @@ func TestUIProjectorIntegration(t *testing.T) {
 		// Verify Form content
 		formContent := sections["declaration_form"].Content.(uiprojector.FormContent)
 		assert.NotNil(t, formContent.Schema)
-		assert.Equal(t, "John Doe", formContent.FormData.(map[string]any)["name"])
+		assert.Equal(t, "John Doe", formContent.Data.(map[string]any)["name"])
 	})
 
 	t.Run("Assemble Approved State (Visibility Logic)", func(t *testing.T) {


### PR DESCRIPTION
## Summary

This PR renames the `FormData` field to `Data` (and its corresponding JSON tag from `formData` to `data`) inside the `FormContent` struct within the `backend/pkg/uiprojector` package. This aligns the field name with the backend data representation and standardizes the structure of projected UI content sections.

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [x] Refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Other (please describe):

## Changes Made

- Renamed the `FormData` field to `Data` (JSON tag: `data,omitempty`) in the `FormContent` struct in [blueprint.go](file:///Users/mushrafmim/GolandProjects/nsw/backend/pkg/uiprojector/blueprint.go).
- Updated the struct initialization in the `FormProjector.Project` function inside [projector.go](file:///Users/mushrafmim/GolandProjects/nsw/backend/pkg/uiprojector/projector.go).
- Updated field assertions from `FormData` to `Data` in the unit tests ([projector_test.go](file:///Users/mushrafmim/GolandProjects/nsw/backend/pkg/uiprojector/projector_test.go)) and integration tests ([integration_test.go](file:///Users/mushrafmim/GolandProjects/nsw/backend/pkg/uiprojector/test/integration/integration_test.go)).

## Testing

- [x] I have tested this change locally
- [ ] I have added unit tests for new functionality
- [ ] I have tested edge cases
- [x] All existing tests pass

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have checked that there are no merge conflicts

## Related Issues

Closes #552

## Screenshots/Demo

N/A

## Additional Notes

*Note: Renaming the JSON key from `formData` to `data` requires corresponding updates in the frontend applications (e.g., `trader-app`) that parse these UI projector section payloads.*

## Deployment Notes

N/A
