### PR TITLE
fix(taskv2): persist active_output_namespace so CompleteTaskStep can scope writes

### DIFF
--- a/backend/internal/database/migrations/019_create_task_records_v2.up.sql
+++ b/backend/internal/database/migrations/019_create_task_records_v2.up.sql
@@ -10,6 +10,7 @@ CREATE TABLE task_records_v2 (
     task_run_id             TEXT,
     subtask_node_id         TEXT,
     active_task_template_id TEXT,
+    active_output_namespace TEXT NOT NULL DEFAULT '',
     data                    JSONB,
     created_at              TIMESTAMPTZ NOT NULL DEFAULT now(),
     updated_at              TIMESTAMPTZ NOT NULL DEFAULT now()

--- a/backend/internal/taskv2/store/gorm_store.go
+++ b/backend/internal/taskv2/store/gorm_store.go
@@ -37,6 +37,7 @@ func (s *GormTaskStore) SaveTask(ctx context.Context, record store.TaskRecord) {
 			"task_run_id",
 			"subtask_node_id",
 			"active_task_template_id",
+			"active_output_namespace",
 			"data",
 			"updated_at",
 		}),

--- a/backend/internal/taskv2/store/model.go
+++ b/backend/internal/taskv2/store/model.go
@@ -10,20 +10,21 @@ import (
 
 // TaskRecordModel is the GORM-compatible model for nsw-task-flow's TaskRecord.
 type TaskRecordModel struct {
-	TaskID               string          `gorm:"primaryKey;column:task_id;type:text"`
-	TaskType             string          `gorm:"column:task_type;type:text;index"`
-	State                string          `gorm:"column:state;type:text"`
-	RenderConfig         json.RawMessage `gorm:"column:render_config;type:jsonb;serializer:json"`
-	ParentWorkflowID     string          `gorm:"column:parent_workflow_id;type:text;index"`
-	ParentRunID          string          `gorm:"column:parent_run_id;type:text"`
-	ParentNodeID         string          `gorm:"column:parent_node_id;type:text"`
-	TaskWorkflowID       string          `gorm:"column:task_workflow_id;type:text;index"`
-	TaskRunID            string          `gorm:"column:task_run_id;type:text"`
-	SubTaskNodeID        string          `gorm:"column:subtask_node_id;type:text"`
-	ActiveTaskTemplateID string          `gorm:"column:active_task_template_id;type:text"`
-	Data                 json.RawMessage `gorm:"column:data;type:jsonb;serializer:json"`
-	CreatedAt            time.Time       `gorm:"column:created_at;type:timestamptz;not null;autoCreateTime"`
-	UpdatedAt            time.Time       `gorm:"column:updated_at;type:timestamptz;not null;autoUpdateTime"`
+	TaskID                string          `gorm:"primaryKey;column:task_id;type:text"`
+	TaskType              string          `gorm:"column:task_type;type:text;index"`
+	State                 string          `gorm:"column:state;type:text"`
+	RenderConfig          json.RawMessage `gorm:"column:render_config;type:jsonb;serializer:json"`
+	ParentWorkflowID      string          `gorm:"column:parent_workflow_id;type:text;index"`
+	ParentRunID           string          `gorm:"column:parent_run_id;type:text"`
+	ParentNodeID          string          `gorm:"column:parent_node_id;type:text"`
+	TaskWorkflowID        string          `gorm:"column:task_workflow_id;type:text;index"`
+	TaskRunID             string          `gorm:"column:task_run_id;type:text"`
+	SubTaskNodeID         string          `gorm:"column:subtask_node_id;type:text"`
+	ActiveTaskTemplateID  string          `gorm:"column:active_task_template_id;type:text"`
+	ActiveOutputNamespace string          `gorm:"column:active_output_namespace;type:text;not null;default:''"`
+	Data                  json.RawMessage `gorm:"column:data;type:jsonb;serializer:json"`
+	CreatedAt             time.Time       `gorm:"column:created_at;type:timestamptz;not null;autoCreateTime"`
+	UpdatedAt             time.Time       `gorm:"column:updated_at;type:timestamptz;not null;autoUpdateTime"`
 }
 
 func (TaskRecordModel) TableName() string {
@@ -41,20 +42,21 @@ func (m TaskRecordModel) ToDomain() store.TaskRecord {
 	}
 
 	return store.TaskRecord{
-		TaskID:               m.TaskID,
-		TaskType:             m.TaskType,
-		State:                m.State,
-		RenderConfig:         m.RenderConfig,
-		ParentWorkflowID:     m.ParentWorkflowID,
-		ParentRunID:          m.ParentRunID,
-		ParentNodeID:         m.ParentNodeID,
-		TaskWorkflowID:       m.TaskWorkflowID,
-		TaskRunID:            m.TaskRunID,
-		SubTaskNodeID:        m.SubTaskNodeID,
-		ActiveTaskTemplateID: m.ActiveTaskTemplateID,
-		Data:                 data,
-		CreatedAt:            m.CreatedAt,
-		UpdatedAt:            m.UpdatedAt,
+		TaskID:                m.TaskID,
+		TaskType:              m.TaskType,
+		State:                 m.State,
+		RenderConfig:          m.RenderConfig,
+		ParentWorkflowID:      m.ParentWorkflowID,
+		ParentRunID:           m.ParentRunID,
+		ParentNodeID:          m.ParentNodeID,
+		TaskWorkflowID:        m.TaskWorkflowID,
+		TaskRunID:             m.TaskRunID,
+		SubTaskNodeID:         m.SubTaskNodeID,
+		ActiveTaskTemplateID:  m.ActiveTaskTemplateID,
+		ActiveOutputNamespace: m.ActiveOutputNamespace,
+		Data:                  data,
+		CreatedAt:             m.CreatedAt,
+		UpdatedAt:             m.UpdatedAt,
 	}
 }
 
@@ -65,17 +67,18 @@ func FromDomain(r store.TaskRecord) TaskRecordModel {
 		slog.Error("taskv2 store: FromDomain failed to marshal Data", "taskId", r.TaskID, "error", err)
 	}
 	return TaskRecordModel{
-		TaskID:               r.TaskID,
-		TaskType:             r.TaskType,
-		State:                r.State,
-		RenderConfig:         r.RenderConfig,
-		ParentWorkflowID:     r.ParentWorkflowID,
-		ParentRunID:          r.ParentRunID,
-		ParentNodeID:         r.ParentNodeID,
-		TaskWorkflowID:       r.TaskWorkflowID,
-		TaskRunID:            r.TaskRunID,
-		SubTaskNodeID:        r.SubTaskNodeID,
-		ActiveTaskTemplateID: r.ActiveTaskTemplateID,
-		Data:                 dataBytes,
+		TaskID:                r.TaskID,
+		TaskType:              r.TaskType,
+		State:                 r.State,
+		RenderConfig:          r.RenderConfig,
+		ParentWorkflowID:      r.ParentWorkflowID,
+		ParentRunID:           r.ParentRunID,
+		ParentNodeID:          r.ParentNodeID,
+		TaskWorkflowID:        r.TaskWorkflowID,
+		TaskRunID:             r.TaskRunID,
+		SubTaskNodeID:         r.SubTaskNodeID,
+		ActiveTaskTemplateID:  r.ActiveTaskTemplateID,
+		ActiveOutputNamespace: r.ActiveOutputNamespace,
+		Data:                  dataBytes,
 	}
 }


