### PR TITLE
feat(uiprojector): decouple projector identity from render type

### DIFF
--- a/backend/pkg/uiprojector/assembler.go
+++ b/backend/pkg/uiprojector/assembler.go
@@ -81,16 +81,16 @@ func (a *Assembler) Assemble(ctx context.Context, blueprint *Blueprint, facts Fa
 		}
 
 		// 5. Project
-		content, err := proj.Project(ctx, templateContent, sectionData)
+		projection, err := proj.Project(ctx, templateContent, sectionData)
 		if err != nil {
 			return nil, fmt.Errorf("assembler: projection failed for section %s: %w", sb.ID, err)
 		}
 
 		sections[zone] = Section{
 			ID:      sb.ID,
-			Type:    SectionType(proj.Type()),
+			Type:    projection.Type,
 			Title:   sb.Title,
-			Content: content,
+			Content: projection.Content,
 		}
 	}
 

--- a/backend/pkg/uiprojector/assembler.go
+++ b/backend/pkg/uiprojector/assembler.go
@@ -85,6 +85,9 @@ func (a *Assembler) Assemble(ctx context.Context, blueprint *Blueprint, facts Fa
 		if err != nil {
 			return nil, fmt.Errorf("assembler: projection failed for section %s: %w", sb.ID, err)
 		}
+		if projection.Type == "" {
+			return nil, fmt.Errorf("assembler: projector %s returned empty Projection.Type for section %s", sb.Projector, sb.ID)
+		}
 
 		sections[zone] = Section{
 			ID:      sb.ID,

--- a/backend/pkg/uiprojector/assembler_test.go
+++ b/backend/pkg/uiprojector/assembler_test.go
@@ -244,6 +244,29 @@ func TestAssembler_Assemble_ProjectorError(t *testing.T) {
 	assert.Contains(t, err.Error(), "section-7", "error should mention the failing section ID")
 }
 
+type emptyTypeProjector struct{ typeName uiprojector.ProjectorType }
+
+func (p *emptyTypeProjector) Type() uiprojector.ProjectorType { return p.typeName }
+func (p *emptyTypeProjector) Project(_ context.Context, _ []byte, _ any) (uiprojector.Projection, error) {
+	return uiprojector.Projection{Type: "", Content: "ok"}, nil
+}
+
+func TestAssembler_Assemble_EmptyProjectionType(t *testing.T) {
+	ctx := context.Background()
+	tp := &stubTemplateProvider{templates: map[string][]byte{"t": []byte("x")}}
+	asm, err := uiprojector.NewAssembler(tp, []uiprojector.Projector{&emptyTypeProjector{typeName: "P"}})
+	require.NoError(t, err)
+
+	bp := &uiprojector.Blueprint{Sections: map[string]uiprojector.SectionBlueprint{
+		"main": {ID: "section-7", TemplateID: "t", Projector: "P"},
+	}}
+
+	_, err = asm.Assemble(ctx, bp, uiprojector.Facts{})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "empty Projection.Type")
+	assert.Contains(t, err.Error(), "section-7")
+}
+
 func TestAssembler_Assemble_DataKeyMissingPassesNil(t *testing.T) {
 	ctx := context.Background()
 	tp := &stubTemplateProvider{templates: map[string][]byte{"t": []byte("x")}}

--- a/backend/pkg/uiprojector/assembler_test.go
+++ b/backend/pkg/uiprojector/assembler_test.go
@@ -28,6 +28,7 @@ func (s *stubTemplateProvider) GetTemplate(_ context.Context, id string) ([]byte
 
 type stubProjector struct {
 	typeName     uiprojector.ProjectorType
+	renderType   uiprojector.SectionType // when empty, defaults to SectionType(typeName)
 	lastTemplate []byte
 	lastData     any
 	out          any
@@ -36,13 +37,17 @@ type stubProjector struct {
 
 func (p *stubProjector) Type() uiprojector.ProjectorType { return p.typeName }
 
-func (p *stubProjector) Project(_ context.Context, template []byte, data any) (any, error) {
+func (p *stubProjector) Project(_ context.Context, template []byte, data any) (uiprojector.Projection, error) {
 	p.lastTemplate = template
 	p.lastData = data
 	if p.err != nil {
-		return nil, p.err
+		return uiprojector.Projection{}, p.err
 	}
-	return p.out, nil
+	rt := p.renderType
+	if rt == "" {
+		rt = uiprojector.SectionType(p.typeName)
+	}
+	return uiprojector.Projection{Type: rt, Content: p.out}, nil
 }
 
 func TestNewAssembler(t *testing.T) {

--- a/backend/pkg/uiprojector/defaults.go
+++ b/backend/pkg/uiprojector/defaults.go
@@ -10,6 +10,16 @@ const (
 	ProjectorRaw      ProjectorType = "RAW"
 )
 
+// Built-in render types emitted by the projectors shipped with this package.
+// These are the SectionType values carried on Projection.Type and copied into
+// Section.Type for the frontend. Custom projectors may emit any other string,
+// and a single projector may emit more than one render type per invocation.
+const (
+	SectionTypeForm     SectionType = "FORM"
+	SectionTypeMarkdown SectionType = "MARKDOWN"
+	SectionTypeRaw      SectionType = "RAW"
+)
+
 // DefaultProjectors returns a fresh slice containing the projectors shipped
 // with this package. The returned slice is owned by the caller and safe to
 // mutate — append, replace, or drop entries before passing it to NewAssembler.

--- a/backend/pkg/uiprojector/projector.go
+++ b/backend/pkg/uiprojector/projector.go
@@ -12,12 +12,23 @@ import (
 // declare their own ProjectorType constants to register custom projectors.
 type ProjectorType string
 
+// Projection is the result of a projector's Project call. Type identifies the
+// render shape the frontend should use; Content is the payload it renders.
+// A single projector may emit different Types per invocation when the choice
+// depends on runtime data (e.g. a payment projector switching between REDIRECT
+// and DESCRIPTION based on the configured payment method).
+type Projection struct {
+	Type    SectionType
+	Content any
+}
+
 // Projector defines the interface for transforming raw template + data into a UI payload.
 // Type returns the identifier under which the projector is registered; it must match
-// the SectionBlueprint.Projector values used in blueprints.
+// the SectionBlueprint.Projector values used in blueprints. The render type used by
+// the frontend is carried on the Projection returned from Project, not on Type().
 type Projector interface {
 	Type() ProjectorType
-	Project(ctx context.Context, templateContent []byte, data any) (any, error)
+	Project(ctx context.Context, templateContent []byte, data any) (Projection, error)
 }
 
 // FormProjector projects raw JSON schema into a FormContent payload.
@@ -29,16 +40,19 @@ func NewFormProjector() *FormProjector {
 
 func (p *FormProjector) Type() ProjectorType { return ProjectorForm }
 
-func (p *FormProjector) Project(ctx context.Context, templateContent []byte, data any) (any, error) {
+func (p *FormProjector) Project(ctx context.Context, templateContent []byte, data any) (Projection, error) {
 	var schema map[string]any
 	if err := json.Unmarshal(templateContent, &schema); err != nil {
-		return nil, fmt.Errorf("form_projector: failed to parse schema: %w", err)
+		return Projection{}, fmt.Errorf("form_projector: failed to parse schema: %w", err)
 	}
 
-	return FormContent{
-		Schema:   schema["schema"],
-		UISchema: schema["uiSchema"],
-		Data:     data,
+	return Projection{
+		Type: SectionTypeForm,
+		Content: FormContent{
+			Schema:   schema["schema"],
+			UISchema: schema["uiSchema"],
+			Data:     data,
+		},
 	}, nil
 }
 
@@ -51,18 +65,18 @@ func NewMarkdownProjector() *MarkdownProjector {
 
 func (p *MarkdownProjector) Type() ProjectorType { return ProjectorMarkdown }
 
-func (p *MarkdownProjector) Project(ctx context.Context, templateContent []byte, data any) (any, error) {
+func (p *MarkdownProjector) Project(ctx context.Context, templateContent []byte, data any) (Projection, error) {
 	tmpl, err := template.New("markdown").Parse(string(templateContent))
 	if err != nil {
-		return nil, fmt.Errorf("markdown_projector: failed to parse template: %w", err)
+		return Projection{}, fmt.Errorf("markdown_projector: failed to parse template: %w", err)
 	}
 
 	var buf bytes.Buffer
 	if err := tmpl.Execute(&buf, data); err != nil {
-		return nil, fmt.Errorf("markdown_projector: failed to execute template: %w", err)
+		return Projection{}, fmt.Errorf("markdown_projector: failed to execute template: %w", err)
 	}
 
-	return buf.String(), nil
+	return Projection{Type: SectionTypeMarkdown, Content: buf.String()}, nil
 }
 
 // RawProjector returns the data as-is without any transformation.
@@ -74,6 +88,6 @@ func NewRawProjector() *RawProjector {
 
 func (p *RawProjector) Type() ProjectorType { return ProjectorRaw }
 
-func (p *RawProjector) Project(ctx context.Context, templateContent []byte, data any) (any, error) {
-	return data, nil
+func (p *RawProjector) Project(ctx context.Context, templateContent []byte, data any) (Projection, error) {
+	return Projection{Type: SectionTypeRaw, Content: data}, nil
 }

--- a/backend/pkg/uiprojector/projector_test.go
+++ b/backend/pkg/uiprojector/projector_test.go
@@ -19,9 +19,10 @@ func TestFormProjector_Project(t *testing.T) {
 
 		out, err := p.Project(ctx, template, data)
 		require.NoError(t, err)
+		assert.Equal(t, uiprojector.SectionTypeForm, out.Type)
 
-		fc, ok := out.(uiprojector.FormContent)
-		require.True(t, ok, "expected FormContent, got %T", out)
+		fc, ok := out.Content.(uiprojector.FormContent)
+		require.True(t, ok, "expected FormContent, got %T", out.Content)
 		assert.Equal(t, map[string]any{"type": "object"}, fc.Schema)
 		assert.Equal(t, map[string]any{"ui:order": []any{"name"}}, fc.UISchema)
 		assert.Equal(t, data, fc.Data)
@@ -32,7 +33,7 @@ func TestFormProjector_Project(t *testing.T) {
 		out, err := p.Project(ctx, template, nil)
 		require.NoError(t, err)
 
-		fc := out.(uiprojector.FormContent)
+		fc := out.Content.(uiprojector.FormContent)
 		assert.NotNil(t, fc.Schema)
 		assert.Nil(t, fc.UISchema)
 		assert.Nil(t, fc.Data)
@@ -42,7 +43,7 @@ func TestFormProjector_Project(t *testing.T) {
 		out, err := p.Project(ctx, []byte("{}"), "data")
 		require.NoError(t, err)
 
-		fc := out.(uiprojector.FormContent)
+		fc := out.Content.(uiprojector.FormContent)
 		assert.Nil(t, fc.Schema)
 		assert.Nil(t, fc.UISchema)
 		assert.Equal(t, "data", fc.Data)
@@ -63,25 +64,26 @@ func TestMarkdownProjector_Project(t *testing.T) {
 	t.Run("substitutes data fields into template", func(t *testing.T) {
 		out, err := p.Project(ctx, []byte("Hello {{.Name}}!"), map[string]any{"Name": "World"})
 		require.NoError(t, err)
-		assert.Equal(t, "Hello World!", out)
+		assert.Equal(t, uiprojector.SectionTypeMarkdown, out.Type)
+		assert.Equal(t, "Hello World!", out.Content)
 	})
 
 	t.Run("returns template verbatim when there are no placeholders", func(t *testing.T) {
 		out, err := p.Project(ctx, []byte("static text"), nil)
 		require.NoError(t, err)
-		assert.Equal(t, "static text", out)
+		assert.Equal(t, "static text", out.Content)
 	})
 
 	t.Run("returns empty string for empty template", func(t *testing.T) {
 		out, err := p.Project(ctx, []byte(""), nil)
 		require.NoError(t, err)
-		assert.Equal(t, "", out)
+		assert.Equal(t, "", out.Content)
 	})
 
 	t.Run("renders <no value> for missing fields under default text/template options", func(t *testing.T) {
 		out, err := p.Project(ctx, []byte("Hello {{.Missing}}"), map[string]any{})
 		require.NoError(t, err)
-		assert.Contains(t, out.(string), "<no value>")
+		assert.Contains(t, out.Content.(string), "<no value>")
 	})
 
 	t.Run("returns parse error for malformed template syntax", func(t *testing.T) {
@@ -100,18 +102,19 @@ func TestRawProjector_Project(t *testing.T) {
 		data := map[string]any{"foo": "bar"}
 		out, err := p.Project(ctx, []byte("ignored"), data)
 		require.NoError(t, err)
-		assert.Equal(t, data, out)
+		assert.Equal(t, uiprojector.SectionTypeRaw, out.Type)
+		assert.Equal(t, data, out.Content)
 	})
 
 	t.Run("returns nil when data is nil", func(t *testing.T) {
 		out, err := p.Project(ctx, nil, nil)
 		require.NoError(t, err)
-		assert.Nil(t, out)
+		assert.Nil(t, out.Content)
 	})
 
 	t.Run("ignores template content entirely", func(t *testing.T) {
 		out, err := p.Project(ctx, []byte("garbage that would break other projectors"), 42)
 		require.NoError(t, err)
-		assert.Equal(t, 42, out)
+		assert.Equal(t, 42, out.Content)
 	})
 }


### PR DESCRIPTION
## Summary

`Projector.Type()` was doing double duty as both the registry key and the render type written to `Section.Type`. That coupling blocked two real cases: (a) multiple distinct projectors that legitimately emit the same render shape, and (b) a single projector that needs to choose its render type at runtime (e.g. a `PaymentProjector` returning `REDIRECT` for online gateways vs `DESCRIPTION` for offline instructions).

This PR splits the two concerns: `Type()` stays as the registry key, and `Project` now returns a `Projection{Type, Content}` so the render type is chosen per invocation.

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [x] Refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Other (please describe):

The `Projector` interface signature changed, which is a breaking change for any external implementer. The package currently has no callers outside its own tests, so production impact is nil.

## Changes Made

- Added `Projection{Type SectionType, Content any}` in `pkg/uiprojector/projector.go`.
- Changed `Projector.Project` to return `(Projection, error)` instead of `(any, error)`.
- `Type()` is now documented as registry-key only; render type is read from `Projection.Type`.
- Updated `FormProjector`, `MarkdownProjector`, `RawProjector` to emit the new struct, using new `SectionTypeForm` / `SectionTypeMarkdown` / `SectionTypeRaw` constants added in `defaults.go`.
- `Assembler.Assemble` now copies `projection.Type` and `projection.Content` into the resulting `Section` (previously it copied `proj.Type()` into `Section.Type`).
- Updated unit tests and the integration test stub to match the new contract.

## Testing

- [x] I have tested this change locally
- [x] I have added unit tests for new functionality
- [x] I have tested edge cases
- [x] All existing tests pass

`go test ./pkg/uiprojector/...` passes (both unit and integration suites).

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have checked that there are no merge conflicts

`pkg/uiprojector/README.md` was not updated in this PR — worth a follow-up once the `PaymentProjector` lands and we can document the dynamic-render-type pattern with a real example.

## Related Issues

Closes #558

## Additional Notes

Reviewer note on what this does **not** address (called out in #558's discussion but intentionally left out of scope):

- Stable section ordering — `Blueprint.Sections` is still a map; ordering is unaddressed here.
- Partial-success on projection errors — one bad section still aborts the whole `Assemble`.
- Template caching — the existing TODO in `assembler.go` is unchanged.
- Constraining which render types a zone may accept — possible follow-up if dynamic projectors proliferate.

## Deployment Notes

No runtime behavior changes for existing call sites because the package has no callers outside its own tests yet. No migrations or config changes required.