### PR TITLE
feat(authz): introduce Principal abstraction and RequireScope middleware (v1 plumbing)

### DIFF
--- a/backend/internal/authz/README.md
+++ b/backend/internal/authz/README.md
@@ -1,0 +1,342 @@
+# authz
+
+Authorization primitives for the NSW backend. Complements
+[`internal/auth`](../auth/) — `auth` answers *"who is the caller?"*, this
+package answers *"what is the caller allowed to do?"*.
+
+The package is designed around a single rule:
+**the downstream service decides who is allowed.** Middleware is a coarse
+gate; handlers are dumb HTTP adapters; services own the policy.
+
+---
+
+## Contents
+
+- `Principal` — a unified view of an authenticated caller (user *or*
+  M2M client) with `HasRole` / `HasScope` helpers.
+- `Manager` — owns the static scope configuration and constructs
+  `Principal`s and middleware.
+- `RequireScope(scope)` — per-route HTTP middleware factory that
+  rejects callers lacking a declared scope.
+- `ErrUnauthenticated` / `ErrForbidden` — sentinel errors that services
+  return and handlers map onto 401 / 403.
+
+---
+
+## The layered model
+
+| Layer | What it decides | Where it lives |
+|---|---|---|
+| `auth.Middleware` (existing) | Is the JWT valid? Who is the caller? | `internal/auth/middleware.go` |
+| `authz.RequireScope` | Does the caller carry *any* scope strong enough to even attempt this route? | route registration in `bootstrap/app.go` |
+| Handler | HTTP wiring only. Pulls the `Principal` from context, forwards it to the service, maps `ErrForbidden` → 403. | per-feature `router.go` |
+| **Service** | All fine-grained decisions: ownership ("is this consignment owned by this user's company?"), role branching, M2M scope checks. | per-feature `service.go` |
+
+> Rule of thumb: if the answer depends on a database lookup, it belongs in
+> the service. If the answer is "is this scope string in the principal's
+> set?", it belongs in middleware.
+
+---
+
+## Wiring it up
+
+`Manager` is constructed once at startup and injected into the handlers
+that need it, mirroring the existing `auth.Manager` pattern.
+
+```go
+// internal/app/bootstrap/app.go
+authzManager, err := authz.NewManager(authz.Config{
+    RoleScopes: map[string][]string{
+        "trader": {"consignments:read", "consignments:write"},
+        "cha":    {"consignments:read", "consignments:initialize"},
+    },
+    ClientScopes: map[string][]string{
+        "LANKAPAY_M2M":  {"payments:webhook"},
+        "FCAU_TO_NSW":   {"consignments:read:all"},
+    },
+})
+if err != nil {
+    return fmt.Errorf("initialize authz manager: %w", err)
+}
+
+withAuth   := authManager.Middleware()
+withScope  := authzManager.RequireScope            // closure-friendly alias
+
+mux.Handle("GET /api/v1/consignments",
+    withAuth(withScope("consignments:read")(
+        http.HandlerFunc(consignmentRouter.HandleGetConsignments))))
+```
+
+`auth.Middleware` must run *before* `RequireScope`, since the latter reads
+the auth context the former injects. Empty `Config` is valid — the
+resulting manager treats every `HasScope` as `false`, useful while you're
+still wiring scopes for a feature.
+
+---
+
+## Migrating a handler — the v1 → v2 pattern
+
+Here is the before/after for a typical handler. The "before" is what is
+in `internal/consignment/router.go` today; the "after" is what v2 will
+look like.
+
+### Before (today)
+
+```go
+// router.go
+func (c *Router) HandleGetConsignments(w http.ResponseWriter, r *http.Request) {
+    authCtx := auth.GetAuthContext(r.Context())
+    if authCtx == nil || authCtx.User == nil {       // boilerplate; rejects M2M
+        http.Error(w, "Unauthorized", http.StatusUnauthorized)
+        return
+    }
+    // TODO: Proper AuthZ need to be implemented.
+    role := r.URL.Query().Get("role")                // user-supplied role — critical flaw
+    if role == "" { role = "trader" }
+    // ... look up company by OUHandle, filter, etc.
+}
+```
+
+### After (with this package)
+
+**1. Route declares its scope (coarse gate):**
+
+```go
+// bootstrap/app.go
+mux.Handle("GET /api/v1/consignments",
+    withAuth(withScope("consignments:read")(
+        http.HandlerFunc(consignmentRouter.HandleGetConsignments))))
+```
+
+**2. Handler shrinks to "extract principal, forward to service":**
+
+```go
+// router.go
+func (c *Router) HandleGetConsignments(w http.ResponseWriter, r *http.Request) {
+    p, ok := c.authz.Principal(r.Context())
+    if !ok {
+        http.Error(w, "Unauthorized", http.StatusUnauthorized)
+        return
+    }
+    out, err := c.cs.ListConsignmentsFor(r.Context(), p, parseFilter(r))
+    switch {
+    case errors.Is(err, authz.ErrForbidden):
+        http.Error(w, "Forbidden", http.StatusForbidden)
+    case err != nil:
+        slog.Error("list consignments", "error", err)
+        http.Error(w, "internal", http.StatusInternalServerError)
+    default:
+        writeJSON(w, http.StatusOK, out)
+    }
+}
+```
+
+**3. Service owns the policy:**
+
+```go
+// service.go
+func (s *Service) ListConsignmentsFor(ctx context.Context, p authz.Principal, f Filter) ([]Consignment, error) {
+    switch p.Kind() {
+    case authz.KindUser:
+        u, _ := p.User()
+        co, err := s.companyService.GetCompanyByOUHandle(ctx, u.OUHandle)
+        if err != nil {
+            return nil, authz.ErrForbidden    // unknown company == not allowed
+        }
+        switch {
+        case p.HasRole("trader"):
+            f.TraderCompanyID = &co.ID
+        case p.HasRole("cha"):
+            f.CHACompanyID = &co.ID
+        default:
+            return nil, authz.ErrForbidden
+        }
+    case authz.KindClient:
+        if !p.HasScope("consignments:read:all") {
+            return nil, authz.ErrForbidden
+        }
+        // M2M with the right scope sees everything — no company filter
+    }
+    return s.list(ctx, f)
+}
+```
+
+What changed:
+
+- The `role=` query parameter is **gone**. Role comes from the JWT roles
+  claim via `p.HasRole(...)`.
+- M2M clients can now reach this endpoint — the service handles them
+  with a different policy (scope-gated, no company filter).
+- The handler has *no* business logic. It maps HTTP to/from the service.
+- The route's `consignments:read` scope is the coarse gate. The
+  service's `HasRole` / `HasScope` checks are the fine gate.
+
+---
+
+## Patterns by access shape
+
+### Frontend-only endpoint
+
+A scope only mapped to user roles, never to a client. M2M tokens will be
+rejected at the middleware (`RequireScope`) with 403.
+
+```go
+RoleScopes:   {"trader": {"profile:write"}}
+ClientScopes: {/* no client has profile:write */}
+```
+
+```go
+mux.Handle("PUT /api/v1/profile",
+    withAuth(withScope("profile:write")(handler)))
+```
+
+### M2M-only endpoint (webhook, internal service)
+
+A scope only mapped to specific client IDs.
+
+```go
+RoleScopes:   {/* no role has payments:webhook */}
+ClientScopes: {"LANKAPAY_M2M": {"payments:webhook"}}
+```
+
+```go
+mux.Handle("POST /api/v1/payments/webhook",
+    withAuth(withScope("payments:webhook")(handler)))
+```
+
+### Mixed endpoint (same route, different policies)
+
+Same scope appears in both maps. The middleware lets both through; the
+service branches on `Kind`.
+
+```go
+RoleScopes:   {"trader": {"consignments:read"}, "cha": {"consignments:read"}}
+ClientScopes: {"FCAU_TO_NSW": {"consignments:read"}}
+```
+
+The service then decides whether the user sees only their company's data
+or whether the M2M sees everything (see the migration example above).
+
+---
+
+## Configuration model
+
+Scopes are *derived* in this package, not carried in the JWT. There are
+two maps:
+
+```go
+type Config struct {
+    RoleScopes   map[string][]string  // for OAuth2 authorization_code (users)
+    ClientScopes map[string][]string  // for OAuth2 client_credentials (M2M)
+}
+```
+
+- **`RoleScopes`** maps a JWT `roles[]` value to the scopes that role
+  grants. A user with multiple roles gets the **union** of their roles'
+  scopes.
+- **`ClientScopes`** maps an OAuth2 `client_id` to the scopes that
+  client is allowed to use. M2M scopes are looked up by `client_id` only,
+  not by any role claim (M2M tokens don't carry roles).
+
+`Manager` clones both maps at construction, so post-startup mutation of
+the input does **not** leak into the manager.
+
+### Adding a new scope
+
+1. Pick a string. Convention: `resource:action` (e.g.
+   `consignments:write`) or `resource:action:qualifier` (e.g.
+   `consignments:read:all` for "M2M sees everything").
+2. Add it to the relevant map(s) in `Config`.
+3. Declare it on the route(s) via `withScope("...")`.
+4. If the policy is fine-grained, also check it (or `HasRole`) inside
+   the service.
+
+That's it. There's no central scope registry yet — scope strings are
+literal in `bootstrap/app.go` and `service.go`. If you grow many scopes,
+collect them as `const` declarations in this package later.
+
+---
+
+## Testing patterns
+
+The unit tests in this package construct `Principal`s directly by
+injecting an `auth.AuthContext` into a `context.Context` — no JWT
+signing required. Copy this pattern when testing services that take a
+`Principal`:
+
+```go
+func ctxWithUser(roles ...string) context.Context {
+    return context.WithValue(context.Background(), auth.AuthContextKey,
+        &auth.AuthContext{User: &auth.UserContext{
+            ID:       "user-1",
+            OUHandle: "ou-test",
+            Roles:    roles,
+        }})
+}
+
+func ctxWithClient(clientID string) context.Context {
+    return context.WithValue(context.Background(), auth.AuthContextKey,
+        &auth.AuthContext{Client: &auth.ClientContext{ClientID: clientID}})
+}
+
+func TestListConsignments_TraderSeesOnlyOwnCompany(t *testing.T) {
+    mgr, _ := authz.NewManager(authz.Config{
+        RoleScopes: map[string][]string{"trader": {"consignments:read"}},
+    })
+    p, _ := mgr.Principal(ctxWithUser("trader"))
+
+    out, err := svc.ListConsignmentsFor(ctx, p, Filter{})
+    // ... assert filter applied
+}
+```
+
+For middleware-level tests, use `httptest.NewRecorder` and
+`req.WithContext(ctx)`. See `middleware_test.go` in this package for the
+full pattern.
+
+---
+
+## Common mistakes
+
+- **Reading `auth.AuthContext.User.Roles` directly in handlers.** Use
+  `p.HasRole(...)` — handlers should not know about the underlying auth
+  context shape.
+- **Putting ownership checks in middleware.** Middleware shouldn't hit
+  the database. Anything that requires a lookup of "does this resource
+  belong to this caller?" goes in the service.
+- **Returning a raw error from a service when it means "forbidden".**
+  Wrap with `%w` from `authz.ErrForbidden` (or return the sentinel
+  directly) so the handler can map it to 403 via `errors.Is`.
+- **Forgetting that `RequireScope` returns 401 for anonymous and 403
+  for missing scope.** That's the conventional distinction; don't
+  collapse them.
+- **Configuring an empty `Config` and wondering why all routes 403.**
+  Empty maps mean nobody has any scope. Either populate the config or
+  don't attach `RequireScope` yet.
+
+---
+
+## What's NOT in this package (yet)
+
+These are deliberately deferred. The interfaces are seams — when any of
+these become real, callers don't change.
+
+- **JWT-issued scope claims.** Today scopes are derived from static
+  config. When Thunder (the IdP) starts issuing `scope`/`scp` claims,
+  swap the resolver inside `principal_impl.go`; `HasScope` semantics
+  are unchanged.
+- **Role hierarchy.** Per the org's group/role model, roles live at the
+  private-sector OU and are inherited by child OUs. Today `HasRole`
+  does exact-match against the JWT roles claim. Hierarchy resolution
+  can be added inside `HasRole` without touching callers.
+- **Audit logging.** `RequireScope` only logs warnings on 403. A future
+  PR will emit structured audit events for every forbidden decision.
+- **Webhook signatures.** `payments/webhook` is unauthenticated today.
+  A future PR will secure it with either HMAC signatures or a dedicated
+  `payments:webhook` scope for M2M.
+- **Policy engines (OPA, Casbin).** Not warranted at current scale.
+  Pure Go interfaces are enough.
+
+See [the v1 PR](https://github.com/OpenNSW/nsw/pull/561) for the full
+phased rollout plan (v2: migrate consignment; v3: remaining handlers;
+v4: security hardening).

--- a/backend/internal/authz/config.go
+++ b/backend/internal/authz/config.go
@@ -1,0 +1,47 @@
+package authz
+
+import "fmt"
+
+// Config configures the authorization manager. Both maps are static
+// configuration typically loaded once at application startup. An empty
+// configuration is valid and produces a manager where every HasScope check
+// returns false; this is useful in environments where authorization is
+// still being rolled out per feature.
+type Config struct {
+	// RoleScopes maps a JWT role claim value to the scopes that role grants.
+	// Applied to principals authenticated via OAuth2 authorization_code grant.
+	// Example: {"trader": ["consignments:read", "consignments:write"]}.
+	RoleScopes map[string][]string
+
+	// ClientScopes maps an OAuth2 client_id to the scopes that client is
+	// allowed to use. Applied to principals authenticated via OAuth2
+	// client_credentials grant.
+	// Example: {"lankapay-m2m": ["payments:webhook"]}.
+	ClientScopes map[string][]string
+}
+
+// Validate returns an error if the configuration contains structural
+// problems. Empty maps are allowed; empty scope strings are not.
+func (c Config) Validate() error {
+	for role, scopes := range c.RoleScopes {
+		if role == "" {
+			return fmt.Errorf("AUTHZ_ROLE_SCOPES: role name must not be empty")
+		}
+		for _, scope := range scopes {
+			if scope == "" {
+				return fmt.Errorf("AUTHZ_ROLE_SCOPES: role %q has an empty scope", role)
+			}
+		}
+	}
+	for clientID, scopes := range c.ClientScopes {
+		if clientID == "" {
+			return fmt.Errorf("AUTHZ_CLIENT_SCOPES: client id must not be empty")
+		}
+		for _, scope := range scopes {
+			if scope == "" {
+				return fmt.Errorf("AUTHZ_CLIENT_SCOPES: client %q has an empty scope", clientID)
+			}
+		}
+	}
+	return nil
+}

--- a/backend/internal/authz/manager.go
+++ b/backend/internal/authz/manager.go
@@ -3,6 +3,7 @@ package authz
 import (
 	"context"
 	"fmt"
+	"slices"
 
 	"github.com/OpenNSW/nsw/internal/auth"
 )
@@ -56,9 +57,7 @@ func cloneScopeMap(src map[string][]string) map[string][]string {
 	}
 	dst := make(map[string][]string, len(src))
 	for k, v := range src {
-		copied := make([]string, len(v))
-		copy(copied, v)
-		dst[k] = copied
+		dst[k] = slices.Clone(v)
 	}
 	return dst
 }

--- a/backend/internal/authz/manager.go
+++ b/backend/internal/authz/manager.go
@@ -1,0 +1,58 @@
+package authz
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/OpenNSW/nsw/internal/auth"
+)
+
+// Manager owns the static authorization configuration and exposes helpers
+// for building Principals and constructing scope-checking middleware. The
+// manager mirrors the pattern of auth.Manager: construct once at startup
+// and inject the same instance into handlers and services that need it.
+type Manager struct {
+	roleScopes   map[string][]string
+	clientScopes map[string][]string
+}
+
+// NewManager constructs a Manager from the given configuration. Returns an
+// error if the configuration is structurally malformed. An empty config is
+// permitted; the resulting manager treats every scope check as false.
+func NewManager(cfg Config) (*Manager, error) {
+	if err := cfg.Validate(); err != nil {
+		return nil, fmt.Errorf("invalid authz config: %w", err)
+	}
+	return &Manager{
+		roleScopes:   cloneScopeMap(cfg.RoleScopes),
+		clientScopes: cloneScopeMap(cfg.ClientScopes),
+	}, nil
+}
+
+// Principal returns the authenticated principal for the given request
+// context, resolved from the auth context injected by auth.Middleware.
+// ok=false when no auth context is attached (anonymous request) or when
+// the attached context is empty (neither user nor client present).
+func (m *Manager) Principal(ctx context.Context) (Principal, bool) {
+	authCtx := auth.GetAuthContext(ctx)
+	if authCtx == nil {
+		return nil, false
+	}
+	if authCtx.User == nil && authCtx.Client == nil {
+		return nil, false
+	}
+	return &principal{authCtx: authCtx, manager: m}, true
+}
+
+func cloneScopeMap(src map[string][]string) map[string][]string {
+	if len(src) == 0 {
+		return map[string][]string{}
+	}
+	dst := make(map[string][]string, len(src))
+	for k, v := range src {
+		copied := make([]string, len(v))
+		copy(copied, v)
+		dst[k] = copied
+	}
+	return dst
+}