### PR DESCRIPTION
## Summary

The upstream task-flow contract uses `TaskRecord.ActiveOutputNamespace` — snapshotted from the active `SubTaskTemplate.OutputNamespace` at `StartSubTask` — to scope `CompleteTaskStep` writes into a top-level slot of `TaskRecord.Data`. When the field is empty, the payload is silently dropped with a warning. Our local GORM model and migration didn't carry the column, so the snapshot never persisted and every form submission was being thrown away.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Changes Made

- `internal/database/migrations/019_create_task_records_v2.up.sql` — added `active_output_namespace TEXT NOT NULL DEFAULT ''` to the table definition (amended in place since 019 hasn't shipped yet).
- `internal/taskv2/store/model.go` — added `ActiveOutputNamespace` to `TaskRecordModel` and threaded it through both `ToDomain` and `FromDomain`.
- `internal/taskv2/store/gorm_store.go` — added the column to the `OnConflict.DoUpdates` `AssignmentColumns` list so upserts persist it.

End-to-end now: `StartSubTask` snapshots `subTemplate.OutputNamespace` → `SaveTask` persists → `GetTask` reloads → `CompleteTaskStep` writes the payload into `record.Data[namespace]`. FCAU templates already declare `output_namespace` on every form/payment subtask (`userform`, `reviewerform`, `payment`, etc.), so the round-trip is complete.

## Testing

- [x] I have tested this change locally
- [x] All existing tests pass

## Deployment Notes

Existing `task_records_v2` tables need to be re-created (or have the column added) to pick up the new column, since migration 019 was amended in place rather than via a follow-up ALTER.