### PR TITLE
fix(CI): fix image name for CI build pipeline

### DIFF
--- a/deployments/helm/nsw-api/values.yaml
+++ b/deployments/helm/nsw-api/values.yaml
@@ -15,7 +15,7 @@ securityContext:
       - ALL
 
 image:
-  repository: ghcr.io/opennsw/nsw-api
+  repository: ghcr.io/opennsw/nsw-backend
   pullPolicy: IfNotPresent
   tag: 0.0.0-replace-me
 


### PR DESCRIPTION
## Summary
 The CI build pipeline publishes the image as 'nsw-backend' but the Helm `chart values.yaml` was pointing to the non-existent 'nsw-api' name. Align the chart default to match what `build-dev.yml` actually produces