--- a/backend/internal/authz/manager.go
+++ b/backend/internal/authz/manager.go
@@ -31,9 +31,15 @@ func NewManager(cfg Config) (*Manager, error) {
 
 // Principal returns the authenticated principal for the given request
 // context, resolved from the auth context injected by auth.Middleware.
-// ok=false when no auth context is attached (anonymous request) or when
-// the attached context is empty (neither user nor client present).
+// ok=false when no auth context is attached (anonymous request), when
+// the attached context is empty (neither user nor client present), or
+// when the receiver itself is nil (defensive — a nil Manager indicates
+// a wiring bug, but treating it as "no principal" avoids a delayed
+// panic on the first HasScope call).
 func (m *Manager) Principal(ctx context.Context) (Principal, bool) {
+	if m == nil {
+		return nil, false
+	}
 	authCtx := auth.GetAuthContext(ctx)
 	if authCtx == nil {
 		return nil, false

--- a/backend/internal/authz/middleware.go
+++ b/backend/internal/authz/middleware.go
@@ -29,14 +29,14 @@ func (m *Manager) RequireScope(scope string) func(http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			p, ok := m.Principal(r.Context())
 			if !ok {
-				slog.Debug("authz: no principal on request", "scope", scope, "path", r.URL.Path)
+				slog.DebugContext(r.Context(), "authz: no principal on request", "scope", scope, "path", r.URL.Path)
 				w.Header().Set("Content-Type", "application/json")
 				w.WriteHeader(http.StatusUnauthorized)
 				_, _ = w.Write([]byte(`{"error":"unauthorized","message":"authentication required"}`))
 				return
 			}
 			if !p.HasScope(scope) {
-				slog.Warn("authz: principal lacks required scope",
+				slog.WarnContext(r.Context(), "authz: principal lacks required scope",
 					"scope", scope,
 					"kind", p.Kind(),
 					"subject", p.Subject(),

--- a/backend/internal/authz/middleware.go
+++ b/backend/internal/authz/middleware.go
@@ -1,0 +1,46 @@
+package authz
+
+import (
+	"log/slog"
+	"net/http"
+)
+
+// RequireScope returns a middleware that rejects requests whose principal
+// lacks the given scope. Use it to declare a coarse authorization gate per
+// route at the application's router setup.
+//
+// Behaviour:
+//   - No principal on the request (anonymous): 401 Unauthorized.
+//   - Principal lacks the scope: 403 Forbidden.
+//   - Otherwise: next handler is invoked unchanged.
+//
+// The JSON response shape matches the existing auth middleware so clients
+// see a consistent error format across authentication and authorization
+// failures.
+func (m *Manager) RequireScope(scope string) func(http.Handler) http.Handler {
+	return func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			p, ok := m.Principal(r.Context())
+			if !ok {
+				slog.Debug("authz: no principal on request", "scope", scope, "path", r.URL.Path)
+				w.Header().Set("Content-Type", "application/json")
+				w.WriteHeader(http.StatusUnauthorized)
+				_, _ = w.Write([]byte(`{"error":"unauthorized","message":"authentication required"}`))
+				return
+			}
+			if !p.HasScope(scope) {
+				slog.Warn("authz: principal lacks required scope",
+					"scope", scope,
+					"kind", p.Kind(),
+					"subject", p.Subject(),
+					"path", r.URL.Path,
+				)
+				w.Header().Set("Content-Type", "application/json")
+				w.WriteHeader(http.StatusForbidden)
+				_, _ = w.Write([]byte(`{"error":"forbidden","message":"insufficient scope"}`))
+				return
+			}
+			next.ServeHTTP(w, r)
+		})
+	}
+}

--- a/backend/internal/authz/middleware.go
+++ b/backend/internal/authz/middleware.go
@@ -17,7 +17,14 @@ import (
 // The JSON response shape matches the existing auth middleware so clients
 // see a consistent error format across authentication and authorization
 // failures.
+//
+// Panics at construction time if the receiver is nil. Failing fast at
+// route-wiring time produces a clear bootstrap error instead of a
+// closure that panics on the first request.
 func (m *Manager) RequireScope(scope string) func(http.Handler) http.Handler {
+	if m == nil {
+		panic("authz: RequireScope called on a nil Manager")
+	}
 	return func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			p, ok := m.Principal(r.Context())

--- a/backend/internal/authz/middleware_test.go
+++ b/backend/internal/authz/middleware_test.go
@@ -17,6 +17,21 @@ func newNextHandler(called *bool) http.Handler {
 	})
 }
 
+func TestRequireScope_NilManagerPanicsAtConstruction(t *testing.T) {
+	defer func() {
+		r := recover()
+		if r == nil {
+			t.Fatal("expected panic when RequireScope is called on a nil Manager")
+		}
+		msg, ok := r.(string)
+		if !ok || !strings.Contains(msg, "nil Manager") {
+			t.Fatalf("expected panic message mentioning nil Manager, got %v (%T)", r, r)
+		}
+	}()
+	var mgr *Manager
+	_ = mgr.RequireScope("anything")
+}
+
 func TestRequireScope_AnonymousReturns401(t *testing.T) {
 	mgr := newTestManager(t)
 

--- a/backend/internal/authz/middleware_test.go
+++ b/backend/internal/authz/middleware_test.go
@@ -1,0 +1,126 @@
+package authz
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/OpenNSW/nsw/internal/auth"
+)
+
+func newNextHandler(called *bool) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		*called = true
+		w.WriteHeader(http.StatusOK)
+	})
+}
+
+func TestRequireScope_AnonymousReturns401(t *testing.T) {
+	mgr := newTestManager(t)
+
+	var nextCalled bool
+	wrapped := mgr.RequireScope("consignments:read")(newNextHandler(&nextCalled))
+
+	req := httptest.NewRequest(http.MethodGet, "http://example.com/protected", nil)
+	rec := httptest.NewRecorder()
+	wrapped.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusUnauthorized {
+		t.Fatalf("expected 401, got %d", rec.Code)
+	}
+	if !strings.Contains(rec.Body.String(), `"unauthorized"`) {
+		t.Fatalf("expected JSON unauthorized body, got %q", rec.Body.String())
+	}
+	if nextCalled {
+		t.Fatal("expected next handler NOT to be called for anonymous request")
+	}
+	if got := rec.Header().Get("Content-Type"); got != "application/json" {
+		t.Fatalf("expected Content-Type application/json, got %q", got)
+	}
+}
+
+func TestRequireScope_UserMissingScopeReturns403(t *testing.T) {
+	mgr := newTestManager(t)
+	// cha has consignments:read but not consignments:write
+	ctx := context.WithValue(context.Background(), auth.AuthContextKey,
+		&auth.AuthContext{User: &auth.UserContext{IDPUserID: "u", Roles: []string{"cha"}}})
+
+	var nextCalled bool
+	wrapped := mgr.RequireScope("consignments:write")(newNextHandler(&nextCalled))
+
+	req := httptest.NewRequest(http.MethodGet, "http://example.com/protected", nil).WithContext(ctx)
+	rec := httptest.NewRecorder()
+	wrapped.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusForbidden {
+		t.Fatalf("expected 403, got %d", rec.Code)
+	}
+	if !strings.Contains(rec.Body.String(), `"forbidden"`) {
+		t.Fatalf("expected JSON forbidden body, got %q", rec.Body.String())
+	}
+	if nextCalled {
+		t.Fatal("expected next handler NOT to be called when scope is missing")
+	}
+}
+
+func TestRequireScope_UserWithScopeReachesHandler(t *testing.T) {
+	mgr := newTestManager(t)
+	ctx := context.WithValue(context.Background(), auth.AuthContextKey,
+		&auth.AuthContext{User: &auth.UserContext{IDPUserID: "u", Roles: []string{"trader"}}})
+
+	var nextCalled bool
+	wrapped := mgr.RequireScope("consignments:write")(newNextHandler(&nextCalled))
+
+	req := httptest.NewRequest(http.MethodGet, "http://example.com/protected", nil).WithContext(ctx)
+	rec := httptest.NewRecorder()
+	wrapped.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", rec.Code)
+	}
+	if !nextCalled {
+		t.Fatal("expected next handler to be called when scope is present")
+	}
+}
+
+func TestRequireScope_ClientWithScopeReachesHandler(t *testing.T) {
+	mgr := newTestManager(t)
+	ctx := context.WithValue(context.Background(), auth.AuthContextKey,
+		&auth.AuthContext{Client: &auth.ClientContext{ClientID: "LANKAPAY_M2M"}})
+
+	var nextCalled bool
+	wrapped := mgr.RequireScope("payments:webhook")(newNextHandler(&nextCalled))
+
+	req := httptest.NewRequest(http.MethodGet, "http://example.com/protected", nil).WithContext(ctx)
+	rec := httptest.NewRecorder()
+	wrapped.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", rec.Code)
+	}
+	if !nextCalled {
+		t.Fatal("expected next handler to be called when client has scope")
+	}
+}
+
+func TestRequireScope_ClientMissingScopeReturns403(t *testing.T) {
+	mgr := newTestManager(t)
+	ctx := context.WithValue(context.Background(), auth.AuthContextKey,
+		&auth.AuthContext{Client: &auth.ClientContext{ClientID: "STRANGER"}})
+
+	var nextCalled bool
+	wrapped := mgr.RequireScope("payments:webhook")(newNextHandler(&nextCalled))
+
+	req := httptest.NewRequest(http.MethodGet, "http://example.com/protected", nil).WithContext(ctx)
+	rec := httptest.NewRecorder()
+	wrapped.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusForbidden {
+		t.Fatalf("expected 403, got %d", rec.Code)
+	}
+	if nextCalled {
+		t.Fatal("expected next handler NOT to be called for unmapped client")
+	}
+}

