### PR TITLE
feat(payment): implement redirect zone rendering and session storage tracking

### DIFF
--- a/backend/internal/app/bootstrap/app.go
+++ b/backend/internal/app/bootstrap/app.go
@@ -114,7 +114,7 @@ func Build(ctx context.Context, cfg *config.Config) (*App, error) {
 		return nil, fmt.Errorf("failed to register taskv2 plugins: %w", err)
 	}
 
-	taskV2, stopTaskV2, err := taskv2.WireTaskV2(db, &temporalClient, pluginsRegistry, paymentService, onTaskCompleted)
+	taskV2, stopTaskV2, err := taskv2.WireTaskV2(db, temporalClient, pluginsRegistry, paymentService, onTaskCompleted)
 	if err != nil {
 		temporalClient.Close()
 		_ = database.Close(db)

--- a/backend/internal/app/bootstrap/app.go
+++ b/backend/internal/app/bootstrap/app.go
@@ -77,7 +77,11 @@ func Build(ctx context.Context, cfg *config.Config) (*App, error) {
 	}
 
 	paymentRepo := payments.NewPaymentRepository(db)
-	paymentService := payments.NewPaymentService(paymentRepo)
+	paymentService, err := payments.NewPaymentService(paymentRepo, cfg.Server.PaymentMethodsConfigPath)
+	if err != nil {
+		_ = database.Close(db)
+		return nil, fmt.Errorf("failed to initialize payment service: %w", err)
+	}
 
 	templateService := service.NewTemplateService(db)
 	chaService := cha.NewService(db)

--- a/backend/internal/app/bootstrap/app.go
+++ b/backend/internal/app/bootstrap/app.go
@@ -108,19 +108,21 @@ func Build(ctx context.Context, cfg *config.Config) (*App, error) {
 	}
 
 	pluginsRegistry := flowplugins.NewRegistry()
-	if err := taskv2plugins.Register(pluginsRegistry, remoteManager, cfg.Server.ServiceURL, cfg.Server.Debug); err != nil {
+	if err := taskv2plugins.Register(pluginsRegistry, remoteManager, paymentService, cfg.Server.ServiceURL, cfg.Server.Debug); err != nil {
 		temporalClient.Close()
 		_ = database.Close(db)
 		return nil, fmt.Errorf("failed to register taskv2 plugins: %w", err)
 	}
 
-	taskV2, stopTaskV2, err := taskv2.WireTaskV2(db, &temporalClient, pluginsRegistry, onTaskCompleted)
+	taskV2, stopTaskV2, err := taskv2.WireTaskV2(db, &temporalClient, pluginsRegistry, paymentService, onTaskCompleted)
 	if err != nil {
 		temporalClient.Close()
 		_ = database.Close(db)
 		return nil, fmt.Errorf("failed to wire taskv2: %w", err)
 	}
 	tm := taskV2.Manager
+
+	paymentService.SetTaskCompleter(tm)
 
 	consignmentService := consignment.NewService(db, templateService, chaService, companyService, userProfileService, hsCodeService)
 	consignmentRouter := consignment.NewRouter(consignmentService, chaService, companyService)

--- a/backend/internal/config/config.go
+++ b/backend/internal/config/config.go
@@ -30,11 +30,12 @@ type Config struct {
 
 // ServerConfig holds server configuration
 type ServerConfig struct {
-	Port               int
-	ServiceURL         string
-	ServicesConfigPath string
-	Debug              bool
-	LogLevel           slog.Level
+	Port                      int
+	ServiceURL                string
+	ServicesConfigPath        string
+	PaymentMethodsConfigPath  string
+	Debug                     bool
+	LogLevel                  slog.Level
 }
 
 // CORSConfig holds CORS configuration
@@ -74,7 +75,8 @@ func Load() (*Config, error) {
 		Server: ServerConfig{
 			Port:               serverPort,
 			ServiceURL:         getEnvOrDefault("SERVICE_URL", fmt.Sprintf("http://localhost:%d", serverPort)),
-			ServicesConfigPath: getEnvOrDefault("SERVICES_CONFIG_PATH", "configs/services.json"),
+			ServicesConfigPath:       getEnvOrDefault("SERVICES_CONFIG_PATH", "configs/services.json"),
+			PaymentMethodsConfigPath: getEnvOrDefault("PAYMENT_METHODS_CONFIG_PATH", "configs/payment_methods.json"),
 			Debug:              getBoolOrDefault("SERVER_DEBUG", true),
 			LogLevel:           parseLogLevel(getEnvOrDefault("SERVER_LOG_LEVEL", "info")),
 		},

--- a/backend/internal/payments/http_handler_test.go
+++ b/backend/internal/payments/http_handler_test.go
@@ -30,6 +30,12 @@ func (m *mockPaymentService) ProcessWebhook(ctx context.Context, payload Webhook
 	return m.processWebhookFunc(ctx, payload)
 }
 
+func (m *mockPaymentService) SetTaskCompleter(completer TaskCompleter) {}
+
+func (m *mockPaymentService) GetPaymentMethod(id string) (*PaymentMethod, error) {
+	return &PaymentMethod{ID: id, Type: "REDIRECT", GatewayURL: "https://mock.lk"}, nil
+}
+
 func TestHandleValidateReference(t *testing.T) {
 	service := &mockPaymentService{}
 	handler := NewHTTPHandler(service)

--- a/backend/internal/payments/models.go
+++ b/backend/internal/payments/models.go
@@ -47,9 +47,10 @@ type CreateCheckoutRequest struct {
 
 // CreateCheckoutResponse is the expected reply from LankaPay.
 type CreateCheckoutResponse struct {
-	SessionID   string `json:"session_id"`
-	CheckoutURL string `json:"checkout_url"` // The hosted URL to redirect the user to
-	ExpiresIn   int    `json:"expires_in_seconds"`
+	SessionID       string `json:"session_id"`
+	CheckoutURL     string `json:"checkout_url"` // The hosted URL to redirect the user to
+	ExpiresIn       int    `json:"expires_in_seconds"`
+	ReferenceNumber string `json:"reference_number"`
 }
 
 // --------------------------------------------------------

--- a/backend/internal/payments/service.go
+++ b/backend/internal/payments/service.go
@@ -2,28 +2,100 @@ package payments
 
 import (
 	"context"
+	"crypto/rand"
+	"encoding/json"
 	"fmt"
 	"log/slog"
+	"os"
 	"time"
 
 	"github.com/google/uuid"
 )
+
+// TaskCompleter defines the interface to resume suspended workflow steps.
+type TaskCompleter interface {
+	CompleteTaskStep(ctx context.Context, taskID string, payload map[string]any) error
+}
+
+// PaymentMethod holds the metadata and configuration for a payment gateway/method.
+type PaymentMethod struct {
+	ID         string `json:"id"`
+	IsActive   bool   `json:"is_active"`
+	Type       string `json:"type"`
+	GatewayURL string `json:"gateway_url"`
+	Template   string `json:"template"`
+}
+
+type paymentMethodsConfig struct {
+	Version string          `json:"version"`
+	Methods []PaymentMethod `json:"methods"`
+}
 
 // PaymentService defines the business logic operations for Payments.
 type PaymentService interface {
 	CreateCheckoutSession(ctx context.Context, req CreateCheckoutRequest) (*CreateCheckoutResponse, error)
 	ValidateReference(ctx context.Context, req ValidateReferenceRequest) (*ValidateReferenceResponse, error)
 	ProcessWebhook(ctx context.Context, payload WebhookPayload) error
+	SetTaskCompleter(completer TaskCompleter)
+	GetPaymentMethod(id string) (*PaymentMethod, error)
 }
 
 type paymentService struct {
-	repo PaymentRepository
-	// In the future, we may inject event publishers or task managers here.
+	repo          PaymentRepository
+	taskCompleter TaskCompleter
 }
 
 // NewPaymentService initializes a new payment service.
 func NewPaymentService(repo PaymentRepository) PaymentService {
 	return &paymentService{repo: repo}
+}
+
+func (s *paymentService) SetTaskCompleter(completer TaskCompleter) {
+	s.taskCompleter = completer
+}
+
+func (s *paymentService) GetPaymentMethod(id string) (*PaymentMethod, error) {
+	var data []byte
+	var err error
+	paths := []string{
+		"configs/payment_methods.json",
+		"../configs/payment_methods.json",
+		"../../configs/payment_methods.json",
+		"../../../configs/payment_methods.json",
+	}
+	for _, p := range paths {
+		data, err = os.ReadFile(p)
+		if err == nil {
+			break
+		}
+	}
+	if err != nil {
+		return nil, fmt.Errorf("failed to read payment methods config: %w", err)
+	}
+
+	var cfg paymentMethodsConfig
+	if err := json.Unmarshal(data, &cfg); err != nil {
+		return nil, fmt.Errorf("failed to parse payment methods config: %w", err)
+	}
+
+	for _, m := range cfg.Methods {
+		if m.ID == id {
+			return &m, nil
+		}
+	}
+
+	return nil, fmt.Errorf("payment method %q not found", id)
+}
+
+const charset = "ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789"
+
+func generatePaymentReference() string {
+	b := make([]byte, 8)
+	_, _ = rand.Read(b)
+	for i := range b {
+		b[i] = charset[int(b[i])%len(charset)]
+	}
+	return "TNSW" + string(b)
 }
 
 // CreateCheckoutSession saves the initial intent and returns mocked LankaPay session details.
@@ -34,9 +106,21 @@ func (s *paymentService) CreateCheckoutSession(ctx context.Context, req CreateCh
 		return nil, fmt.Errorf("task_id is required in metadata")
 	}
 
+	refNum := req.ReferenceNumber
+	if refNum == "" {
+		for {
+			candidate := generatePaymentReference()
+			existing, err := s.repo.GetByReferenceNumber(ctx, candidate)
+			if err == nil && existing == nil {
+				refNum = candidate
+				break
+			}
+		}
+	}
+
 	tx := &PaymentTransaction{
 		ID:              uuid.NewString(),
-		ReferenceNumber: req.ReferenceNumber,
+		ReferenceNumber: refNum,
 		TaskID:          taskID,
 		SessionID:       sessionID,
 		Amount:          req.Amount,
@@ -50,12 +134,13 @@ func (s *paymentService) CreateCheckoutSession(ctx context.Context, req CreateCh
 		return nil, fmt.Errorf("failed to create payment transaction: %w", err)
 	}
 
-	slog.Info("created checkout session", "reference_number", req.ReferenceNumber, "session_id", sessionID)
+	slog.Info("created checkout session", "reference_number", refNum, "session_id", sessionID)
 
 	return &CreateCheckoutResponse{
-		SessionID:   sessionID,
-		CheckoutURL: "https://sandbox.govpay.lk/checkout/" + sessionID,
-		ExpiresIn:   int(time.Until(req.ExpiresAt).Seconds()),
+		SessionID:       sessionID,
+		CheckoutURL:     "https://sandbox.govpay.lk/checkout/" + sessionID,
+		ExpiresIn:       int(time.Until(req.ExpiresAt).Seconds()),
+		ReferenceNumber: refNum,
 	}, nil
 }
 
@@ -117,9 +202,16 @@ func (s *paymentService) ProcessWebhook(ctx context.Context, payload WebhookPayl
 
 	slog.Info("payment transaction updated successfully", "reference", tx.ReferenceNumber, "status", tx.Status)
 
-	// In a complete implementation, we'd emit an internal event here:
-	// "PaymentConfirmedEvent" for the Task Engine to pick up.
-	// We leave this uncoupled as requested ("ONLY focus first on implementing Payment Service").
+	if s.taskCompleter != nil {
+		statusStr := "success"
+		if tx.Status == PaymentStatusFailed {
+			statusStr = "fail"
+		}
+		slog.Info("taskv2 payment: webhook advancing task step", "taskId", tx.TaskID, "status", statusStr)
+		if err := s.taskCompleter.CompleteTaskStep(ctx, tx.TaskID, map[string]any{"payment_status": statusStr}); err != nil {
+			slog.Error("taskv2 payment: failed to automatically advance task step", "taskId", tx.TaskID, "error", err)
+		}
+	}
 
 	return nil
 }

--- a/backend/internal/payments/service.go
+++ b/backend/internal/payments/service.go
@@ -43,11 +43,25 @@ type PaymentService interface {
 type paymentService struct {
 	repo          PaymentRepository
 	taskCompleter TaskCompleter
+	methods       []PaymentMethod
+	methodIdx     map[string]int
 }
 
-// NewPaymentService initializes a new payment service.
-func NewPaymentService(repo PaymentRepository) PaymentService {
-	return &paymentService{repo: repo}
+// NewPaymentService loads payment methods from configPath and initializes a new payment service.
+func NewPaymentService(repo PaymentRepository, configPath string) (PaymentService, error) {
+	data, err := os.ReadFile(configPath)
+	if err != nil {
+		return nil, fmt.Errorf("payments: read config %q: %w", configPath, err)
+	}
+	var cfg paymentMethodsConfig
+	if err := json.Unmarshal(data, &cfg); err != nil {
+		return nil, fmt.Errorf("payments: parse config %q: %w", configPath, err)
+	}
+	idx := make(map[string]int, len(cfg.Methods))
+	for i, m := range cfg.Methods {
+		idx[m.ID] = i
+	}
+	return &paymentService{repo: repo, methods: cfg.Methods, methodIdx: idx}, nil
 }
 
 func (s *paymentService) SetTaskCompleter(completer TaskCompleter) {
@@ -55,36 +69,11 @@ func (s *paymentService) SetTaskCompleter(completer TaskCompleter) {
 }
 
 func (s *paymentService) GetPaymentMethod(id string) (*PaymentMethod, error) {
-	var data []byte
-	var err error
-	paths := []string{
-		"configs/payment_methods.json",
-		"../configs/payment_methods.json",
-		"../../configs/payment_methods.json",
-		"../../../configs/payment_methods.json",
+	i, ok := s.methodIdx[id]
+	if !ok {
+		return nil, fmt.Errorf("payment method %q not found", id)
 	}
-	for _, p := range paths {
-		data, err = os.ReadFile(p)
-		if err == nil {
-			break
-		}
-	}
-	if err != nil {
-		return nil, fmt.Errorf("failed to read payment methods config: %w", err)
-	}
-
-	var cfg paymentMethodsConfig
-	if err := json.Unmarshal(data, &cfg); err != nil {
-		return nil, fmt.Errorf("failed to parse payment methods config: %w", err)
-	}
-
-	for _, m := range cfg.Methods {
-		if m.ID == id {
-			return &m, nil
-		}
-	}
-
-	return nil, fmt.Errorf("payment method %q not found", id)
+	return &s.methods[i], nil
 }
 
 const charset = "ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789"
@@ -102,7 +91,7 @@ func generatePaymentReference() string {
 
 // CreateCheckoutSession saves the initial intent and returns mocked LankaPay session details.
 func (s *paymentService) CreateCheckoutSession(ctx context.Context, req CreateCheckoutRequest) (*CreateCheckoutResponse, error) {
-	sessionID := "sess_" + fmt.Sprintf("%d", time.Now().UnixNano())
+	sessionID := "sess_" + uuid.NewString()
 	taskID, ok := req.Metadata["task_id"]
 	if !ok {
 		return nil, fmt.Errorf("task_id is required in metadata")
@@ -113,7 +102,10 @@ func (s *paymentService) CreateCheckoutSession(ctx context.Context, req CreateCh
 		for {
 			candidate := generatePaymentReference()
 			existing, err := s.repo.GetByReferenceNumber(ctx, candidate)
-			if err == nil && existing == nil {
+			if err != nil {
+				return nil, fmt.Errorf("failed to check existing reference number: %w", err)
+			}
+			if existing == nil {
 				refNum = candidate
 				break
 			}

--- a/backend/internal/payments/service.go
+++ b/backend/internal/payments/service.go
@@ -91,11 +91,13 @@ const charset = "ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789"
 
 func generatePaymentReference() string {
 	b := make([]byte, 8)
-	_, _ = rand.Read(b)
+	if _, err := rand.Read(b); err != nil {
+		panic(fmt.Sprintf("failed to generate random bytes: %v", err))
+	}
 	for i := range b {
 		b[i] = charset[int(b[i])%len(charset)]
 	}
-	return "TNSW" + string(b)
+	return "TNSW-" + string(b)
 }
 
 // CreateCheckoutSession saves the initial intent and returns mocked LankaPay session details.

--- a/backend/internal/payments/service_test.go
+++ b/backend/internal/payments/service_test.go
@@ -89,6 +89,24 @@ func TestCreateCheckoutSession(t *testing.T) {
 		if resp.SessionID == "" {
 			t.Fatal("expected session ID to be generated")
 		}
+		if resp.ReferenceNumber != "REF-123" {
+			t.Errorf("expected reference number to be REF-123, got %s", resp.ReferenceNumber)
+		}
+	})
+
+	t.Run("success with auto-generated reference number", func(t *testing.T) {
+		reqEmptyRef := req
+		reqEmptyRef.ReferenceNumber = ""
+		resp, err := service.CreateCheckoutSession(context.Background(), reqEmptyRef)
+		if err != nil {
+			t.Fatalf("expected no error, got %v", err)
+		}
+		if resp.ReferenceNumber == "" {
+			t.Fatal("expected reference number to be generated")
+		}
+		if len(resp.ReferenceNumber) != 13 || resp.ReferenceNumber[:5] != "TNSW-" {
+			t.Errorf("unexpected generated reference format: %s", resp.ReferenceNumber)
+		}
 	})
 
 	t.Run("missing task_id", func(t *testing.T) {
@@ -231,6 +249,38 @@ func TestProcessWebhook(t *testing.T) {
 		err := service.ProcessWebhook(context.Background(), payload)
 		if err != nil {
 			t.Fatalf("expected no error for idempotent call, got %v", err)
+		}
+	})
+}
+
+func TestGetPaymentMethod(t *testing.T) {
+	repo := &mockRepository{txs: make(map[string]*PaymentTransaction)}
+	service := NewPaymentService(repo)
+
+	t.Run("lankapay exists", func(t *testing.T) {
+		m, err := service.GetPaymentMethod("lankapay")
+		if err != nil {
+			t.Fatalf("expected no error, got %v", err)
+		}
+		if m.ID != "lankapay" || m.Type != "REDIRECT" {
+			t.Errorf("unexpected payment method: %+v", m)
+		}
+	})
+
+	t.Run("govpay exists", func(t *testing.T) {
+		m, err := service.GetPaymentMethod("govpay")
+		if err != nil {
+			t.Fatalf("expected no error, got %v", err)
+		}
+		if m.ID != "govpay" || m.Type != "INFO" {
+			t.Errorf("unexpected payment method: %+v", m)
+		}
+	})
+
+	t.Run("not found", func(t *testing.T) {
+		_, err := service.GetPaymentMethod("non_existent_method")
+		if err == nil {
+			t.Fatal("expected error, got nil")
 		}
 	})
 }

--- a/backend/internal/payments/service_test.go
+++ b/backend/internal/payments/service_test.go
@@ -69,9 +69,18 @@ func (m *mockRepository) WithTx(tx *gorm.DB) PaymentRepository {
 	return m
 }
 
+func newTestService(t *testing.T, repo PaymentRepository) PaymentService {
+	t.Helper()
+	svc, err := NewPaymentService(repo, "testdata/payment_methods.json")
+	if err != nil {
+		t.Fatalf("failed to create payment service: %v", err)
+	}
+	return svc
+}
+
 func TestCreateCheckoutSession(t *testing.T) {
 	repo := &mockRepository{txs: make(map[string]*PaymentTransaction)}
-	service := NewPaymentService(repo)
+	service := newTestService(t, repo)
 
 	req := CreateCheckoutRequest{
 		ReferenceNumber: "REF-123",
@@ -130,7 +139,7 @@ func TestCreateCheckoutSession(t *testing.T) {
 
 func TestValidateReference(t *testing.T) {
 	repo := &mockRepository{txs: make(map[string]*PaymentTransaction)}
-	service := NewPaymentService(repo)
+	service := newTestService(t, repo)
 
 	t.Run("not found", func(t *testing.T) {
 		resp, err := service.ValidateReference(context.Background(), ValidateReferenceRequest{PaymentReference: "NON-EXISTENT"})
@@ -173,7 +182,7 @@ func TestValidateReference(t *testing.T) {
 
 func TestProcessWebhook(t *testing.T) {
 	repo := &mockRepository{txs: make(map[string]*PaymentTransaction)}
-	service := NewPaymentService(repo)
+	service := newTestService(t, repo)
 
 	txKey := "REF-123"
 	repo.txs[txKey] = &PaymentTransaction{
@@ -255,7 +264,7 @@ func TestProcessWebhook(t *testing.T) {
 
 func TestGetPaymentMethod(t *testing.T) {
 	repo := &mockRepository{txs: make(map[string]*PaymentTransaction)}
-	service := NewPaymentService(repo)
+	service := newTestService(t, repo)
 
 	t.Run("lankapay exists", func(t *testing.T) {
 		m, err := service.GetPaymentMethod("lankapay")

--- a/backend/internal/payments/testdata/payment_methods.json
+++ b/backend/internal/payments/testdata/payment_methods.json
@@ -1,0 +1,19 @@
+{
+  "version": "1.0",
+  "methods": [
+    {
+      "id": "lankapay",
+      "is_active": true,
+      "type": "REDIRECT",
+      "gateway_url": "https://sandbox.govpay.lk/checkout",
+      "template": "Pay {{ .Amount }} {{ .Currency }} ref {{ .ReferenceNumber }}"
+    },
+    {
+      "id": "govpay",
+      "is_active": true,
+      "type": "INFO",
+      "gateway_url": "",
+      "template": "GovPay ref {{ .ReferenceNumber }} amount {{ .Amount }}"
+    }
+  ]
+}

--- a/backend/internal/task/plugin/payment_test.go
+++ b/backend/internal/task/plugin/payment_test.go
@@ -39,6 +39,12 @@ func (m *MockPaymentService) ProcessWebhook(ctx context.Context, payload payment
 	return args.Error(0)
 }
 
+func (m *MockPaymentService) SetTaskCompleter(completer payments.TaskCompleter) {}
+
+func (m *MockPaymentService) GetPaymentMethod(id string) (*payments.PaymentMethod, error) {
+	return &payments.PaymentMethod{ID: id, Type: "REDIRECT", GatewayURL: "https://mock.lk"}, nil
+}
+
 // ── FSM Tests ─────────────────────────────────────────────────────────────────
 
 func TestNewPaymentFSM(t *testing.T) {

--- a/backend/internal/taskv2/plugins/payment.go
+++ b/backend/internal/taskv2/plugins/payment.go
@@ -25,13 +25,23 @@ func NewPaymentPlugin(paymentService payments.PaymentService) *PaymentPlugin {
 }
 
 type paymentConfig struct {
-	TaskCode string `json:"task_code"`
+	TaskCode    string          `json:"task_code"`
+	ServiceName string          `json:"service_name"`
+	Amount      decimal.Decimal `json:"amount"`
+	Currency    string          `json:"currency"`
 }
 
 func (p *PaymentPlugin) Execute(ctx pluginContext, configRaw json.RawMessage) error {
 	var cfg paymentConfig
 	if err := json.Unmarshal(configRaw, &cfg); err != nil {
 		return fmt.Errorf("payment: failed to parse generic_payment config: %w", err)
+	}
+
+	if cfg.Amount.IsZero() {
+		return fmt.Errorf("payment: plugin_properties.amount is required and must be non-zero")
+	}
+	if cfg.Currency == "" {
+		return fmt.Errorf("payment: plugin_properties.currency is required")
 	}
 
 	// 1. Determine selected payment gateway
@@ -48,16 +58,8 @@ func (p *PaymentPlugin) Execute(ctx pluginContext, configRaw json.RawMessage) er
 	// 2. Transition task state to PENDING_PAYMENT
 	ctx.Record.State = "PENDING_PAYMENT"
 
-	// 4. Determine amount and currency based on task_code
-	amount := decimal.NewFromFloat(1000.00) // Default LKR 1000.00
-	currency := "LKR"
-
-	switch cfg.TaskCode {
-	case "fcau_app_fee_payment_v1":
-		amount = decimal.NewFromFloat(1500.00)
-	case "fcau_lab_fee_payment_v1":
-		amount = decimal.NewFromFloat(5000.00)
-	}
+	amount := cfg.Amount
+	currency := cfg.Currency
 
 	slog.Info("taskv2 payment: initiating checkout session",
 		"taskId", ctx.Record.TaskID, "taskCode", cfg.TaskCode, "amount", amount, "method", selectedMethod)
@@ -87,13 +89,8 @@ func (p *PaymentPlugin) Execute(ctx pluginContext, configRaw json.RawMessage) er
 			ctx.Record.Data = make(map[string]any)
 		}
 
-		var serviceName string
-		switch cfg.TaskCode {
-		case "fcau_app_fee_payment_v1":
-			serviceName = "Application Fee"
-		case "fcau_lab_fee_payment_v1":
-			serviceName = "Laboratory Test Fee"
-		default:
+		serviceName := cfg.ServiceName
+		if serviceName == "" {
 			serviceName = "Payment"
 		}
 

--- a/backend/internal/taskv2/plugins/payment.go
+++ b/backend/internal/taskv2/plugins/payment.go
@@ -1,0 +1,116 @@
+package plugins
+
+import (
+	"encoding/json"
+	"fmt"
+	"log/slog"
+	"time"
+
+	"github.com/OpenNSW/nsw/internal/payments"
+	"github.com/shopspring/decimal"
+)
+
+// PaymentPlugin implements a custom generic_payment plugin for taskv2.
+// It initiates a checkout session with the payment service and transitions
+// the task record state to PENDING_PAYMENT.
+type PaymentPlugin struct {
+	paymentService payments.PaymentService
+}
+
+// NewPaymentPlugin creates a new PaymentPlugin.
+func NewPaymentPlugin(paymentService payments.PaymentService) *PaymentPlugin {
+	return &PaymentPlugin{
+		paymentService: paymentService,
+	}
+}
+
+type paymentConfig struct {
+	TaskCode string `json:"task_code"`
+}
+
+func (p *PaymentPlugin) Execute(ctx pluginContext, configRaw json.RawMessage) error {
+	var cfg paymentConfig
+	if err := json.Unmarshal(configRaw, &cfg); err != nil {
+		return fmt.Errorf("payment: failed to parse generic_payment config: %w", err)
+	}
+
+	// 1. Determine selected payment gateway
+	selectedMethod, _ := ctx.Inputs["selected_method"].(string)
+	if selectedMethod == "" {
+		selectedMethod = "lankapay" // Default fallback
+	}
+
+	_, err := p.paymentService.GetPaymentMethod(selectedMethod)
+	if err != nil {
+		return fmt.Errorf("payment: failed to get payment method %q: %w", selectedMethod, err)
+	}
+
+	// 2. Transition task state to PENDING_PAYMENT
+	ctx.Record.State = "PENDING_PAYMENT"
+
+	// 4. Determine amount and currency based on task_code
+	amount := decimal.NewFromFloat(1000.00) // Default LKR 1000.00
+	currency := "LKR"
+
+	switch cfg.TaskCode {
+	case "fcau_app_fee_payment_v1":
+		amount = decimal.NewFromFloat(1500.00)
+	case "fcau_lab_fee_payment_v1":
+		amount = decimal.NewFromFloat(5000.00)
+	}
+
+	slog.Info("taskv2 payment: initiating checkout session",
+		"taskId", ctx.Record.TaskID, "taskCode", cfg.TaskCode, "amount", amount, "method", selectedMethod)
+
+	// 5. Create checkout session in payments.PaymentService to register transaction
+	resp, err := p.paymentService.CreateCheckoutSession(ctx.Context, payments.CreateCheckoutRequest{
+		ReferenceNumber: "", // Empty string instructs the service to generate a unique TNSW- reference
+		Amount:          amount,
+		Currency:        currency,
+		ExpiresAt:       time.Now().Add(24 * time.Hour), // Aligned with typical TTL
+		Metadata: map[string]string{
+			"task_id":   ctx.Record.TaskID,
+			"task_code": cfg.TaskCode,
+			"method_id": selectedMethod,
+		},
+	})
+	if err != nil {
+		return fmt.Errorf("payment: failed to create checkout session: %w", err)
+	}
+
+	slog.Info("taskv2 payment: checkout session registered",
+		"taskId", ctx.Record.TaskID, "sessionId", resp.SessionID, "referenceNumber", resp.ReferenceNumber, "method", selectedMethod)
+
+	// 6. Populate payment info under the active output namespace
+	if ctx.Record.ActiveOutputNamespace != "" {
+		if ctx.Record.Data == nil {
+			ctx.Record.Data = make(map[string]any)
+		}
+
+		var serviceName string
+		switch cfg.TaskCode {
+		case "fcau_app_fee_payment_v1":
+			serviceName = "Application Fee"
+		case "fcau_lab_fee_payment_v1":
+			serviceName = "Laboratory Test Fee"
+		default:
+			serviceName = "Payment"
+		}
+
+		pData := map[string]any{
+			"session_id":       resp.SessionID,
+			"reference_number": resp.ReferenceNumber,
+			"amount":           amount.String(),
+			"currency":         currency,
+			"selected_method":  selectedMethod,
+			"checkout_url":     resp.CheckoutURL,
+			"service_name":     serviceName,
+			"service_type":     cfg.TaskCode,
+		}
+
+		ctx.Record.Data[ctx.Record.ActiveOutputNamespace] = pData
+	}
+
+	// Suspend the workflow until LankaPay/webhook callback arrives
+	return ErrSuspended
+}

--- a/backend/internal/taskv2/plugins/payment_test.go
+++ b/backend/internal/taskv2/plugins/payment_test.go
@@ -53,7 +53,7 @@ func TestPaymentPlugin_Execute(t *testing.T) {
 	plugin := NewPaymentPlugin(mockSvc)
 
 	// Check config
-	configRaw := json.RawMessage(`{"task_code": "fcau_app_fee_payment_v1"}`)
+	configRaw := json.RawMessage(`{"task_code": "fcau_app_fee_payment_v1", "service_name": "Application Fee", "amount": "1500.00", "currency": "LKR"}`)
 
 	t.Run("successful execution", func(t *testing.T) {
 		record := store.TaskRecord{

--- a/backend/internal/taskv2/plugins/payment_test.go
+++ b/backend/internal/taskv2/plugins/payment_test.go
@@ -1,0 +1,168 @@
+package plugins
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"testing"
+
+	"github.com/OpenNSW/nsw-task-flow/store"
+	"github.com/OpenNSW/nsw/internal/payments"
+	"github.com/shopspring/decimal"
+	"github.com/stretchr/testify/assert"
+)
+
+type mockPaymentService struct {
+	createCheckoutSessionFunc func(ctx context.Context, req payments.CreateCheckoutRequest) (*payments.CreateCheckoutResponse, error)
+	getPaymentMethodFunc      func(id string) (*payments.PaymentMethod, error)
+}
+
+func (m *mockPaymentService) CreateCheckoutSession(ctx context.Context, req payments.CreateCheckoutRequest) (*payments.CreateCheckoutResponse, error) {
+	if m.createCheckoutSessionFunc != nil {
+		return m.createCheckoutSessionFunc(ctx, req)
+	}
+	return nil, errors.New("unimplemented")
+}
+
+func (m *mockPaymentService) ValidateReference(ctx context.Context, req payments.ValidateReferenceRequest) (*payments.ValidateReferenceResponse, error) {
+	return nil, nil
+}
+
+func (m *mockPaymentService) ProcessWebhook(ctx context.Context, payload payments.WebhookPayload) error {
+	return nil
+}
+
+func (m *mockPaymentService) SetTaskCompleter(completer payments.TaskCompleter) {}
+
+func (m *mockPaymentService) GetPaymentMethod(id string) (*payments.PaymentMethod, error) {
+	if m.getPaymentMethodFunc != nil {
+		return m.getPaymentMethodFunc(id)
+	}
+	return &payments.PaymentMethod{
+		ID:         id,
+		IsActive:   true,
+		Type:       "REDIRECT",
+		GatewayURL: "https://sandbox.govpay.lk/checkout",
+		Template:   "# Mock Template",
+	}, nil
+}
+
+func TestPaymentPlugin_Execute(t *testing.T) {
+	// Setup
+	mockSvc := &mockPaymentService{}
+	plugin := NewPaymentPlugin(mockSvc)
+
+	// Check config
+	configRaw := json.RawMessage(`{"task_code": "fcau_app_fee_payment_v1"}`)
+
+	t.Run("successful execution", func(t *testing.T) {
+		record := store.TaskRecord{
+			TaskID:                "test-task-123",
+			ActiveOutputNamespace: "payment",
+		}
+
+		mockSvc.createCheckoutSessionFunc = func(ctx context.Context, req payments.CreateCheckoutRequest) (*payments.CreateCheckoutResponse, error) {
+			assert.Equal(t, "", req.ReferenceNumber)
+			assert.True(t, req.Amount.Equal(decimal.NewFromFloat(1500.00)))
+			assert.Equal(t, "LKR", req.Currency)
+			assert.Equal(t, "test-task-123", req.Metadata["task_id"])
+			assert.Equal(t, "fcau_app_fee_payment_v1", req.Metadata["task_code"])
+
+			return &payments.CreateCheckoutResponse{
+				SessionID:       "mock-session-123",
+				CheckoutURL:     "https://sandbox.govpay.lk/checkout/mock-session-123",
+				ReferenceNumber: "TNSW-MOCK123",
+			}, nil
+		}
+
+		ctx := pluginContext{
+			Context: context.Background(),
+			Record:  &record,
+			Inputs:  map[string]any{}, // empty inputs to trigger fallback
+		}
+
+		err := plugin.Execute(ctx, configRaw)
+		assert.True(t, errors.Is(err, ErrSuspended), "expected ErrSuspended")
+		assert.Equal(t, "PENDING_PAYMENT", record.State)
+
+		// Check output data structure
+		paymentData, ok := record.Data["payment"].(map[string]any)
+		assert.True(t, ok)
+		assert.Equal(t, "mock-session-123", paymentData["session_id"])
+		assert.Equal(t, "https://sandbox.govpay.lk/checkout/mock-session-123", paymentData["checkout_url"])
+		assert.Equal(t, "TNSW-MOCK123", paymentData["reference_number"])
+		assert.Equal(t, "1500", paymentData["amount"])
+		assert.Equal(t, "LKR", paymentData["currency"])
+	})
+
+	t.Run("successful execution with explicit reference number", func(t *testing.T) {
+		record := store.TaskRecord{
+			TaskID:                "test-task-123",
+			ActiveOutputNamespace: "payment",
+		}
+
+		mockSvc.createCheckoutSessionFunc = func(ctx context.Context, req payments.CreateCheckoutRequest) (*payments.CreateCheckoutResponse, error) {
+			assert.Equal(t, "", req.ReferenceNumber)
+			return &payments.CreateCheckoutResponse{
+				SessionID:       "mock-session-999",
+				ReferenceNumber: "TNSW-MOCK999",
+			}, nil
+		}
+
+		ctx := pluginContext{
+			Context: context.Background(),
+			Record:  &record,
+			Inputs: map[string]any{
+				"reference_number": "NSW-REF-999",
+			},
+		}
+
+		err := plugin.Execute(ctx, configRaw)
+		assert.True(t, errors.Is(err, ErrSuspended))
+	})
+
+	t.Run("successful execution with govpay offline method selection", func(t *testing.T) {
+		record := store.TaskRecord{
+			TaskID:                "test-task-123",
+			ActiveOutputNamespace: "payment",
+		}
+
+		mockSvc.getPaymentMethodFunc = func(id string) (*payments.PaymentMethod, error) {
+			assert.Equal(t, "govpay", id)
+			return &payments.PaymentMethod{
+				ID:       id,
+				IsActive: true,
+				Type:     "INFO",
+				Template: "Pay LKR {{ .Amount }} for {{ .ReferenceNumber }}",
+			}, nil
+		}
+
+		mockSvc.createCheckoutSessionFunc = func(ctx context.Context, req payments.CreateCheckoutRequest) (*payments.CreateCheckoutResponse, error) {
+			assert.Equal(t, "", req.ReferenceNumber)
+			return &payments.CreateCheckoutResponse{
+				SessionID:       "mock-govpay-session",
+				ReferenceNumber: "TNSW-MOCKGOV",
+			}, nil
+		}
+
+		ctx := pluginContext{
+			Context: context.Background(),
+			Record:  &record,
+			Inputs: map[string]any{
+				"reference_number": "NSW-REF-GOVPAY",
+				"selected_method":  "govpay",
+			},
+		}
+
+		err := plugin.Execute(ctx, configRaw)
+		assert.True(t, errors.Is(err, ErrSuspended))
+
+		// Check payment details were saved correctly
+		paymentData, ok := record.Data["payment"].(map[string]any)
+		assert.True(t, ok)
+		assert.Equal(t, "govpay", paymentData["selected_method"])
+		assert.Equal(t, "Application Fee", paymentData["service_name"])
+		assert.Equal(t, "fcau_app_fee_payment_v1", paymentData["service_type"])
+		assert.Equal(t, "TNSW-MOCKGOV", paymentData["reference_number"])
+	})
+}

--- a/backend/internal/taskv2/plugins/wiring.go
+++ b/backend/internal/taskv2/plugins/wiring.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 
 	flowplugins "github.com/OpenNSW/nsw-task-flow/plugins"
+	"github.com/OpenNSW/nsw/internal/payments"
 	"github.com/OpenNSW/nsw/pkg/remote"
 )
 
@@ -23,9 +24,9 @@ const (
 //
 // EXTERNAL_REVIEW uses our local plugin (ExternalReviewPlugin) that resolves
 // targets via remote.Manager and posts the OGA submission envelope. Payment
-// and API_CALL still use the library's stock plugins with the default HTTP
-// dispatcher — swap them out as local replacements are written.
-func Register(reg *flowplugins.Registry, mgr *remote.Manager, backendBaseURL string, devMode bool) error {
+// uses our local plugin (PaymentPlugin) that initiates checkout sessions via
+// payments.PaymentService.
+func Register(reg *flowplugins.Registry, mgr *remote.Manager, paymentService payments.PaymentService, backendBaseURL string, devMode bool) error {
 	if reg == nil {
 		return fmt.Errorf("plugins: registry is nil")
 	}
@@ -39,7 +40,7 @@ func Register(reg *flowplugins.Registry, mgr *remote.Manager, backendBaseURL str
 	}{
 		{TaskTypeUserInput, flowplugins.NewUserInputPlugin()},
 		{TaskTypeExternalReview, NewExternalReviewPlugin(mgr, backendBaseURL, devMode)},
-		{TaskTypePayment, flowplugins.NewPaymentPlugin(flowplugins.DefaultHTTPDispatcher)},
+		{TaskTypePayment, NewPaymentPlugin(paymentService)},
 		{TaskTypeAPICall, flowplugins.NewAPICallPlugin(flowplugins.DefaultHTTPDispatcher)},
 	}
 

--- a/backend/internal/taskv2/renderer/payment_projector.go
+++ b/backend/internal/taskv2/renderer/payment_projector.go
@@ -1,0 +1,71 @@
+package renderer
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"text/template"
+
+	"github.com/OpenNSW/nsw/internal/payments"
+	"github.com/OpenNSW/nsw/pkg/uiprojector"
+)
+
+// ProjectorPayment defines the payment instructions projector type.
+const ProjectorPayment uiprojector.ProjectorType = "PAYMENT"
+
+// PaymentProjector dynamically templates payment instructions from the payment service.
+type PaymentProjector struct {
+	paymentService payments.PaymentService
+}
+
+// NewPaymentProjector creates a new PaymentProjector.
+func NewPaymentProjector(paymentService payments.PaymentService) *PaymentProjector {
+	return &PaymentProjector{
+		paymentService: paymentService,
+	}
+}
+
+// Type returns the projector type.
+func (p *PaymentProjector) Type() uiprojector.ProjectorType {
+	return ProjectorPayment
+}
+
+// Project resolves the selected payment method's instructions template and renders it.
+func (p *PaymentProjector) Project(ctx context.Context, templateContent []byte, data any) (any, error) {
+	dataMap, ok := data.(map[string]any)
+	if !ok {
+		return nil, fmt.Errorf("payment_projector: expected map data, got %T", data)
+	}
+
+	selectedMethod, _ := dataMap["selected_method"].(string)
+	if selectedMethod == "" {
+		selectedMethod = "lankapay"
+	}
+
+	method, err := p.paymentService.GetPaymentMethod(selectedMethod)
+	if err != nil {
+		return nil, fmt.Errorf("payment_projector: get payment method %q: %w", selectedMethod, err)
+	}
+
+	tmpl, err := template.New("instructions").Parse(method.Template)
+	if err != nil {
+		return nil, fmt.Errorf("payment_projector: parse template: %w", err)
+	}
+
+	tmplData := map[string]any{
+		"ReferenceNumber":  dataMap["reference_number"],
+		"Amount":           dataMap["amount"],
+		"Currency":         dataMap["currency"],
+		"CheckoutURL":      dataMap["checkout_url"],
+		"ServiceName":      dataMap["service_name"],
+		"ServiceType":      dataMap["service_type"],
+		"OrganizationName": "FCAU",
+	}
+
+	var buf bytes.Buffer
+	if err := tmpl.Execute(&buf, tmplData); err != nil {
+		return nil, fmt.Errorf("payment_projector: execute template: %w", err)
+	}
+
+	return buf.String(), nil
+}

--- a/backend/internal/taskv2/renderer/payment_projector.go
+++ b/backend/internal/taskv2/renderer/payment_projector.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"fmt"
+	"sync"
 	"text/template"
 
 	"github.com/OpenNSW/nsw/internal/payments"
@@ -16,6 +17,7 @@ const ProjectorPayment uiprojector.ProjectorType = "PAYMENT"
 // PaymentProjector dynamically templates payment instructions from the payment service.
 type PaymentProjector struct {
 	paymentService payments.PaymentService
+	tmplCache      sync.Map // map[methodID string]*template.Template
 }
 
 // NewPaymentProjector creates a new PaymentProjector.
@@ -47,11 +49,19 @@ func (p *PaymentProjector) Project(ctx context.Context, templateContent []byte, 
 		return uiprojector.Projection{}, fmt.Errorf("payment_projector: get payment method %q: %w", selectedMethod, err)
 	}
 
-	tmpl, err := template.New("instructions").Parse(method.Template)
-	if err != nil {
-		return uiprojector.Projection{}, fmt.Errorf("payment_projector: parse template: %w", err)
+	var tmpl *template.Template
+	if cached, ok := p.tmplCache.Load(selectedMethod); ok {
+		tmpl = cached.(*template.Template)
+	} else {
+		parsed, err := template.New("instructions").Parse(method.Template)
+		if err != nil {
+			return uiprojector.Projection{}, fmt.Errorf("payment_projector: parse template: %w", err)
+		}
+		p.tmplCache.Store(selectedMethod, parsed)
+		tmpl = parsed
 	}
 
+	orgName, _ := dataMap["org_name"].(string)
 	tmplData := map[string]any{
 		"ReferenceNumber":  dataMap["reference_number"],
 		"Amount":           dataMap["amount"],
@@ -59,7 +69,7 @@ func (p *PaymentProjector) Project(ctx context.Context, templateContent []byte, 
 		"CheckoutURL":      dataMap["checkout_url"],
 		"ServiceName":      dataMap["service_name"],
 		"ServiceType":      dataMap["service_type"],
-		"OrganizationName": "FCAU",
+		"OrganizationName": orgName,
 	}
 
 	var buf bytes.Buffer

--- a/backend/internal/taskv2/renderer/payment_projector.go
+++ b/backend/internal/taskv2/renderer/payment_projector.go
@@ -31,10 +31,10 @@ func (p *PaymentProjector) Type() uiprojector.ProjectorType {
 }
 
 // Project resolves the selected payment method's instructions template and renders it.
-func (p *PaymentProjector) Project(ctx context.Context, templateContent []byte, data any) (any, error) {
+func (p *PaymentProjector) Project(ctx context.Context, templateContent []byte, data any) (uiprojector.Projection, error) {
 	dataMap, ok := data.(map[string]any)
 	if !ok {
-		return nil, fmt.Errorf("payment_projector: expected map data, got %T", data)
+		return uiprojector.Projection{}, fmt.Errorf("payment_projector: expected map data, got %T", data)
 	}
 
 	selectedMethod, _ := dataMap["selected_method"].(string)
@@ -44,12 +44,12 @@ func (p *PaymentProjector) Project(ctx context.Context, templateContent []byte, 
 
 	method, err := p.paymentService.GetPaymentMethod(selectedMethod)
 	if err != nil {
-		return nil, fmt.Errorf("payment_projector: get payment method %q: %w", selectedMethod, err)
+		return uiprojector.Projection{}, fmt.Errorf("payment_projector: get payment method %q: %w", selectedMethod, err)
 	}
 
 	tmpl, err := template.New("instructions").Parse(method.Template)
 	if err != nil {
-		return nil, fmt.Errorf("payment_projector: parse template: %w", err)
+		return uiprojector.Projection{}, fmt.Errorf("payment_projector: parse template: %w", err)
 	}
 
 	tmplData := map[string]any{
@@ -64,8 +64,22 @@ func (p *PaymentProjector) Project(ctx context.Context, templateContent []byte, 
 
 	var buf bytes.Buffer
 	if err := tmpl.Execute(&buf, tmplData); err != nil {
-		return nil, fmt.Errorf("payment_projector: execute template: %w", err)
+		return uiprojector.Projection{}, fmt.Errorf("payment_projector: execute template: %w", err)
 	}
 
-	return buf.String(), nil
+	if method.Type == "REDIRECT" {
+		checkoutURL, _ := dataMap["checkout_url"].(string)
+		return uiprojector.Projection{
+			Type: uiprojector.SectionType("REDIRECT"),
+			Content: map[string]any{
+				"checkout_url": checkoutURL,
+				"content":      buf.String(),
+			},
+		}, nil
+	}
+
+	return uiprojector.Projection{
+		Type:    uiprojector.SectionTypeMarkdown,
+		Content: buf.String(),
+	}, nil
 }

--- a/backend/internal/taskv2/renderer/payment_projector_test.go
+++ b/backend/internal/taskv2/renderer/payment_projector_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/OpenNSW/nsw/internal/payments"
+	"github.com/OpenNSW/nsw/pkg/uiprojector"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -56,7 +57,11 @@ func TestPaymentProjector_Project(t *testing.T) {
 
 		out, err := proj.Project(context.Background(), nil, data)
 		assert.NoError(t, err)
-		assert.Equal(t, "LankaPay App Fee (https://checkout.lk/123)", out)
+		assert.Equal(t, uiprojector.SectionType("REDIRECT"), out.Type)
+		content, ok := out.Content.(map[string]any)
+		assert.True(t, ok)
+		assert.Equal(t, "https://checkout.lk/123", content["checkout_url"])
+		assert.Equal(t, "LankaPay App Fee (https://checkout.lk/123)", content["content"])
 	})
 
 	t.Run("renders govpay offline template", func(t *testing.T) {
@@ -77,6 +82,7 @@ func TestPaymentProjector_Project(t *testing.T) {
 
 		out, err := proj.Project(context.Background(), nil, data)
 		assert.NoError(t, err)
-		assert.Equal(t, "GovPay REF-999 amount 1500.00", out)
+		assert.Equal(t, uiprojector.SectionTypeMarkdown, out.Type)
+		assert.Equal(t, "GovPay REF-999 amount 1500.00", out.Content)
 	})
 }

--- a/backend/internal/taskv2/renderer/payment_projector_test.go
+++ b/backend/internal/taskv2/renderer/payment_projector_test.go
@@ -1,0 +1,82 @@
+package renderer
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/OpenNSW/nsw/internal/payments"
+	"github.com/stretchr/testify/assert"
+)
+
+type mockPaymentService struct {
+	getPaymentMethodFunc func(id string) (*payments.PaymentMethod, error)
+}
+
+func (m *mockPaymentService) CreateCheckoutSession(ctx context.Context, req payments.CreateCheckoutRequest) (*payments.CreateCheckoutResponse, error) {
+	return nil, nil
+}
+
+func (m *mockPaymentService) ValidateReference(ctx context.Context, req payments.ValidateReferenceRequest) (*payments.ValidateReferenceResponse, error) {
+	return nil, nil
+}
+
+func (m *mockPaymentService) ProcessWebhook(ctx context.Context, payload payments.WebhookPayload) error {
+	return nil
+}
+
+func (m *mockPaymentService) SetTaskCompleter(completer payments.TaskCompleter) {}
+
+func (m *mockPaymentService) GetPaymentMethod(id string) (*payments.PaymentMethod, error) {
+	if m.getPaymentMethodFunc != nil {
+		return m.getPaymentMethodFunc(id)
+	}
+	return nil, errors.New("unimplemented")
+}
+
+func TestPaymentProjector_Project(t *testing.T) {
+	mockSvc := &mockPaymentService{}
+	proj := NewPaymentProjector(mockSvc)
+
+	t.Run("renders lankapay redirect template", func(t *testing.T) {
+		mockSvc.getPaymentMethodFunc = func(id string) (*payments.PaymentMethod, error) {
+			assert.Equal(t, "lankapay", id)
+			return &payments.PaymentMethod{
+				ID:       id,
+				Type:     "REDIRECT",
+				Template: "LankaPay {{ .ServiceName }} ({{ .CheckoutURL }})",
+			}, nil
+		}
+
+		data := map[string]any{
+			"selected_method": "lankapay",
+			"checkout_url":    "https://checkout.lk/123",
+			"service_name":    "App Fee",
+		}
+
+		out, err := proj.Project(context.Background(), nil, data)
+		assert.NoError(t, err)
+		assert.Equal(t, "LankaPay App Fee (https://checkout.lk/123)", out)
+	})
+
+	t.Run("renders govpay offline template", func(t *testing.T) {
+		mockSvc.getPaymentMethodFunc = func(id string) (*payments.PaymentMethod, error) {
+			assert.Equal(t, "govpay", id)
+			return &payments.PaymentMethod{
+				ID:       id,
+				Type:     "INFO",
+				Template: "GovPay {{ .ReferenceNumber }} amount {{ .Amount }}",
+			}, nil
+		}
+
+		data := map[string]any{
+			"selected_method":  "govpay",
+			"reference_number": "REF-999",
+			"amount":           "1500.00",
+		}
+
+		out, err := proj.Project(context.Background(), nil, data)
+		assert.NoError(t, err)
+		assert.Equal(t, "GovPay REF-999 amount 1500.00", out)
+	})
+}

--- a/backend/internal/taskv2/renderer/renderer.go
+++ b/backend/internal/taskv2/renderer/renderer.go
@@ -41,12 +41,22 @@ func (r *TaskRenderer) Render(ctx context.Context, configRaw json.RawMessage, fa
 
 	result := make(renderer.RenderResult, len(sections))
 	for slot, sec := range sections {
-		payload, err := json.Marshal(sec.Content)
+		var content any = sec.Content
+		secType := string(sec.Type)
+		if sec.Type == "PAYMENT" {
+			secType = "MARKDOWN"
+		}
+		if secType == "MARKDOWN" {
+			if str, ok := sec.Content.(string); ok {
+				content = map[string]any{"content": str}
+			}
+		}
+		payload, err := json.Marshal(content)
 		if err != nil {
 			return nil, fmt.Errorf("renderer: marshal section %q: %w", slot, err)
 		}
 		result[slot] = renderer.UIComponent{
-			Type:    string(sec.Type),
+			Type:    secType,
 			Payload: payload,
 		}
 	}

--- a/backend/internal/taskv2/renderer/renderer.go
+++ b/backend/internal/taskv2/renderer/renderer.go
@@ -41,11 +41,8 @@ func (r *TaskRenderer) Render(ctx context.Context, configRaw json.RawMessage, fa
 
 	result := make(renderer.RenderResult, len(sections))
 	for slot, sec := range sections {
-		var content any = sec.Content
+		var content = sec.Content
 		secType := string(sec.Type)
-		if sec.Type == "PAYMENT" {
-			secType = "MARKDOWN"
-		}
 		if secType == "MARKDOWN" {
 			if str, ok := sec.Content.(string); ok {
 				content = map[string]any{"content": str}

--- a/backend/internal/taskv2/wiring.go
+++ b/backend/internal/taskv2/wiring.go
@@ -34,7 +34,10 @@ type WireResult struct {
 // macro workflow can advance past its Task node. The plugin registry must be
 // pre-populated by the caller; an empty registry means every sub-task
 // activation will fail to find a handler.
-func WireTaskV2(db *gorm.DB, c *client.Client, pluginsRegistry *plugins.Registry, paymentService payments.PaymentService, onTaskCompleted orchestrator.TaskCompletedCallback) (*WireResult, func() error, error) {
+func WireTaskV2(db *gorm.DB, c client.Client, pluginsRegistry *plugins.Registry, paymentService payments.PaymentService, onTaskCompleted orchestrator.TaskCompletedCallback) (*WireResult, func() error, error) {
+	if c == nil {
+		return nil, nil, fmt.Errorf("taskv2: temporal client is nil")
+	}
 	if pluginsRegistry == nil {
 		return nil, nil, fmt.Errorf("taskv2: plugins registry is nil")
 	}
@@ -78,7 +81,7 @@ func WireTaskV2(db *gorm.DB, c *client.Client, pluginsRegistry *plugins.Registry
 		return tm.HandleTaskCompletion(context.Background(), workflowID, finalVariables)
 	}
 
-	workflowRunner := engine.NewTemporalManager(*c, "MICRO_WORKFLOW_QUEUE", microActivationHandler, microCompletionHandler)
+	workflowRunner := engine.NewTemporalManager(c, "MICRO_WORKFLOW_QUEUE", microActivationHandler, microCompletionHandler)
 
 	tm = orchestrator.NewTaskManager(taskStore, templateRegistry, pluginsRegistry, workflowRunner, onTaskCompleted, taskRenderer)
 

--- a/backend/internal/taskv2/wiring.go
+++ b/backend/internal/taskv2/wiring.go
@@ -8,6 +8,7 @@ import (
 	engine "github.com/OpenNSW/go-temporal-workflow"
 	"github.com/OpenNSW/nsw-task-flow/orchestrator"
 	"github.com/OpenNSW/nsw-task-flow/plugins"
+	"github.com/OpenNSW/nsw/internal/payments"
 	"github.com/OpenNSW/nsw/internal/taskv2/registry"
 	taskrenderer "github.com/OpenNSW/nsw/internal/taskv2/renderer"
 	"github.com/OpenNSW/nsw/internal/taskv2/store"
@@ -33,7 +34,7 @@ type WireResult struct {
 // macro workflow can advance past its Task node. The plugin registry must be
 // pre-populated by the caller; an empty registry means every sub-task
 // activation will fail to find a handler.
-func WireTaskV2(db *gorm.DB, c *client.Client, pluginsRegistry *plugins.Registry, onTaskCompleted orchestrator.TaskCompletedCallback) (*WireResult, func() error, error) {
+func WireTaskV2(db *gorm.DB, c *client.Client, pluginsRegistry *plugins.Registry, paymentService payments.PaymentService, onTaskCompleted orchestrator.TaskCompletedCallback) (*WireResult, func() error, error) {
 	if pluginsRegistry == nil {
 		return nil, nil, fmt.Errorf("taskv2: plugins registry is nil")
 	}
@@ -45,9 +46,10 @@ func WireTaskV2(db *gorm.DB, c *client.Client, pluginsRegistry *plugins.Registry
 		return nil, nil, fmt.Errorf("taskv2: load configs: %w", err)
 	}
 
+	projectors := append(uiprojector.DefaultProjectors(), taskrenderer.NewPaymentProjector(paymentService))
 	uiAssembler, err := uiprojector.NewAssembler(
 		registryTemplateProvider{reg: templateRegistry},
-		uiprojector.DefaultProjectors(),
+		projectors,
 	)
 	if err != nil {
 		return nil, nil, fmt.Errorf("taskv2: build assembler: %w", err)

--- a/backend/pkg/uiprojector/projector.go
+++ b/backend/pkg/uiprojector/projector.go
@@ -66,7 +66,15 @@ func NewMarkdownProjector() *MarkdownProjector {
 func (p *MarkdownProjector) Type() ProjectorType { return ProjectorMarkdown }
 
 func (p *MarkdownProjector) Project(ctx context.Context, templateContent []byte, data any) (Projection, error) {
-	tmpl, err := template.New("markdown").Parse(string(templateContent))
+	var wrapper struct {
+		Template string `json:"template"`
+	}
+	templateStr := string(templateContent)
+	if json.Unmarshal(templateContent, &wrapper) == nil && wrapper.Template != "" {
+		templateStr = wrapper.Template
+	}
+
+	tmpl, err := template.New("markdown").Parse(templateStr)
 	if err != nil {
 		return Projection{}, fmt.Errorf("markdown_projector: failed to parse template: %w", err)
 	}

--- a/backend/pkg/uiprojector/projector_test.go
+++ b/backend/pkg/uiprojector/projector_test.go
@@ -86,6 +86,13 @@ func TestMarkdownProjector_Project(t *testing.T) {
 		assert.Contains(t, out.Content.(string), "<no value>")
 	})
 
+	t.Run("extracts template string from json wrapper and projects it", func(t *testing.T) {
+		templateJSON := []byte(`{"id": "test-id", "template": "Hello {{.Name}}!"}`)
+		out, err := p.Project(ctx, templateJSON, map[string]any{"Name": "JSON"})
+		require.NoError(t, err)
+		assert.Equal(t, "Hello JSON!", out)
+	})
+
 	t.Run("returns parse error for malformed template syntax", func(t *testing.T) {
 		_, err := p.Project(ctx, []byte("{{.Name"), nil)
 		require.Error(t, err)

--- a/portals/apps/trader-app/src/zones/renderers/FormRenderer.tsx
+++ b/portals/apps/trader-app/src/zones/renderers/FormRenderer.tsx
@@ -14,10 +14,7 @@ type Props = ZoneRendererProps<'FORM'> & {
   onValidityChange?: (isValid: boolean) => void
 }
 
-export const FormRenderer = forwardRef<FormHandle, Props>(function FormRenderer(
-  { payload, onValidityChange },
-  ref,
-) {
+export const FormRenderer = forwardRef<FormHandle, Props>(function FormRenderer({ payload, onValidityChange }, ref) {
   const [data, setData] = useState<Record<string, unknown>>(payload.data ?? {})
   const dataRef = useRef(data)
   dataRef.current = data

--- a/portals/apps/trader-app/src/zones/renderers/RedirectRenderer.tsx
+++ b/portals/apps/trader-app/src/zones/renderers/RedirectRenderer.tsx
@@ -17,12 +17,20 @@ export function RedirectRenderer({ payload }: ZoneRendererProps<'REDIRECT'>) {
 
   useEffect(() => {
     if (checkout_url && !hasRedirected) {
+      let success = false
       try {
         sessionStorage.setItem(sessionKey, 'true')
+        success = true
       } catch (err) {
         console.error('Failed to set sessionStorage:', err)
       }
-      window.location.href = checkout_url
+      if (success) {
+        window.location.href = checkout_url
+      } else {
+        // Fallback: if sessionStorage is unavailable, do not auto-redirect
+        // to prevent infinite loops. Force manual redirection instead.
+        setHasRedirected(true)
+      }
     }
   }, [checkout_url, hasRedirected, sessionKey])
 

--- a/portals/apps/trader-app/src/zones/renderers/RedirectRenderer.tsx
+++ b/portals/apps/trader-app/src/zones/renderers/RedirectRenderer.tsx
@@ -24,7 +24,7 @@ export function RedirectRenderer({ payload }: ZoneRendererProps<'REDIRECT'>) {
       } catch (err) {
         console.error('Failed to set sessionStorage:', err)
       }
-      if (success) {
+      if (success && (checkout_url.startsWith('https://') || checkout_url.startsWith('http://'))) {
         window.location.href = checkout_url
       } else {
         // Fallback: if sessionStorage is unavailable, do not auto-redirect
@@ -35,7 +35,7 @@ export function RedirectRenderer({ payload }: ZoneRendererProps<'REDIRECT'>) {
   }, [checkout_url, hasRedirected, sessionKey])
 
   const handleGoToSession = () => {
-    if (checkout_url) {
+    if (checkout_url && (checkout_url.startsWith('https://') || checkout_url.startsWith('http://'))) {
       window.location.href = checkout_url
     }
   }

--- a/portals/apps/trader-app/src/zones/renderers/RedirectRenderer.tsx
+++ b/portals/apps/trader-app/src/zones/renderers/RedirectRenderer.tsx
@@ -1,0 +1,143 @@
+import { useEffect, useState } from 'react'
+import ReactMarkdown from 'react-markdown'
+import { Button } from '@radix-ui/themes'
+import type { ZoneRendererProps } from './types'
+
+export function RedirectRenderer({ payload }: ZoneRendererProps<'REDIRECT'>) {
+  const { checkout_url, content } = payload
+  const sessionKey = `nsw:redirected:${checkout_url}`
+
+  const [hasRedirected, setHasRedirected] = useState(() => {
+    try {
+      return sessionStorage.getItem(sessionKey) === 'true'
+    } catch {
+      return false
+    }
+  })
+
+  useEffect(() => {
+    if (checkout_url && !hasRedirected) {
+      try {
+        sessionStorage.setItem(sessionKey, 'true')
+      } catch (err) {
+        console.error('Failed to set sessionStorage:', err)
+      }
+      window.location.href = checkout_url
+    }
+  }, [checkout_url, hasRedirected, sessionKey])
+
+  const handleGoToSession = () => {
+    if (checkout_url) {
+      window.location.href = checkout_url
+    }
+  }
+
+  const handleReset = () => {
+    try {
+      sessionStorage.removeItem(sessionKey)
+    } catch (err) {
+      console.error('Failed to remove sessionStorage key:', err)
+    }
+    setHasRedirected(false)
+  }
+
+  if (hasRedirected) {
+    return (
+      <div className="rounded-lg border border-indigo-200 bg-indigo-50/40 p-6 text-sm text-gray-700 shadow-sm transition-all duration-300">
+        <div className="flex items-center gap-3 mb-4">
+          <div className="p-2 bg-indigo-100 rounded-full text-indigo-700">
+            <svg
+              xmlns="http://www.w3.org/2000/svg"
+              className="w-5 h-5"
+              fill="none"
+              viewBox="0 0 24 24"
+              stroke="currentColor"
+              strokeWidth={2}
+            >
+              <path
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                d="M10 6H6a2 2 0 00-2 2v10a2 2 0 002 2h10a2 2 0 002-2v-4M14 4h6m0 0v6m0-6L10 14"
+              />
+            </svg>
+          </div>
+          <div>
+            <h4 className="font-semibold text-indigo-900 text-base">Redirected to Payment Gateway</h4>
+            <p className="text-xs text-gray-500">Your session was redirected to the external payment gateway.</p>
+          </div>
+        </div>
+
+        <div className="text-gray-600 mb-6 bg-white/60 p-4 rounded-md border border-gray-100">
+          <ReactMarkdown
+            components={{
+              a: ({ children, href }) => (
+                <a href={href} target="_blank" rel="noreferrer" className="text-indigo-600 hover:underline">
+                  {children}
+                </a>
+              ),
+              p: ({ children }) => <p className="text-gray-700 leading-relaxed mb-2 last:mb-0">{children}</p>,
+              strong: ({ children }) => <strong className="font-semibold text-gray-900">{children}</strong>,
+              em: ({ children }) => <em className="italic text-gray-800">{children}</em>,
+              h3: ({ children }) => <h3 className="text-base font-semibold text-gray-900 mt-2 mb-1">{children}</h3>,
+            }}
+          >
+            {content}
+          </ReactMarkdown>
+        </div>
+
+        <div className="flex items-center gap-3">
+          <Button
+            type="button"
+            size="3"
+            onClick={handleGoToSession}
+            className="cursor-pointer font-medium shadow-sm flex items-center gap-2"
+          >
+            Return to payment session
+            <svg
+              xmlns="http://www.w3.org/2000/svg"
+              className="w-4 h-4"
+              fill="none"
+              viewBox="0 0 24 24"
+              stroke="currentColor"
+              strokeWidth={2}
+            >
+              <path strokeLinecap="round" strokeLinejoin="round" d="M14 5l7 7m0 0l-7 7m7-7H3" />
+            </svg>
+          </Button>
+
+          <Button
+            type="button"
+            variant="ghost"
+            color="gray"
+            size="3"
+            onClick={handleReset}
+            className="cursor-pointer text-gray-500 hover:text-gray-900 transition-colors"
+          >
+            Reset redirection state
+          </Button>
+        </div>
+      </div>
+    )
+  }
+
+  return (
+    <div className="rounded border border-indigo-200 bg-indigo-50/40 p-6 text-sm text-gray-700">
+      <p className="mb-3 font-medium text-indigo-700">Redirecting to payment gateway…</p>
+      <ReactMarkdown
+        components={{
+          a: ({ children, href }) => (
+            <a href={href} target="_blank" rel="noreferrer" className="text-indigo-600 hover:underline">
+              {children}
+            </a>
+          ),
+          p: ({ children }) => <p className="text-gray-700">{children}</p>,
+          strong: ({ children }) => <strong className="font-semibold text-gray-900">{children}</strong>,
+          em: ({ children }) => <em className="italic text-gray-800">{children}</em>,
+          h3: ({ children }) => <h3 className="text-base font-semibold text-gray-900 mt-2 mb-1">{children}</h3>,
+        }}
+      >
+        {content}
+      </ReactMarkdown>
+    </div>
+  )
+}

--- a/portals/apps/trader-app/src/zones/renderers/index.tsx
+++ b/portals/apps/trader-app/src/zones/renderers/index.tsx
@@ -11,7 +11,7 @@ export function renderZoneComponent(component: ZoneComponent) {
     case 'MARKDOWN':
       return <MarkdownRenderer payload={component.payload} />
     case 'REDIRECT':
-      return <RedirectRenderer payload={component.payload} />
+      return <RedirectRenderer key={component.payload.checkout_url} payload={component.payload} />
     default:
       return <UnknownRenderer type={(component as { type: string }).type} />
   }

--- a/portals/apps/trader-app/src/zones/renderers/index.tsx
+++ b/portals/apps/trader-app/src/zones/renderers/index.tsx
@@ -1,6 +1,7 @@
 import type { ZoneComponent } from '../types'
 import { FormRenderer } from './FormRenderer'
 import { MarkdownRenderer } from './MarkdownRenderer'
+import { RedirectRenderer } from './RedirectRenderer'
 import { UnknownRenderer } from './UnknownRenderer'
 
 export function renderZoneComponent(component: ZoneComponent) {
@@ -9,6 +10,8 @@ export function renderZoneComponent(component: ZoneComponent) {
       return <FormRenderer payload={component.payload} />
     case 'MARKDOWN':
       return <MarkdownRenderer payload={component.payload} />
+    case 'REDIRECT':
+      return <RedirectRenderer payload={component.payload} />
     default:
       return <UnknownRenderer type={(component as { type: string }).type} />
   }

--- a/portals/apps/trader-app/src/zones/types.ts
+++ b/portals/apps/trader-app/src/zones/types.ts
@@ -11,7 +11,15 @@ export type MarkdownPayload = {
   content: string
 }
 
-export type ZoneComponent = { type: 'FORM'; payload: FormPayload } | { type: 'MARKDOWN'; payload: MarkdownPayload }
+export type RedirectPayload = {
+  checkout_url: string
+  content: string
+}
+
+export type ZoneComponent =
+  | { type: 'FORM'; payload: FormPayload }
+  | { type: 'MARKDOWN'; payload: MarkdownPayload }
+  | { type: 'REDIRECT'; payload: RedirectPayload }
 
 export type AlertVariant = 'info' | 'success' | 'warning' | 'error'
 


### PR DESCRIPTION
## Summary

Implement redirect zone rendering in `trader-app` and session storage tracking to prevent infinite redirection loops when returning from the payment gateway. Provides interactive controls to return to the active session or reset the redirection state.

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Other (please describe):

## Changes Made

- **Session Tracking:** Checked and set `nsw:redirected:${checkout_url}` in `sessionStorage` to track whether the automatic redirect has already run.
- **Auto-redirect Prevention:** Limited automatic redirect logic in `RedirectRenderer` to run only when `hasRedirected` is false, preventing infinite redirect loops when navigating back to the app.
- **Polished UI / Controls:** Rendered a premium notification card once redirected, containing:
  - Markdown instructions of the payment details.
  - A primary `@radix-ui/themes` `Button` to return to the external checkout/payment session.
  - A secondary ghost `Button` to reset the redirection state and allow starting over.
- **Registration:** Wired the new `REDIRECT` zone component type in renderer, workspace layout, and type definitions.

## Testing

- [x] I have tested this change locally
- [ ] I have added unit tests for new functionality
- [ ] I have tested edge cases
- [x] All existing tests pass

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have checked that there are no merge conflicts

## Related Issues

Related to #395

## Screenshots/Demo

*(UI displays a clear status banner, markdown content, and actions to return to or reset the session.)*

## Additional Notes

Linter checks and type checks (`npm run type-check`) pass clean.

## Deployment Notes

No special deployment instructions.
