### PR TITLE
fix(taskv2): recognize consignment_id in unwrapOGACallback (legacy workflow_id removed)

### DIFF
--- a/backend/internal/taskv2/http_handler.go
+++ b/backend/internal/taskv2/http_handler.go
@@ -105,14 +105,14 @@ func (h *HTTPHandler) HandleCompleteTaskStep(w http.ResponseWriter, r *http.Requ
 // unwrapOGACallback detects OGA's legacy TaskResponse envelope and returns the
 // reviewer payload that the task plugin actually expects.
 //
-// OGA's sendToService posts back:
+// Agency's sendToService posts back:
 //
-//	{ "task_id": "...", "workflow_id": "...", "payload": { "action": "OGA_VERIFICATION", "content": {...} } }
+//	{ "task_id": "...", "consignment_id": "...", "payload": { "action": "AGENCY_VERIFICATION", "content": {...} } }
 //
 // but our plugins expect the bare reviewer form data. We detect the envelope
-// (presence of task_id + workflow_id + payload.content) and lift content up.
+// (presence of task_id + consignment_id + payload.content) and lift content up.
 //
-// TODO(oga-callback): remove once OGA is updated to post the bare reviewer
+// TODO(agency-callback): remove once the agency is updated to post the bare reviewer
 // payload directly to /api/v1/tasks/{id} (or to a dedicated /oga-callback
 // route that owns this translation).
 func unwrapOGACallback(payload map[string]any) map[string]any {
@@ -122,7 +122,7 @@ func unwrapOGACallback(payload map[string]any) map[string]any {
 	if _, hasTaskID := payload["task_id"]; !hasTaskID {
 		return payload
 	}
-	if _, hasWorkflowID := payload["workflow_id"]; !hasWorkflowID {
+	if _, hasConsignmentID := payload["consignment_id"]; !hasConsignmentID {
 		return payload
 	}
 	envelope, ok := payload["payload"].(map[string]any)


### PR DESCRIPTION
## Summary
- The agency renamed its outbound envelope field `workflow_id` → `consignment_id` to match
  the semantic identity (it's a consignment, not a generic workflow). `unwrapOGACallback`
  was hardcoded against the legacy name and silently passed the envelope through
  unstripped — task records ended up storing the wrapped envelope under their
  `output_namespace`, breaking the trader-portal reviewer form display and forcing
  per-workflow `payload.content.X` hacks in `output_mapping` configs.
- Updated `unwrapOGACallback` in `backend/internal/taskv2/http_handler.go` to detect
  `consignment_id` instead of `workflow_id`, and refreshed the godoc/TODO accordingly.

## Backwards compatibility
Breaking change for any agency still posting `workflow_id`. Coordinate the rollout:
agency posts `consignment_id` only after this change is merged. No other consumer of
the unwrap envelope shape exists in this repo (verified via
`grep -rn 'workflow_id' backend/internal/taskv2/` — remaining matches are unrelated
DB column names `parent_workflow_id` / `task_workflow_id`).

## Test plan
- [x] `go build ./...` passes
- [x] `go vet ./...` passes
- [ ] After merge: `go get github.com/OpenNSW/nsw/backend@taskv2 && go mod tidy` in
      downstream consumers, then restart the backend to pick up the new unwrap behavior