--- a/backend/internal/authz/principal.go
+++ b/backend/internal/authz/principal.go
@@ -32,6 +32,19 @@ const (
 	KindClient
 )
 
+// String renders Kind as a stable, human-readable token. Mostly used by
+// slog so log lines say kind=user instead of kind=1.
+func (k Kind) String() string {
+	switch k {
+	case KindUser:
+		return "user"
+	case KindClient:
+		return "client"
+	default:
+		return "unknown"
+	}
+}
+
 // Principal is the unified view of an authenticated caller. It wraps the
 // existing *auth.AuthContext and exposes authorization-friendly helpers
 // without coupling callers to the underlying user/client structs.

--- a/backend/internal/authz/principal.go
+++ b/backend/internal/authz/principal.go
@@ -1,0 +1,73 @@
+// Package authz provides authorization primitives that complement the
+// authentication layer in internal/auth.
+//
+// The package introduces a Principal abstraction that unifies the two
+// principal types produced by the auth middleware (user vs. client) behind
+// a single interface, and a Manager that resolves OAuth2-style scopes from
+// the principal's roles (for users) or client_id (for M2M clients) using a
+// static configuration.
+//
+// The package deliberately leaves business policy decisions to the
+// downstream service: callers receive a Principal, branch on Kind, and use
+// HasRole/HasScope to make decisions. Coarse-grained "is this scope present
+// at all?" gating is provided by Manager.RequireScope as HTTP middleware.
+package authz
+
+import (
+	"errors"
+
+	"github.com/OpenNSW/nsw/internal/auth"
+)
+
+// Kind discriminates between principal types so callers can branch on
+// whether the caller is a human user or an M2M client.
+type Kind int
+
+const (
+	// KindUser indicates the principal was authenticated via the OAuth2
+	// authorization_code grant (a human user with identity claims and roles).
+	KindUser Kind = iota + 1
+	// KindClient indicates the principal was authenticated via the OAuth2
+	// client_credentials grant (an M2M client identified by client_id only).
+	KindClient
+)
+
+// Principal is the unified view of an authenticated caller. It wraps the
+// existing *auth.AuthContext and exposes authorization-friendly helpers
+// without coupling callers to the underlying user/client structs.
+//
+// All methods are safe to call on any Principal returned by Manager.Principal.
+// HasRole returns false for client principals; Client returns ok=false for
+// user principals (and vice versa).
+type Principal interface {
+	// Kind returns whether the principal is a user or a client.
+	Kind() Kind
+	// Subject returns a stable identifier for the principal: the persisted
+	// user ID (falling back to the IdP subject if not persisted yet) for
+	// users, or the client_id for M2M clients.
+	Subject() string
+	// HasScope reports whether the principal has the given scope, as
+	// resolved by the Manager that produced this Principal (role-map for
+	// users, client-allowlist for clients).
+	HasScope(scope string) bool
+	// HasRole reports whether the principal carries the given role claim.
+	// Always returns false for client principals.
+	HasRole(role string) bool
+	// User returns the underlying user context; ok=false for clients.
+	User() (*auth.UserContext, bool)
+	// Client returns the underlying client context; ok=false for users.
+	Client() (*auth.ClientContext, bool)
+}
+
+// Sentinel errors returned by services that perform downstream
+// authorization checks. Handlers use errors.Is to map these onto HTTP
+// status codes.
+var (
+	// ErrUnauthenticated indicates no principal is available on the request.
+	// Handlers should map this to 401 Unauthorized.
+	ErrUnauthenticated = errors.New("authz: unauthenticated")
+	// ErrForbidden indicates the principal is authenticated but not allowed
+	// to perform the requested action on the requested resource.
+	// Handlers should map this to 403 Forbidden.
+	ErrForbidden = errors.New("authz: forbidden")
+)

