### PR TITLE
feat(taskv2): integrate zone-based rendering end-to-end

### DIFF
--- a/backend/internal/app/bootstrap/app.go
+++ b/backend/internal/app/bootstrap/app.go
@@ -114,12 +114,13 @@ func Build(ctx context.Context, cfg *config.Config) (*App, error) {
 		return nil, fmt.Errorf("failed to register taskv2 plugins: %w", err)
 	}
 
-	tm, _, stopTaskV2, err := taskv2.WireTaskV2(db, &temporalClient, pluginsRegistry, onTaskCompleted)
+	taskV2, stopTaskV2, err := taskv2.WireTaskV2(db, &temporalClient, pluginsRegistry, onTaskCompleted)
 	if err != nil {
 		temporalClient.Close()
 		_ = database.Close(db)
 		return nil, fmt.Errorf("failed to wire taskv2: %w", err)
 	}
+	tm := taskV2.Manager
 
 	consignmentService := consignment.NewService(db, templateService, chaService, companyService, userProfileService, hsCodeService)
 	consignmentRouter := consignment.NewRouter(consignmentService, chaService, companyService)
@@ -192,7 +193,7 @@ func Build(ctx context.Context, cfg *config.Config) (*App, error) {
 	// smsChannel := channels.NewSMSChannel(...)
 	// notificationManager.RegisterSMSChannel(smsChannel)
 
-	taskV2Handler := taskv2.NewHTTPHandler(tm)
+	taskV2Handler := taskv2.NewHTTPHandler(tm, taskV2.Store, taskV2.Assembler)
 
 	// withAuth wraps an individual handler with the authentication middleware.
 	withAuth := authManager.Middleware()

--- a/backend/internal/taskv2/http_handler.go
+++ b/backend/internal/taskv2/http_handler.go
@@ -33,6 +33,8 @@ func NewHTTPHandler(manager *orchestrator.TaskManager, store TaskFetcher, assemb
 //
 //	GET /api/v1/tasks/{id}
 func (h *HTTPHandler) HandleGetTask(w http.ResponseWriter, r *http.Request) {
+	// TODO: retrieve the authenticated context and validate it against the
+	// task's ownership bounds before returning ZoneView.
 	taskID := r.PathValue("id")
 	if taskID == "" {
 		writeJSONError(w, http.StatusBadRequest, "task id is required")
@@ -47,7 +49,8 @@ func (h *HTTPHandler) HandleGetTask(w http.ResponseWriter, r *http.Request) {
 
 	zv, err := h.Assembler.Assemble(r.Context(), record)
 	if err != nil {
-		writeJSONError(w, http.StatusInternalServerError, err.Error())
+		slog.Error("taskv2: failed to assemble zone view", "taskId", taskID, "error", err)
+		writeJSONError(w, http.StatusInternalServerError, "An internal error occurred while loading the task")
 		return
 	}
 
@@ -59,6 +62,8 @@ func (h *HTTPHandler) HandleGetTask(w http.ResponseWriter, r *http.Request) {
 //	POST /api/v1/tasks/{id}
 //	body: arbitrary JSON object — passed through to the task plugin
 func (h *HTTPHandler) HandleCompleteTaskStep(w http.ResponseWriter, r *http.Request) {
+	// TODO: retrieve the authenticated context and validate it against the
+	// task's ownership bounds before completing the step.
 	taskID := r.PathValue("id")
 
 	var payload map[string]any
@@ -87,7 +92,8 @@ func (h *HTTPHandler) HandleCompleteTaskStep(w http.ResponseWriter, r *http.Requ
 	payload = unwrapOGACallback(payload)
 
 	if err := h.Manager.CompleteTaskStep(r.Context(), taskID, payload); err != nil {
-		writeJSONError(w, http.StatusInternalServerError, err.Error())
+		slog.Error("taskv2: failed to complete task step", "taskId", taskID, "error", err)
+		writeJSONError(w, http.StatusInternalServerError, "An internal error occurred while processing the task")
 		return
 	}
 

--- a/backend/internal/taskv2/http_handler.go
+++ b/backend/internal/taskv2/http_handler.go
@@ -1,6 +1,7 @@
 package taskv2
 
 import (
+	"context"
 	"encoding/json"
 	"errors"
 	"io"
@@ -8,19 +9,29 @@ import (
 	"net/http"
 
 	"github.com/OpenNSW/nsw-task-flow/orchestrator"
+	tfstore "github.com/OpenNSW/nsw-task-flow/store"
+
+	"github.com/OpenNSW/nsw/internal/taskv2/renderer"
 )
 
+// TaskFetcher is the narrow surface HandleGetTask needs from the task store.
+type TaskFetcher interface {
+	GetTask(ctx context.Context, taskID string) (tfstore.TaskRecord, bool)
+}
+
 type HTTPHandler struct {
-	Manager *orchestrator.TaskManager
+	Manager   *orchestrator.TaskManager
+	Store     TaskFetcher
+	Assembler *renderer.ZoneViewAssembler
 }
 
-func NewHTTPHandler(manager *orchestrator.TaskManager) *HTTPHandler {
-	return &HTTPHandler{Manager: manager}
+func NewHTTPHandler(manager *orchestrator.TaskManager, store TaskFetcher, assembler *renderer.ZoneViewAssembler) *HTTPHandler {
+	return &HTTPHandler{Manager: manager, Store: store, Assembler: assembler}
 }
 
-// HandleGetTask returns the rendered UI payload for a single task.
+// HandleGetTask returns the ZoneView payload for a single task.
 //
-//	GET /api/v2/tasks/{id}
+//	GET /api/v1/tasks/{id}
 func (h *HTTPHandler) HandleGetTask(w http.ResponseWriter, r *http.Request) {
 	taskID := r.PathValue("id")
 	if taskID == "" {
@@ -28,18 +39,24 @@ func (h *HTTPHandler) HandleGetTask(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	info, err := h.Manager.GetTaskRenderInfo(r.Context(), taskID)
+	record, ok := h.Store.GetTask(r.Context(), taskID)
+	if !ok {
+		writeJSONError(w, http.StatusNotFound, "task not found")
+		return
+	}
+
+	zv, err := h.Assembler.Assemble(r.Context(), record)
 	if err != nil {
 		writeJSONError(w, http.StatusInternalServerError, err.Error())
 		return
 	}
 
-	writeJSONResponse(w, http.StatusOK, info)
+	writeJSONResponse(w, http.StatusOK, zv)
 }
 
 // HandleCompleteTaskStep advances a task by submitting a step payload.
 //
-//	POST /api/v2/tasks/{id}/step
+//	POST /api/v1/tasks/{id}
 //	body: arbitrary JSON object — passed through to the task plugin
 func (h *HTTPHandler) HandleCompleteTaskStep(w http.ResponseWriter, r *http.Request) {
 	taskID := r.PathValue("id")

--- a/backend/internal/taskv2/renderer/zone_assembler.go
+++ b/backend/internal/taskv2/renderer/zone_assembler.go
@@ -1,0 +1,48 @@
+package renderer
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	tfrenderer "github.com/OpenNSW/nsw-task-flow/renderer"
+	"github.com/OpenNSW/nsw-task-flow/store"
+)
+
+// ZoneViewAssembler builds the ZoneView payload served by GET /api/v1/tasks/{id}.
+// It delegates the per-zone projection to TaskRenderer and pulls state→actions
+// from the same render config blob.
+type ZoneViewAssembler struct {
+	inner *TaskRenderer
+}
+
+func NewZoneViewAssembler(inner *TaskRenderer) *ZoneViewAssembler {
+	return &ZoneViewAssembler{inner: inner}
+}
+
+func (a *ZoneViewAssembler) Assemble(ctx context.Context, record store.TaskRecord) (ZoneView, error) {
+	view, err := a.inner.Render(ctx, record.RenderConfig, tfrenderer.Facts{
+		State: record.State,
+		Data:  record.Data,
+	})
+	if err != nil {
+		return ZoneView{}, fmt.Errorf("zone assembler: render: %w", err)
+	}
+
+	var cfg TaskTemplateConfig
+	if len(record.RenderConfig) > 0 {
+		if err := json.Unmarshal(record.RenderConfig, &cfg); err != nil {
+			return ZoneView{}, fmt.Errorf("zone assembler: decode states: %w", err)
+		}
+	}
+
+	return ZoneView{
+		TaskID:    record.TaskID,
+		TaskType:  record.TaskType,
+		State:     record.State,
+		Actions:   cfg.States[record.State].Actions,
+		View:      view,
+		CreatedAt: record.CreatedAt,
+		UpdatedAt: record.UpdatedAt,
+	}, nil
+}

--- a/backend/internal/taskv2/renderer/zoneview.go
+++ b/backend/internal/taskv2/renderer/zoneview.go
@@ -1,0 +1,41 @@
+package renderer
+
+import (
+	"time"
+
+	"github.com/OpenNSW/nsw-task-flow/renderer"
+)
+
+// Action mirrors the trader-app Action discriminated union. Kind selects which
+// of Command (submit_form) or Action (task_action) carries the payload.
+type Action struct {
+	Kind    string `json:"kind"`
+	Label   string `json:"label"`
+	Command string `json:"command,omitempty"`
+	Action  string `json:"action,omitempty"`
+	Variant string `json:"variant,omitempty"`
+}
+
+// StateView declares what affordances a task offers while it sits in a given
+// state. Empty (or missing) means the state is terminal / non-interactive.
+type StateView struct {
+	Actions []Action `json:"actions,omitempty"`
+}
+
+// TaskTemplateConfig is the taskv2-level view of a render.json blob. The
+// blueprint fields (sections, etc.) are decoded by the inner TaskRenderer and
+// not modeled here — only States is consumed by the assembler.
+type TaskTemplateConfig struct {
+	States map[string]StateView `json:"states,omitempty"`
+}
+
+// ZoneView is the wire shape the trader-app's zone renderer consumes.
+type ZoneView struct {
+	TaskID    string                `json:"task_id"`
+	TaskType  string                `json:"task_type"`
+	State     string                `json:"state"`
+	Actions   []Action              `json:"actions,omitempty"`
+	View      renderer.RenderResult `json:"view"`
+	CreatedAt time.Time             `json:"created_at"`
+	UpdatedAt time.Time             `json:"updated_at"`
+}

--- a/backend/internal/taskv2/wiring.go
+++ b/backend/internal/taskv2/wiring.go
@@ -16,6 +16,15 @@ import (
 	"gorm.io/gorm"
 )
 
+// WireResult bundles the taskv2 objects bootstrap needs to expose handlers
+// and to wire the parent workflow runner.
+type WireResult struct {
+	Manager   *orchestrator.TaskManager
+	Runner    engine.TemporalManager
+	Store     *store.GormTaskStore
+	Assembler *taskrenderer.ZoneViewAssembler
+}
+
 // WireTaskV2 builds and starts the taskv2 stack on MICRO_WORKFLOW_QUEUE.
 // The returned TemporalManager runs the per-task (micro) sub-workflows; the
 // parent/macro workflow runner is owned by the workflow package and must be
@@ -24,26 +33,27 @@ import (
 // macro workflow can advance past its Task node. The plugin registry must be
 // pre-populated by the caller; an empty registry means every sub-task
 // activation will fail to find a handler.
-func WireTaskV2(db *gorm.DB, c *client.Client, pluginsRegistry *plugins.Registry, onTaskCompleted orchestrator.TaskCompletedCallback) (*orchestrator.TaskManager, engine.TemporalManager, func() error, error) {
+func WireTaskV2(db *gorm.DB, c *client.Client, pluginsRegistry *plugins.Registry, onTaskCompleted orchestrator.TaskCompletedCallback) (*WireResult, func() error, error) {
 	if pluginsRegistry == nil {
-		return nil, nil, nil, fmt.Errorf("taskv2: plugins registry is nil")
+		return nil, nil, fmt.Errorf("taskv2: plugins registry is nil")
 	}
 
 	taskStore := store.NewGormTaskStore(db)
 
 	templateRegistry := registry.NewInMemRegistry()
 	if err := registry.LoadConfigsInto(templateRegistry, "configs/fcau"); err != nil {
-		return nil, nil, nil, fmt.Errorf("taskv2: load configs: %w", err)
+		return nil, nil, fmt.Errorf("taskv2: load configs: %w", err)
 	}
 
-	assembler, err := uiprojector.NewAssembler(
+	uiAssembler, err := uiprojector.NewAssembler(
 		registryTemplateProvider{reg: templateRegistry},
 		uiprojector.DefaultProjectors(),
 	)
 	if err != nil {
-		return nil, nil, nil, fmt.Errorf("taskv2: build assembler: %w", err)
+		return nil, nil, fmt.Errorf("taskv2: build assembler: %w", err)
 	}
-	taskRenderer := taskrenderer.NewTaskRenderer(assembler)
+	taskRenderer := taskrenderer.NewTaskRenderer(uiAssembler)
+	zoneAssembler := taskrenderer.NewZoneViewAssembler(taskRenderer)
 
 	var tm *orchestrator.TaskManager
 
@@ -71,7 +81,7 @@ func WireTaskV2(db *gorm.DB, c *client.Client, pluginsRegistry *plugins.Registry
 	tm = orchestrator.NewTaskManager(taskStore, templateRegistry, pluginsRegistry, workflowRunner, onTaskCompleted, taskRenderer)
 
 	if err := workflowRunner.StartWorker(); err != nil {
-		return nil, nil, nil, fmt.Errorf("taskv2: start worker: %w", err)
+		return nil, nil, fmt.Errorf("taskv2: start worker: %w", err)
 	}
 
 	stop := func() error {
@@ -79,7 +89,12 @@ func WireTaskV2(db *gorm.DB, c *client.Client, pluginsRegistry *plugins.Registry
 		return nil
 	}
 
-	return tm, workflowRunner, stop, nil
+	return &WireResult{
+		Manager:   tm,
+		Runner:    workflowRunner,
+		Store:     taskStore,
+		Assembler: zoneAssembler,
+	}, stop, nil
 }
 
 // registryTemplateProvider adapts the orchestrator's TaskTemplateRegistry to

--- a/portals/apps/trader-app/src/screens/TaskDetailScreen.tsx
+++ b/portals/apps/trader-app/src/screens/TaskDetailScreen.tsx
@@ -2,14 +2,15 @@ import { useState, useEffect, useCallback, useRef } from 'react'
 import { useParams, useNavigate } from 'react-router-dom'
 import { Button, Spinner, Text } from '@radix-ui/themes'
 import { ArrowLeftIcon } from '@radix-ui/react-icons'
-import { getTaskInfo } from '../services/task'
+import { getTaskInfo, getZoneView, submitTaskStep } from '../services/task'
 import { useApi } from '../services/ApiContext'
 import PluginRenderer, { type RenderInfo } from '../plugins'
 import { getBooleanEnv } from '../runtimeConfig'
 import { TraderZoneLayout } from '../zones/TraderZoneLayout'
-import { SAMPLE_TASK } from '../zones/fixtures'
+import type { ZoneView } from '../zones/types'
 
 const POLL_INTERVAL_MS = 3000
+const POST_SUBMIT_REFETCH_DELAY_MS = 1500
 const PAYMENT_TERMINAL_STATES = ['COMPLETED', 'FAILED']
 const WAIT_FOR_EVENT_TERMINAL_STATES = ['COMPLETED', 'RECEIVED_CALLBACK', 'NOTIFY_FAILED', 'SUBMISSION_FAILED']
 
@@ -19,6 +20,7 @@ export function TaskDetailScreen() {
   const goBack = () => navigate(-1)
   const api = useApi()
   const [renderInfo, setRenderInfo] = useState<RenderInfo | null>(null)
+  const [zoneView, setZoneView] = useState<ZoneView | null>(null)
   const [loading, setLoading] = useState(true)
   const [error, setError] = useState<string | null>(null)
   const pollTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
@@ -43,6 +45,14 @@ export function TaskDetailScreen() {
       try {
         if (!silent) setLoading(true)
         if (!silent) setError(null)
+
+        if (useZoneRenderer) {
+          const zv = await getZoneView(taskId, api)
+          setZoneView(zv)
+          stopPolling()
+          return
+        }
+
         const taskRenderInfo = await getTaskInfo(taskId, api)
         setRenderInfo(taskRenderInfo)
 
@@ -68,39 +78,13 @@ export function TaskDetailScreen() {
         if (!silent) setLoading(false)
       }
     },
-    [api, taskId, stopPolling],
+    [api, taskId, stopPolling, useZoneRenderer],
   )
 
   useEffect(() => {
-    if (useZoneRenderer) return
     void fetchTask()
     return () => stopPolling()
-  }, [fetchTask, stopPolling, useZoneRenderer])
-
-  if (useZoneRenderer) {
-    // Flag-gated preview: backend doesn't emit the ZoneView shape yet, so we
-    // render a fixture inside the real task route. The taskId from the URL is
-    // intentionally ignored.
-    // TODO(zones): swap fixture for fetch once /api/v1/tasks/{id} returns ZoneView,
-    // then delete this branch.
-    return (
-      <div className="bg-gray-50 min-h-full">
-        <div className="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8 pt-6">
-          <Button
-            variant="ghost"
-            color="gray"
-            onClick={() => {
-              void goBack()
-            }}
-          >
-            <ArrowLeftIcon />
-            Back to Tasks
-          </Button>
-        </div>
-        <TraderZoneLayout task={SAMPLE_TASK} />
-      </div>
-    )
-  }
+  }, [fetchTask, stopPolling])
 
   if (loading) {
     return (
@@ -127,6 +111,47 @@ export function TaskDetailScreen() {
             </Button>
           </div>
         </div>
+      </div>
+    )
+  }
+
+  if (useZoneRenderer) {
+    if (!zoneView) {
+      return (
+        <div className="p-6">
+          <div className="bg-white rounded-lg shadow p-6 text-center">
+            <Text size="4" color="gray" weight="medium">
+              Task not found.
+            </Text>
+            <div className="mt-4">
+              <Button variant="soft" onClick={goBack}>
+                <ArrowLeftIcon />
+                Go Back
+              </Button>
+            </div>
+          </div>
+        </div>
+      )
+    }
+    return (
+      <div className="bg-gray-50 min-h-full">
+        <div className="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8 pt-6">
+          <Button variant="ghost" color="gray" onClick={goBack}>
+            <ArrowLeftIcon />
+            Back to Tasks
+          </Button>
+        </div>
+        <TraderZoneLayout
+          task={zoneView}
+          onSubmitForm={async (_command, data) => {
+            if (!taskId) return
+            await submitTaskStep(taskId, data, api)
+            // Give Temporal a moment to advance the workflow before refetching.
+            await new Promise((resolve) => setTimeout(resolve, POST_SUBMIT_REFETCH_DELAY_MS))
+            console.log('Submitted task step, refetching...')
+            await fetchTask()
+          }}
+        />
       </div>
     )
   }

--- a/portals/apps/trader-app/src/screens/TaskDetailScreen.tsx
+++ b/portals/apps/trader-app/src/screens/TaskDetailScreen.tsx
@@ -145,11 +145,15 @@ export function TaskDetailScreen() {
           task={zoneView}
           onSubmitForm={async (_command, data) => {
             if (!taskId) return
-            await submitTaskStep(taskId, data, api)
-            // Give Temporal a moment to advance the workflow before refetching.
-            await new Promise((resolve) => setTimeout(resolve, POST_SUBMIT_REFETCH_DELAY_MS))
-            console.log('Submitted task step, refetching...')
-            await fetchTask()
+            try {
+              await submitTaskStep(taskId, data, api)
+              // Give Temporal a moment to advance the workflow before refetching.
+              await new Promise((resolve) => setTimeout(resolve, POST_SUBMIT_REFETCH_DELAY_MS))
+              await fetchTask()
+            } catch (err) {
+              setError('Failed to submit task. Please try again.')
+              console.error(err)
+            }
           }}
         />
       </div>

--- a/portals/apps/trader-app/src/services/api.ts
+++ b/portals/apps/trader-app/src/services/api.ts
@@ -103,7 +103,8 @@ export async function apiPost<T, R>(endpoint: string, body: T, token?: string | 
 
   const text = await response.text()
   if (!text) {
-    throw new Error('API returned empty response')
+    // 204 No Content (or any empty 2xx) is a valid success response.
+    return undefined as R
   }
 
   try {
@@ -131,7 +132,7 @@ export async function apiPut<T, R>(endpoint: string, body: T, token?: string | n
 
   const text = await response.text()
   if (!text) {
-    throw new Error('API returned empty response')
+    return undefined as R
   }
 
   try {

--- a/portals/apps/trader-app/src/services/task.ts
+++ b/portals/apps/trader-app/src/services/task.ts
@@ -1,5 +1,6 @@
 import { defaultApiClient, type ApiClient, type ApiResponse, apiPost } from './api'
 import type { RenderInfo } from '../plugins'
+import type { ZoneView } from '../zones/types'
 
 export type TaskCommand = 'SUBMISSION' | 'SAVE_AS_DRAFT'
 
@@ -36,6 +37,18 @@ export async function getTaskInfo(taskId: string, apiClient: ApiClient = default
     throw new Error('Failed to fetch task information')
   }
   return response.data
+}
+
+export async function getZoneView(taskId: string, apiClient: ApiClient = defaultApiClient): Promise<ZoneView> {
+  return apiClient.get<ZoneView>(`${TASKS_API_URL}/${taskId}`)
+}
+
+export async function submitTaskStep(
+  taskId: string,
+  payload: Record<string, unknown>,
+  apiClient: ApiClient = defaultApiClient,
+): Promise<void> {
+  await apiClient.post<Record<string, unknown>, unknown>(`${TASKS_API_URL}/${taskId}`, payload)
 }
 
 export async function sendTaskAction(taskId: string, workflowId: string, action: string): Promise<TaskCommandResponse> {

--- a/portals/apps/trader-app/src/zones/PresentationalZone.tsx
+++ b/portals/apps/trader-app/src/zones/PresentationalZone.tsx
@@ -1,0 +1,21 @@
+import type { ZoneComponent } from './types'
+import { renderZoneComponent } from './renderers'
+
+type Props = {
+  name: string
+  component: ZoneComponent
+}
+
+export function PresentationalZone({ name, component }: Props) {
+  return (
+    <section className="space-y-2">
+      <div className="flex items-center gap-2">
+        <span className="text-xs font-semibold uppercase tracking-widest text-gray-400">{name}</span>
+        <span className="text-[10px] font-medium uppercase tracking-wider text-gray-300">{component.type}</span>
+      </div>
+      <div className="bg-white rounded-lg shadow-sm border border-gray-100">
+        <div className="p-6">{renderZoneComponent(component)}</div>
+      </div>
+    </section>
+  )
+}

--- a/portals/apps/trader-app/src/zones/TraderZoneLayout.tsx
+++ b/portals/apps/trader-app/src/zones/TraderZoneLayout.tsx
@@ -1,73 +1,39 @@
-import { Button } from '@radix-ui/themes'
-import type { Action, ActionVariant, Alert, AlertVariant, AuditEntry, ZoneComponent, ZoneView } from './types'
-import { renderZoneComponent } from './renderers'
+import type { Alert, AlertVariant, AuditEntry, ZoneComponent, ZoneView } from './types'
+import { WorkspaceZone } from './WorkspaceZone'
+import { PresentationalZone } from './PresentationalZone'
 
 type Props = {
   task: ZoneView
+  onSubmitForm?: (command: string, data: Record<string, unknown>) => Promise<void>
 }
 
 // Zones render in this order when present; any unknown keys render after, in
 // insertion order.
 const ZONE_ORDER = ['instructions', 'workspace', 'reference']
 
-export function TraderZoneLayout({ task }: Props) {
+export function TraderZoneLayout({ task, onSubmitForm }: Props) {
   const zones = orderedZones(task.view)
 
   return (
     <div className="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8 py-8 space-y-6">
       <Header task={task} />
       {task.alert !== undefined && <AlertBanner alert={task.alert} />}
-      {zones.map(([name, component]) => (
-        <ZoneSection
-          key={name}
-          name={name}
-          component={component}
-          actions={name === 'workspace' ? task.actions : undefined}
-        />
-      ))}
+      {zones.map(([name, component]) =>
+        name === 'workspace' ? (
+          <WorkspaceZone
+            key={`${name}:${task.task_id}:${task.state}`}
+            name={name}
+            component={component}
+            actions={task.actions ?? []}
+            onSubmitForm={onSubmitForm}
+          />
+        ) : (
+          <PresentationalZone key={name} name={name} component={component} />
+        ),
+      )}
       {task.audit && task.audit.length > 0 && <AuditLog entries={task.audit} />}
     </div>
   )
-}
-
-function WorkspaceActionBar({ actions }: { actions: Action[] }) {
-  return (
-    <div className="sticky bottom-0 border-t border-gray-100 bg-white/95 backdrop-blur rounded-b-lg shadow-[0_-4px_12px_-8px_rgba(0,0,0,0.08)]">
-      <div className="px-6 py-4 flex justify-end gap-3">
-        {actions.map((action) => (
-          <ActionButton key={actionKey(action)} action={action} />
-        ))}
-      </div>
-    </div>
-  )
-}
-
-function ActionButton({ action }: { action: Action }) {
-  const variant = action.variant ?? 'primary'
-  const handler = () => {
-    if (action.kind === 'submit_form') {
-      console.log('[zones] submit_form', { command: action.command })
-    } else {
-      console.log('[zones] task_action', { action: action.action })
-    }
-  }
-  return (
-    <Button onClick={handler} size="3" variant={buttonVariant(variant)} color={buttonColor(variant)}>
-      {action.label}
-    </Button>
-  )
-}
-
-function buttonVariant(v: ActionVariant): 'solid' | 'outline' {
-  return v === 'outline' ? 'outline' : 'solid'
-}
-
-function buttonColor(v: ActionVariant): 'red' | undefined {
-  return v === 'danger' ? 'red' : undefined
-}
-
-function actionKey(action: Action): string {
-  return action.kind === 'submit_form' ? `submit:${action.command}` : `action:${action.action}`
 }
 
 function orderedZones(view: Record<string, ZoneComponent>): Array<[string, ZoneComponent]> {
@@ -231,7 +197,7 @@ function formatRelative(iso: string): string {
   if (mins < 60) return `${mins}m ago`
   const hours = Math.floor(mins / 60)
   if (hours < 24) return `${hours}h ago`
-  const days = Math.floor(hours / 24)
+  const days = Math.floor(mins / 60 / 24)
   if (days < 7) return `${days}d ago`
   return new Date(iso).toLocaleDateString()
 }
@@ -249,20 +215,5 @@ function Header({ task }: { task: ZoneView }) {
         </span>
       </div>
     </div>
-  )
-}
-
-function ZoneSection({ name, component, actions }: { name: string; component: ZoneComponent; actions?: Action[] }) {
-  return (
-    <section className="space-y-2">
-      <div className="flex items-center gap-2">
-        <span className="text-xs font-semibold uppercase tracking-widest text-gray-400">{name}</span>
-        <span className="text-[10px] font-medium uppercase tracking-wider text-gray-300">{component.type}</span>
-      </div>
-      <div className="bg-white rounded-lg shadow-sm border border-gray-100">
-        <div className="p-6">{renderZoneComponent(component)}</div>
-        {actions && actions.length > 0 && <WorkspaceActionBar actions={actions} />}
-      </div>
-    </section>
   )
 }

--- a/portals/apps/trader-app/src/zones/WorkspaceZone.tsx
+++ b/portals/apps/trader-app/src/zones/WorkspaceZone.tsx
@@ -1,0 +1,141 @@
+import { useRef, useState } from 'react'
+import { Button } from '@radix-ui/themes'
+import type { Action, ActionVariant, ZoneComponent } from './types'
+import { renderZoneComponent } from './renderers'
+import { FormRenderer, type FormHandle } from './renderers/FormRenderer'
+import { getBooleanEnv } from '../runtimeConfig'
+
+type Props = {
+  name: string
+  component: ZoneComponent
+  actions: Action[]
+  onSubmitForm?: (command: string, data: Record<string, unknown>) => Promise<void>
+}
+
+export function WorkspaceZone({ name, component, actions, onSubmitForm }: Props) {
+  const formRef = useRef<FormHandle>(null)
+  const [isFormValid, setIsFormValid] = useState(false)
+  const [submitting, setSubmitting] = useState(false)
+
+  const handleAction = (action: Action) => {
+    if (action.kind !== 'submit_form') {
+      console.log('[zones] task_action', { action: action.action })
+      return
+    }
+    if (!onSubmitForm) return
+    const data = formRef.current?.getData() ?? {}
+    setSubmitting(true)
+    void onSubmitForm(action.command, data).finally(() => setSubmitting(false))
+  }
+
+  const handleAutoFill = () => formRef.current?.autoFill()
+
+  const showAutoFill = component.type === 'FORM' && getBooleanEnv('VITE_SHOW_AUTOFILL_BUTTON', false)
+
+  return (
+    <section className="space-y-2">
+      <ZoneHeader name={name} type={component.type} />
+      <div className="bg-white rounded-lg shadow-sm border border-gray-100">
+        <div className="p-6">
+          {component.type === 'FORM' ? (
+            <FormRenderer ref={formRef} payload={component.payload} onValidityChange={setIsFormValid} />
+          ) : (
+            renderZoneComponent(component)
+          )}
+        </div>
+        {(actions.length > 0 || showAutoFill) && (
+          <WorkspaceActionBar
+            actions={actions}
+            onAction={handleAction}
+            submitting={submitting}
+            canSubmit={component.type === 'FORM' ? isFormValid : true}
+            onAutoFill={showAutoFill ? handleAutoFill : undefined}
+          />
+        )}
+      </div>
+    </section>
+  )
+}
+
+function WorkspaceActionBar({
+  actions,
+  onAction,
+  submitting,
+  canSubmit,
+  onAutoFill,
+}: {
+  actions: Action[]
+  onAction: (action: Action) => void
+  submitting: boolean
+  canSubmit: boolean
+  onAutoFill?: () => void
+}) {
+  return (
+    <div className="sticky bottom-0 border-t border-gray-100 bg-white/95 backdrop-blur rounded-b-lg shadow-[0_-4px_12px_-8px_rgba(0,0,0,0.08)]">
+      <div className="px-6 py-4 flex items-center gap-3">
+        {onAutoFill && (
+          <Button type="button" variant="soft" color="purple" size="3" onClick={onAutoFill} disabled={submitting}>
+            Demo - Auto Fill
+          </Button>
+        )}
+        <div className="flex-1" />
+        {actions.map((action) => (
+          <ActionButton
+            key={actionKey(action)}
+            action={action}
+            onAction={onAction}
+            submitting={submitting}
+            canSubmit={canSubmit}
+          />
+        ))}
+      </div>
+    </div>
+  )
+}
+
+function ActionButton({
+  action,
+  onAction,
+  submitting,
+  canSubmit,
+}: {
+  action: Action
+  onAction: (action: Action) => void
+  submitting: boolean
+  canSubmit: boolean
+}) {
+  const variant = action.variant ?? 'primary'
+  const disabled = submitting || (action.kind === 'submit_form' && !canSubmit)
+  return (
+    <Button
+      onClick={() => onAction(action)}
+      size="3"
+      variant={buttonVariant(variant)}
+      color={buttonColor(variant)}
+      disabled={disabled}
+    >
+      {submitting && action.kind === 'submit_form' ? 'Submitting...' : action.label}
+    </Button>
+  )
+}
+
+function ZoneHeader({ name, type }: { name: string; type: string }) {
+  return (
+    <div className="flex items-center gap-2">
+      <span className="text-xs font-semibold uppercase tracking-widest text-gray-400">{name}</span>
+      <span className="text-[10px] font-medium uppercase tracking-wider text-gray-300">{type}</span>
+    </div>
+  )
+}
+
+function buttonVariant(v: ActionVariant): 'solid' | 'outline' {
+  return v === 'outline' ? 'outline' : 'solid'
+}
+
+function buttonColor(v: ActionVariant): 'red' | undefined {
+  return v === 'danger' ? 'red' : undefined
+}
+
+function actionKey(action: Action): string {
+  return action.kind === 'submit_form' ? `submit:${action.command}` : `action:${action.action}`
+}

--- a/portals/apps/trader-app/src/zones/renderers/FormRenderer.tsx
+++ b/portals/apps/trader-app/src/zones/renderers/FormRenderer.tsx
@@ -1,15 +1,93 @@
+import { forwardRef, useEffect, useImperativeHandle, useRef, useState } from 'react'
 import { JsonForms } from '@jsonforms/react'
 import { radixRenderers } from '@opennsw/jsonforms-renderers'
+import type { JsonSchema } from '@jsonforms/core'
 import type { ZoneRendererProps } from './types'
+import { autoFillForm } from '../../utils/formUtils'
 
-export function FormRenderer({ payload }: ZoneRendererProps<'FORM'>) {
+export type FormHandle = {
+  getData: () => Record<string, unknown>
+  autoFill: () => void
+}
+
+type Props = ZoneRendererProps<'FORM'> & {
+  onValidityChange?: (isValid: boolean) => void
+}
+
+export const FormRenderer = forwardRef<FormHandle, Props>(function FormRenderer(
+  { payload, onValidityChange },
+  ref,
+) {
+  const [data, setData] = useState<Record<string, unknown>>(payload.data ?? {})
+  const dataRef = useRef(data)
+  dataRef.current = data
+
+  useImperativeHandle(
+    ref,
+    () => ({
+      getData: () => dataRef.current,
+      autoFill: () => {
+        const next = autoFillForm(payload.schema, dataRef.current) as Record<string, unknown>
+        setData(next)
+        onValidityChange?.(isFormValid(payload.schema, next, []))
+      },
+    }),
+    [onValidityChange, payload.schema],
+  )
+
+  useEffect(() => {
+    onValidityChange?.(isFormValid(payload.schema, data, []))
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [])
+
   return (
     <JsonForms
       schema={payload.schema}
       uischema={payload.uiSchema}
-      data={payload.data ?? {}}
+      data={data}
       renderers={radixRenderers}
       readonly={payload.readonly ?? false}
+      onChange={({ data, errors }) => {
+        const next = (data ?? {}) as Record<string, unknown>
+        setData(next)
+        onValidityChange?.(isFormValid(payload.schema, next, errors ?? []))
+      }}
     />
   )
+})
+
+function isFormValid(schema: JsonSchema, data: Record<string, unknown>, errors: unknown[]): boolean {
+  if (errors.length > 0) return false
+  return allRequiredFilled(schema, data)
+}
+
+// Walks the schema's `required` arrays and checks each path against the data.
+// Treats undefined, null, empty string, and empty array as "missing".
+function allRequiredFilled(schema: JsonSchema | undefined, data: unknown): boolean {
+  if (!schema || typeof schema !== 'object') return true
+  const required = (schema as { required?: string[] }).required
+  const properties = (schema as { properties?: Record<string, JsonSchema> }).properties
+
+  if (Array.isArray(required) && properties && data && typeof data === 'object') {
+    const obj = data as Record<string, unknown>
+    for (const key of required) {
+      if (isEmpty(obj[key])) return false
+    }
+  }
+
+  if (properties && data && typeof data === 'object') {
+    const obj = data as Record<string, unknown>
+    for (const key of Object.keys(properties)) {
+      if (!allRequiredFilled(properties[key], obj[key])) return false
+    }
+  }
+
+  return true
+}
+
+function isEmpty(value: unknown): boolean {
+  if (value === undefined || value === null) return true
+  if (typeof value === 'string' && value.trim() === '') return true
+  if (Array.isArray(value) && value.length === 0) return true
+  return false
 }

--- a/portals/apps/trader-app/src/zones/renderers/FormRenderer.tsx
+++ b/portals/apps/trader-app/src/zones/renderers/FormRenderer.tsx
@@ -68,7 +68,7 @@ function allRequiredFilled(schema: JsonSchema | undefined, data: unknown): boole
   const required = (schema as { required?: string[] }).required
   const properties = (schema as { properties?: Record<string, JsonSchema> }).properties
 
-  if (Array.isArray(required) && properties && data && typeof data === 'object') {
+  if (Array.isArray(required) && data && typeof data === 'object') {
     const obj = data as Record<string, unknown>
     for (const key of required) {
       if (isEmpty(obj[key])) return false

--- a/portals/apps/trader-app/src/zones/renderers/index.tsx
+++ b/portals/apps/trader-app/src/zones/renderers/index.tsx
@@ -1,22 +1,15 @@
-import type { ComponentType } from 'react'
 import type { ZoneComponent } from '../types'
 import { FormRenderer } from './FormRenderer'
 import { MarkdownRenderer } from './MarkdownRenderer'
 import { UnknownRenderer } from './UnknownRenderer'
-import type { ZoneRenderer } from './types'
-
-type Registry = { [K in ZoneComponent['type']]: ZoneRenderer<K> }
-
-// Add new component types here. `satisfies` ensures every variant in the
-// ZoneComponent discriminated union has a renderer — missing one fails the
-// build instead of falling through to UnknownRenderer at runtime.
-const REGISTRY = {
-  FORM: FormRenderer,
-  MARKDOWN: MarkdownRenderer,
-} satisfies Registry
 
 export function renderZoneComponent(component: ZoneComponent) {
-  const Renderer = REGISTRY[component.type] as ComponentType<{ payload: typeof component.payload }> | undefined
-  if (!Renderer) return <UnknownRenderer type={component.type} />
-  return <Renderer payload={component.payload} />
+  switch (component.type) {
+    case 'FORM':
+      return <FormRenderer payload={component.payload} />
+    case 'MARKDOWN':
+      return <MarkdownRenderer payload={component.payload} />
+    default:
+      return <UnknownRenderer type={(component as { type: string }).type} />
+  }
 }


### PR DESCRIPTION
## Summary

Wires the new zone-based renderer end-to-end in `trader-app` behind the `VITE_USE_ZONE_RENDERER` feature flag. The backend grows a `ZoneViewAssembler` that projects a task record into a `ZoneView` payload; the frontend consumes it via a clean workspace/presentational zone split. Closes #395.

Download these files and place it inside the `backend/configs/`
[fcau-configs.zip](https://github.com/user-attachments/files/28224670/fcau-configs.zip)

## Type of Change

- [x] New feature (non-breaking change which adds functionality)
- [x] Refactoring (no functional changes)

## Changes Made

**Backend**
- New `taskv2/renderer/zone_assembler.go` + `zoneview.go`: assembles `ZoneView` (sections, actions, state, audit) from a `TaskRecord` + its render config, using the existing uiprojector pipeline.
- `taskv2/http_handler.go`: `GET /tasks/{id}` returns the assembled `ZoneView` when the new path is active.
- `taskv2/wiring.go` + `app/bootstrap/app.go`: wires the assembler into the renderer factory.

**Frontend — zone architecture**
- `WorkspaceZone.tsx` (new): owns workspace chrome — `formRef`, validity state, submitting state, action bar. For `FORM` components, renders `FormRenderer` directly to attach the ref + validity callback; otherwise falls back to the generic dispatcher.
- `PresentationalZone.tsx` (new): dumb wrapper for `reference`/`instructions` zones — header + generic dispatcher.
- `TraderZoneLayout.tsx`: slimmed down to a thin layout that slots `WorkspaceZone` for the workspace and `PresentationalZone` for the rest. No form state. Workspace is keyed on `task_id:state` so a state transition remounts it with fresh form state.
- `renderers/index.tsx`: `renderZoneComponent(component)` reverted to a pure single-arg dispatcher.
- `renderers/FormRenderer.tsx`: exposes `FormHandle = { getData, autoFill }` via ref. `onValidityChange` callback prop emits validity on every JSONForms change. Built-in validity helper treats empty string/null/undefined/empty-array as missing for any schema-required field (works around AJV's permissive `required` check). Auto-fill encapsulates `autoFillForm` internally so the workspace doesn't reach into form internals.

**Frontend — wiring**
- `screens/TaskDetailScreen.tsx`: when `VITE_USE_ZONE_RENDERER` is on, fetches `ZoneView` via `getZoneView` and renders `TraderZoneLayout`. `onSubmitForm` POSTs the data, waits 1.5s for Temporal to advance, then refetches.
- `services/task.ts`: adds `getZoneView` + `submitTaskStep`.
- `services/api.ts`: `apiPost`/`apiPut` now treat an empty body on a 2xx response as `undefined` (was throwing). 204 No Content from `POST /tasks/{id}` is a legitimate success.

## Testing

- [x] I have tested this change locally
- [ ] I have added unit tests for new functionality
- [x] I have tested edge cases (empty form invalidation, post-submit refetch, 204 handling, form-state reset on task state transition)
- [x] All existing tests pass

Manually exercised:
1. Submit button starts disabled on empty form, enables when all required fields filled, disables again if a required field is cleared.
2. Submit POSTs the form, receives 204, waits 1.5s, refetches — `WorkspaceZone` remounts cleanly when `task.state` transitions.
3. Auto-fill button (gated by `VITE_SHOW_AUTOFILL_BUTTON`) populates the form and enables submit.
4. Reference zone hides when there's no `reviewerform` data, appears once external review writes it back.
5. v1 rendering path (flag off) untouched — verified existing flows still work.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings (`tsc --noEmit` clean; no new lint errors in changed files)
- [x] I have checked that there are no merge conflicts

## Related Issues

Closes #395

## Additional Notes

**Architecture rationale.** The split between `WorkspaceZone` and `PresentationalZone` was deliberate. Workspace is the only *editable* zone — it owns the form-ref + validity + submit-state coupling. Reference and instructions are presentational. Keeping the generic `renderZoneComponent` dispatcher pure (single arg, no form plumbing) means new presentational renderers don't pay for workspace-only concerns.

**Known seams** (intentional, deferred until needed):
- Workspace identity is position-based (`name === 'workspace'`). Fine while we have one editable zone per task; would need a `mode` flag if a task ever needs multiple editors.
- `FORM` is special-cased inside `WorkspaceZone`. When a second submittable renderer appears (provider picker for payments — see follow-up below), the special-case generalizes to a `SubmittableHandle` interface.
- `getTaskInfo` and `getZoneView` GET the same URL with different response interpretations. Will consolidate when the v1 path is retired.

**Backend echo on refetch.** The backend returns the user's just-submitted data back in `payload.data`, so when state transitions are slow the form may look unchanged after refresh. The 1.5s delay + state-keyed remount mitigates this; a deeper fix is out of scope for this PR.

**Follow-up captured.** PAYMENT plugin + zone renderer (including provider-selection workspace and the generalization to `SubmittableHandle`) is captured as a separate workstream — not in scope here.

## Config changes (attached separately)

The FCAU render configs need a small companion change to exercise the new pipeline — not included in the pushed commits since they live under `backend/configs/fcau/`. I'll attach the full `fcau/` folder as a zip for reviewers to drop in locally and test against.

- `fcau/1-application/render.json`: added `visibleWhen: { requireDataKey: "reviewerform" }` to the `reference` section so the reviewer form only appears once the external review writes data back. Also added the workspace `submit_form` action for the `PENDING_USER` state.

## Deployment Notes

- Feature flag `VITE_USE_ZONE_RENDERER` defaults to `false`. The v1 rendering path is unchanged.
- Dev-only flag `VITE_SHOW_AUTOFILL_BUTTON` restores the demo auto-fill button in the new path.
- Reviewers: unzip the attached `fcau/` folder over `backend/configs/fcau/` to pick up the render-config changes before testing.