--- a/backend/internal/authz/principal_impl.go
+++ b/backend/internal/authz/principal_impl.go
@@ -1,0 +1,78 @@
+package authz
+
+import (
+	"slices"
+
+	"github.com/OpenNSW/nsw/internal/auth"
+)
+
+// principal is the unexported Principal implementation backed by
+// *auth.AuthContext. Scope resolution is delegated to the originating
+// Manager so each request can reuse the manager's static configuration
+// without copying maps.
+type principal struct {
+	authCtx *auth.AuthContext
+	manager *Manager
+}
+
+// Compile-time interface satisfaction check.
+var _ Principal = (*principal)(nil)
+
+func (p *principal) Kind() Kind {
+	if p.authCtx.User != nil {
+		return KindUser
+	}
+	return KindClient
+}
+
+func (p *principal) Subject() string {
+	if p.authCtx.User != nil {
+		if p.authCtx.User.ID != "" {
+			return p.authCtx.User.ID
+		}
+		return p.authCtx.User.IDPUserID
+	}
+	if p.authCtx.Client != nil {
+		return p.authCtx.Client.ClientID
+	}
+	return ""
+}
+
+func (p *principal) HasScope(scope string) bool {
+	if scope == "" {
+		return false
+	}
+	if p.authCtx.User != nil {
+		for _, role := range p.authCtx.User.Roles {
+			if slices.Contains(p.manager.roleScopes[role], scope) {
+				return true
+			}
+		}
+		return false
+	}
+	if p.authCtx.Client != nil {
+		return slices.Contains(p.manager.clientScopes[p.authCtx.Client.ClientID], scope)
+	}
+	return false
+}
+
+func (p *principal) HasRole(role string) bool {
+	if p.authCtx.User == nil {
+		return false
+	}
+	return slices.Contains(p.authCtx.User.Roles, role)
+}
+
+func (p *principal) User() (*auth.UserContext, bool) {
+	if p.authCtx.User == nil {
+		return nil, false
+	}
+	return p.authCtx.User, true
+}
+
+func (p *principal) Client() (*auth.ClientContext, bool) {
+	if p.authCtx.Client == nil {
+		return nil, false
+	}
+	return p.authCtx.Client, true
+}

--- a/backend/internal/authz/principal_test.go
+++ b/backend/internal/authz/principal_test.go
@@ -67,10 +67,36 @@ func TestNewManager_InvalidConfig(t *testing.T) {
 	}
 }
 
+func TestKind_String(t *testing.T) {
+	tests := []struct {
+		kind Kind
+		want string
+	}{
+		{KindUser, "user"},
+		{KindClient, "client"},
+		{Kind(0), "unknown"},
+		{Kind(99), "unknown"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.want, func(t *testing.T) {
+			if got := tt.kind.String(); got != tt.want {
+				t.Fatalf("Kind(%d).String() = %q, want %q", tt.kind, got, tt.want)
+			}
+		})
+	}
+}
+
 func TestManagerPrincipal_NoAuthContext(t *testing.T) {
 	mgr := newTestManager(t)
 	if _, ok := mgr.Principal(context.Background()); ok {
 		t.Fatal("expected ok=false when no auth context attached")
+	}
+}
+
+func TestManagerPrincipal_NilReceiver(t *testing.T) {
+	var mgr *Manager
+	if _, ok := mgr.Principal(contextWithUser(t, &auth.UserContext{IDPUserID: "u", Roles: []string{"trader"}})); ok {
+		t.Fatal("expected ok=false when Manager receiver is nil")
 	}
 }
 

--- a/backend/internal/authz/principal_test.go
+++ b/backend/internal/authz/principal_test.go
@@ -1,0 +1,222 @@
+package authz
+
+import (
+	"context"
+	"testing"
+
+	"github.com/OpenNSW/nsw/internal/auth"
+)
+
+// contextWithUser builds a request context carrying a UserContext, matching
+// what auth.Middleware would inject for a JWT issued via authorization_code.
+func contextWithUser(t *testing.T, user *auth.UserContext) context.Context {
+	t.Helper()
+	return context.WithValue(context.Background(), auth.AuthContextKey, &auth.AuthContext{User: user})
+}
+
+// contextWithClient builds a request context carrying a ClientContext, matching
+// what auth.Middleware would inject for a JWT issued via client_credentials.
+func contextWithClient(t *testing.T, client *auth.ClientContext) context.Context {
+	t.Helper()
+	return context.WithValue(context.Background(), auth.AuthContextKey, &auth.AuthContext{Client: client})
+}
+
+func newTestManager(t *testing.T) *Manager {
+	t.Helper()
+	mgr, err := NewManager(Config{
+		RoleScopes: map[string][]string{
+			"trader": {"consignments:read", "consignments:write"},
+			"cha":    {"consignments:read"},
+		},
+		ClientScopes: map[string][]string{
+			"LANKAPAY_M2M": {"payments:webhook"},
+		},
+	})
+	if err != nil {
+		t.Fatalf("unexpected error from NewManager: %v", err)
+	}
+	return mgr
+}
+
+func TestNewManager_EmptyConfigIsValid(t *testing.T) {
+	mgr, err := NewManager(Config{})
+	if err != nil {
+		t.Fatalf("expected nil error for empty config, got %v", err)
+	}
+	if mgr == nil {
+		t.Fatal("expected non-nil manager")
+	}
+}
+
+func TestNewManager_InvalidConfig(t *testing.T) {
+	tests := []struct {
+		name string
+		cfg  Config
+	}{
+		{name: "empty scope in role", cfg: Config{RoleScopes: map[string][]string{"trader": {""}}}},
+		{name: "empty role name", cfg: Config{RoleScopes: map[string][]string{"": {"consignments:read"}}}},
+		{name: "empty scope in client", cfg: Config{ClientScopes: map[string][]string{"X": {""}}}},
+		{name: "empty client id", cfg: Config{ClientScopes: map[string][]string{"": {"payments:webhook"}}}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if _, err := NewManager(tt.cfg); err == nil {
+				t.Fatalf("expected error, got nil")
+			}
+		})
+	}
+}
+
+func TestManagerPrincipal_NoAuthContext(t *testing.T) {
+	mgr := newTestManager(t)
+	if _, ok := mgr.Principal(context.Background()); ok {
+		t.Fatal("expected ok=false when no auth context attached")
+	}
+}
+
+func TestManagerPrincipal_EmptyAuthContext(t *testing.T) {
+	mgr := newTestManager(t)
+	ctx := context.WithValue(context.Background(), auth.AuthContextKey, &auth.AuthContext{})
+	if _, ok := mgr.Principal(ctx); ok {
+		t.Fatal("expected ok=false when both user and client are nil")
+	}
+}
+
+func TestPrincipal_UserKindAndAccessors(t *testing.T) {
+	mgr := newTestManager(t)
+	user := &auth.UserContext{
+		ID:        "USER-DB-001",
+		IDPUserID: "USER-IDP-001",
+		Email:     "trader@example.com",
+		OUHandle:  "ou-trader",
+		Roles:     []string{"trader"},
+	}
+	p, ok := mgr.Principal(contextWithUser(t, user))
+	if !ok {
+		t.Fatal("expected ok=true for user context")
+	}
+	if p.Kind() != KindUser {
+		t.Fatalf("expected KindUser, got %d", p.Kind())
+	}
+	if p.Subject() != "USER-DB-001" {
+		t.Fatalf("expected persisted ID as subject, got %q", p.Subject())
+	}
+	gotUser, gotOK := p.User()
+	if !gotOK || gotUser != user {
+		t.Fatalf("expected User() to return wrapped user, got %v (ok=%v)", gotUser, gotOK)
+	}
+	if _, clientOK := p.Client(); clientOK {
+		t.Fatal("expected Client() ok=false for user principal")
+	}
+}
+
+func TestPrincipal_SubjectFallsBackToIDPUserID(t *testing.T) {
+	mgr := newTestManager(t)
+	user := &auth.UserContext{IDPUserID: "USER-IDP-002", Roles: []string{"trader"}}
+	p, _ := mgr.Principal(contextWithUser(t, user))
+	if p.Subject() != "USER-IDP-002" {
+		t.Fatalf("expected IDPUserID as subject when ID is empty, got %q", p.Subject())
+	}
+}
+
+func TestPrincipal_HasRole(t *testing.T) {
+	mgr := newTestManager(t)
+	user := &auth.UserContext{IDPUserID: "u", Roles: []string{"trader", "ops"}}
+	p, _ := mgr.Principal(contextWithUser(t, user))
+	if !p.HasRole("trader") {
+		t.Error("expected HasRole(trader)=true")
+	}
+	if !p.HasRole("ops") {
+		t.Error("expected HasRole(ops)=true")
+	}
+	if p.HasRole("cha") {
+		t.Error("expected HasRole(cha)=false")
+	}
+}
+
+func TestPrincipal_HasRole_FalseForClient(t *testing.T) {
+	mgr := newTestManager(t)
+	p, _ := mgr.Principal(contextWithClient(t, &auth.ClientContext{ClientID: "LANKAPAY_M2M"}))
+	if p.HasRole("trader") {
+		t.Error("expected HasRole=false for client principals")
+	}
+}
+
+func TestPrincipal_HasScope_UserViaRoleMap(t *testing.T) {
+	mgr := newTestManager(t)
+	tests := []struct {
+		name  string
+		roles []string
+		scope string
+		want  bool
+	}{
+		{name: "trader has read", roles: []string{"trader"}, scope: "consignments:read", want: true},
+		{name: "trader has write", roles: []string{"trader"}, scope: "consignments:write", want: true},
+		{name: "cha has read", roles: []string{"cha"}, scope: "consignments:read", want: true},
+		{name: "cha lacks write", roles: []string{"cha"}, scope: "consignments:write", want: false},
+		{name: "multi-role union", roles: []string{"cha", "trader"}, scope: "consignments:write", want: true},
+		{name: "unknown role grants nothing", roles: []string{"ghost"}, scope: "consignments:read", want: false},
+		{name: "no roles grants nothing", roles: nil, scope: "consignments:read", want: false},
+		{name: "empty scope query rejected", roles: []string{"trader"}, scope: "", want: false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			user := &auth.UserContext{IDPUserID: "u", Roles: tt.roles}
+			p, _ := mgr.Principal(contextWithUser(t, user))
+			if got := p.HasScope(tt.scope); got != tt.want {
+				t.Fatalf("HasScope(%q) = %v, want %v", tt.scope, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestPrincipal_ClientKindAndScope(t *testing.T) {
+	mgr := newTestManager(t)
+	p, ok := mgr.Principal(contextWithClient(t, &auth.ClientContext{ClientID: "LANKAPAY_M2M"}))
+	if !ok {
+		t.Fatal("expected ok=true for client context")
+	}
+	if p.Kind() != KindClient {
+		t.Fatalf("expected KindClient, got %d", p.Kind())
+	}
+	if p.Subject() != "LANKAPAY_M2M" {
+		t.Fatalf("expected client_id as subject, got %q", p.Subject())
+	}
+	if !p.HasScope("payments:webhook") {
+		t.Error("expected client to have payments:webhook scope")
+	}
+	if p.HasScope("consignments:read") {
+		t.Error("expected client to NOT have consignments:read scope")
+	}
+	gotClient, gotOK := p.Client()
+	if !gotOK || gotClient.ClientID != "LANKAPAY_M2M" {
+		t.Fatalf("expected Client() to return wrapped client, got %v (ok=%v)", gotClient, gotOK)
+	}
+	if _, userOK := p.User(); userOK {
+		t.Fatal("expected User() ok=false for client principal")
+	}
+}
+
+func TestPrincipal_UnknownClientHasNoScopes(t *testing.T) {
+	mgr := newTestManager(t)
+	p, _ := mgr.Principal(contextWithClient(t, &auth.ClientContext{ClientID: "STRANGER"}))
+	if p.HasScope("payments:webhook") {
+		t.Error("expected unmapped client to have no scopes")
+	}
+}
+
+func TestManagerPrincipal_DoesNotMutateInputMaps(t *testing.T) {
+	// Ensure cloneScopeMap actually decouples the manager from caller-owned maps.
+	role := map[string][]string{"trader": {"consignments:read"}}
+	mgr, err := NewManager(Config{RoleScopes: role})
+	if err != nil {
+		t.Fatalf("unexpected NewManager error: %v", err)
+	}
+	role["trader"] = append(role["trader"], "consignments:write")
+
+	user := &auth.UserContext{IDPUserID: "u", Roles: []string{"trader"}}
+	p, _ := mgr.Principal(contextWithUser(t, user))
+	if p.HasScope("consignments:write") {
+		t.Fatal("expected manager to be isolated from post-construction mutation of input maps")
+	}
+}


### PR DESCRIPTION
## Summary

- Adds a new `internal/authz` package that complements `internal/auth`: a `Principal` interface unifying user/client principal types and a `Manager.RequireScope(scope)` middleware factory for coarse authorization gating per route.
- Scopes are resolved in-package (static `role -> scopes` map for users, static `client_id -> scopes` allowlist for M2M) so this works today without any IdP / Thunder change. The interface is a seam — when Thunder issues real scope claims later, swap the resolver and callers don't change.
- Pure plumbing — **no existing handler, route, or service is touched** and **no behavioural change**. v1 is unreferenced (no caller yet) until the first feature migrates to it in a follow-up PR.

## Why

Current authz patterns in the repo are inconsistent and partially broken:
- Every handler repeats `if authCtx == nil || authCtx.User == nil { 401 }`, which silently locks out M2M callers from endpoints that should serve them.
- [`internal/consignment/router.go:85`](https://github.com/OpenNSW/nsw/blob/main/backend/internal/consignment/router.go#L85) carries an explicit `TODO: Proper AuthZ` and accepts a `role=trader|cha` **query parameter** from the caller — a critical flaw, since the role isn't enforced from JWT claims.
- Service-layer ownership checks (e.g. [`consignment/service.go:160`](https://github.com/OpenNSW/nsw/blob/main/backend/internal/consignment/service.go#L160)) are ad-hoc and inconsistent across services.

This PR establishes the foundational primitives so authorization can be done the same way everywhere, with the policy decisions living **inside the downstream service** — required because the same endpoint can serve frontend users and M2M clients with different rules.

## Architecture (layered hybrid)

| Layer | Responsibility | Lives in |
|---|---|---|
| Authentication middleware (exists) | Parse JWT, build `AuthContext`. | `internal/auth/middleware.go` |
| **`RequireScope` middleware (new)** | Reject tokens missing a declared scope. Coarse gate, declared per route. | `internal/authz/middleware.go` |
| Handler (per-feature, future) | Pull `Principal` from context, forward to service. Maps `ErrForbidden` -> 403. | `**/router.go` |
| Service (per-feature, future) | All fine-grained authz: ownership, role branching, etc. Receives `Principal`. | `**/service.go` |

## What's in v1 (this PR)

| File | Purpose |
|---|---|
| `principal.go` | `Principal` interface, `Kind` enum, `ErrUnauthenticated` / `ErrForbidden` sentinels |
| `principal_impl.go` | Implementation wrapping `*auth.AuthContext`; scope resolution delegated to the `Manager` |
| `config.go` | `Config{RoleScopes, ClientScopes}` + `Validate` (empty config is valid) |
| `manager.go` | `Manager`, `NewManager`, `Principal(ctx) (Principal, bool)` |
| `middleware.go` | `Manager.RequireScope(scope)` — 401 anonymous / 403 missing-scope, JSON shape matches `auth` |
| `principal_test.go`, `middleware_test.go` | 13 tests / 18 subtests covering user, client, anonymous, unknown role, unmapped client, map-isolation, JSON response shape |

## Deferred (future PRs)

- **v2 — first migration:** Migrate `internal/consignment` onto the new pattern. Replace the `role=` query parameter with `p.HasRole(...)` branching inside the service. Wire `RequireScope("consignments:read"|"consignments:write")` on the routes in `bootstrap/app.go`. **This is the PR that closes the existing `TODO: Proper AuthZ`.**
- **v3 — broader rollout:** Migrate remaining handlers (tasks, hscodes, profiles, storage) one feature at a time. Stop hardcoding `authCtx.User == nil` so M2M can reach these endpoints where appropriate.
- **v4 — security hardening:** Secure the unauthenticated payment webhook (`payments/http_handler.go:44`), audit-log every `ErrForbidden`, add 401/403 metrics.
- **Deferred indefinitely:** JWT `scope` claim from Thunder (swap the resolver impl when ready; callers don't change), group/role hierarchy resolver, heavy policy engines (OPA/Casbin).

## Test plan

- [x] `go build ./...` clean
- [x] `go vet ./...` clean
- [x] `golangci-lint run ./internal/authz/...` — 0 issues
- [x] `go test ./internal/authz/...` — 13 tests / 18 subtests passing
- [x] No existing file modified (diff vs `HEAD` shows only files added under `internal/authz/`)
- [ ] Reviewer: confirm `Principal` interface shape is what v2 will need
- [ ] Reviewer: confirm "scopes derived from static config maps" is acceptable as the initial source (vs. waiting for Thunder to issue JWT scope claims)
- [ ] CI green