### PR TITLE
feat(authz): introduce generic scope-based authorization layer

### DIFF
--- a/backend/internal/authz/README.md
+++ b/backend/internal/authz/README.md
@@ -1,0 +1,78 @@
+# authz — generic, scope-based authorization
+
+A small, **generic** authorization layer for HTTP services. It authorizes from the
+**OAuth2 scopes carried on the token** and is fully decoupled from the
+authentication layer.
+
+## Design principles
+
+- **Imports nothing internal.** The package depends only on the standard library.
+  It defines a minimal `Principal` interface — `Subject()`, `Roles()`, `Scopes()` —
+  which the authn layer's `*auth.AuthContext` satisfies **structurally**. authz
+  never imports `internal/auth`.
+- **Principal via dependency injection.** An `Extractor func(context.Context) (Principal, bool)`
+  is supplied at construction. The composition root wires the authn lookup into it,
+  so this package has no knowledge of how authentication works.
+- **Scopes come from the token.** Decisions use the scopes the IdP granted on the
+  token (e.g. `nsw:consignment:read`); there is no role- or client-ID-to-scope
+  mapping. `Roles()` is exposed for finer, business-level checks at the service layer.
+- **App scopes stay in the app.** Concrete scope strings (`nsw:...`) are defined at
+  the composition root, never in this generic package.
+
+## API
+
+```go
+type Principal interface { Subject() string; Roles() []string; Scopes() []string }
+type Extractor func(context.Context) (Principal, bool)
+
+func New(extract Extractor) (*Authorizer, error)
+
+func (a *Authorizer) Principal(ctx context.Context) (Principal, bool)
+func (a *Authorizer) RequireScope(scope string) func(http.Handler) http.Handler
+func (a *Authorizer) RequireAnyScope(scopes ...string) func(http.Handler) http.Handler
+func (a *Authorizer) RequireAllScopes(scopes ...string) func(http.Handler) http.Handler
+
+func HasScope(p Principal, scope string) bool
+func HasAnyScope(p Principal, scopes ...string) bool
+func HasAllScopes(p Principal, scopes ...string) bool
+
+var ErrUnauthenticated, ErrForbidden error
+```
+
+Middleware returns **401** when the request is unauthenticated and **403** when the
+principal lacks the required scope(s).
+
+## Wiring (composition root)
+
+```go
+authzr, err := authz.New(func(ctx context.Context) (authz.Principal, bool) {
+    ac := auth.GetAuthContext(ctx)
+    if ac == nil || ac.Type() == "" {
+        return nil, false
+    }
+    return ac, true // *auth.AuthContext satisfies authz.Principal structurally
+})
+if err != nil {
+    return fmt.Errorf("init authz: %w", err)
+}
+
+// Apply per route, after the authn middleware. Scope constants are app-defined.
+mux.Handle("GET /api/v1/consignments",
+    withAuth(authzr.RequireScope(scopes.ConsignmentRead)(
+        http.HandlerFunc(consignmentRouter.HandleGetConsignments))))
+```
+
+## Service-layer checks
+
+For logic beyond a coarse route gate, resolve the principal and inspect it:
+
+```go
+p, ok := authzr.Principal(ctx)
+if !ok {
+    return authz.ErrUnauthenticated
+}
+if !authz.HasScope(p, scopes.ConsignmentWrite) {
+    return authz.ErrForbidden
+}
+// p.Roles() / p.Subject() are available for finer, business-specific decisions.
+```

--- a/backend/internal/authz/authorizer.go
+++ b/backend/internal/authz/authorizer.go
@@ -1,0 +1,98 @@
+package authz
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"log/slog"
+	"net/http"
+)
+
+// Authorizer is the policy enforcement point. It resolves the authenticated
+// Principal (via the injected Extractor) and provides middleware that gates HTTP
+// routes on OAuth2 scopes.
+type Authorizer struct {
+	extract Extractor
+}
+
+// New constructs an Authorizer. extract supplies the authenticated Principal from
+// a request context (typically wrapping the authn layer's context lookup). It
+// returns an error if extract is nil.
+func New(extract Extractor) (*Authorizer, error) {
+	if extract == nil {
+		return nil, errors.New("authz: New requires a non-nil Extractor")
+	}
+	return &Authorizer{extract: extract}, nil
+}
+
+// Principal returns the authenticated principal from ctx, or (nil, false) when
+// the request is unauthenticated. Useful for service/handler-layer checks that go
+// beyond a coarse scope gate.
+func (a *Authorizer) Principal(ctx context.Context) (Principal, bool) {
+	if a == nil || a.extract == nil {
+		return nil, false
+	}
+	p, ok := a.extract(ctx)
+	if !ok || p == nil {
+		return nil, false
+	}
+	return p, true
+}
+
+// RequireScope returns middleware that admits a request only if the principal
+// holds scope: 401 when unauthenticated, 403 when authenticated but missing it.
+func (a *Authorizer) RequireScope(scope string) func(http.Handler) http.Handler {
+	if scope == "" {
+		panic("authz: RequireScope requires a non-empty scope")
+	}
+	return a.require(func(p Principal) bool { return HasScope(p, scope) }, scope)
+}
+
+// RequireAnyScope admits the request if the principal holds at least one of scopes.
+func (a *Authorizer) RequireAnyScope(scopes ...string) func(http.Handler) http.Handler {
+	if len(scopes) == 0 {
+		panic("authz: RequireAnyScope requires at least one scope")
+	}
+	return a.require(func(p Principal) bool { return HasAnyScope(p, scopes...) }, scopes...)
+}
+
+// RequireAllScopes admits the request only if the principal holds every one of scopes.
+func (a *Authorizer) RequireAllScopes(scopes ...string) func(http.Handler) http.Handler {
+	if len(scopes) == 0 {
+		panic("authz: RequireAllScopes requires at least one scope")
+	}
+	return a.require(func(p Principal) bool { return HasAllScopes(p, scopes...) }, scopes...)
+}
+
+func (a *Authorizer) require(allow func(Principal) bool, required ...string) func(http.Handler) http.Handler {
+	if a == nil || a.extract == nil {
+		panic("authz: middleware constructed on a nil Authorizer")
+	}
+	return func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			p, ok := a.extract(r.Context())
+			if !ok || p == nil {
+				writeError(w, http.StatusUnauthorized, "unauthorized", "authentication required")
+				return
+			}
+			if !allow(p) {
+				slog.Warn("authz: forbidden",
+					"subject", p.Subject(),
+					"required_scopes", required,
+					"granted_scopes", p.Scopes(),
+					"method", r.Method,
+					"path", r.URL.Path,
+				)
+				writeError(w, http.StatusForbidden, "forbidden", "insufficient scope")
+				return
+			}
+			next.ServeHTTP(w, r)
+		})
+	}
+}
+
+func writeError(w http.ResponseWriter, status int, code, message string) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(status)
+	_ = json.NewEncoder(w).Encode(map[string]string{"error": code, "message": message})
+}

--- a/backend/internal/authz/authorizer.go
+++ b/backend/internal/authz/authorizer.go
@@ -53,6 +53,11 @@ func (a *Authorizer) RequireAnyScope(scopes ...string) func(http.Handler) http.H
 	if len(scopes) == 0 {
 		panic("authz: RequireAnyScope requires at least one scope")
 	}
+	for _, s := range scopes {
+		if s == "" {
+			panic("authz: RequireAnyScope requires non-empty scopes")
+		}
+	}
 	return a.require(func(p Principal) bool { return HasAnyScope(p, scopes...) }, scopes...)
 }
 
@@ -60,6 +65,11 @@ func (a *Authorizer) RequireAnyScope(scopes ...string) func(http.Handler) http.H
 func (a *Authorizer) RequireAllScopes(scopes ...string) func(http.Handler) http.Handler {
 	if len(scopes) == 0 {
 		panic("authz: RequireAllScopes requires at least one scope")
+	}
+	for _, s := range scopes {
+		if s == "" {
+			panic("authz: RequireAllScopes requires non-empty scopes")
+		}
 	}
 	return a.require(func(p Principal) bool { return HasAllScopes(p, scopes...) }, scopes...)
 }

--- a/backend/internal/authz/authz_test.go
+++ b/backend/internal/authz/authz_test.go
@@ -170,5 +170,18 @@ func TestRequireAnyAndAllScopes(t *testing.T) {
 				a.RequireAllScopes()
 			}
 		})
+
+		t.Run("empty scope string panics ("+name+")", func(t *testing.T) {
+			defer func() {
+				if recover() == nil {
+					t.Fatal("expected panic when empty scope string provided")
+				}
+			}()
+			if name == "any" {
+				a.RequireAnyScope("nsw:task:read", "")
+			} else {
+				a.RequireAllScopes("nsw:task:read", "")
+			}
+		})
 	}
 }

--- a/backend/internal/authz/authz_test.go
+++ b/backend/internal/authz/authz_test.go
@@ -1,0 +1,174 @@
+package authz
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+// fakePrincipal is a plain struct (no authn dependency) used to prove the package
+// authorizes purely against the Principal contract.
+type fakePrincipal struct {
+	subject string
+	roles   []string
+	scopes  []string
+}
+
+func (f *fakePrincipal) Subject() string  { return f.subject }
+func (f *fakePrincipal) Roles() []string  { return f.roles }
+func (f *fakePrincipal) Scopes() []string { return f.scopes }
+
+// Compile-time proof that a plain struct satisfies Principal (no authn needed).
+var _ Principal = (*fakePrincipal)(nil)
+
+// staticExtractor returns p for every context; a nil p models an unauthenticated request.
+func staticExtractor(p Principal) Extractor {
+	return func(context.Context) (Principal, bool) {
+		if p == nil {
+			return nil, false
+		}
+		return p, true
+	}
+}
+
+func mustNew(t *testing.T, extract Extractor) *Authorizer {
+	t.Helper()
+	a, err := New(extract)
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	return a
+}
+
+func TestScopeHelpers(t *testing.T) {
+	p := &fakePrincipal{scopes: []string{"nsw:task:read", "nsw:consignment:read"}}
+	cases := []struct {
+		name string
+		got  bool
+		want bool
+	}{
+		{"has exact", HasScope(p, "nsw:task:read"), true},
+		{"missing", HasScope(p, "nsw:task:write"), false},
+		{"empty scope", HasScope(p, ""), false},
+		{"nil principal", HasScope(nil, "x"), false},
+		{"any present", HasAnyScope(p, "x", "nsw:consignment:read"), true},
+		{"any absent", HasAnyScope(p, "x", "y"), false},
+		{"any none given", HasAnyScope(p), false},
+		{"all present", HasAllScopes(p, "nsw:task:read", "nsw:consignment:read"), true},
+		{"all partial", HasAllScopes(p, "nsw:task:read", "x"), false},
+		{"all none given", HasAllScopes(p), true},
+	}
+	for _, c := range cases {
+		if c.got != c.want {
+			t.Errorf("%s: got %v, want %v", c.name, c.got, c.want)
+		}
+	}
+}
+
+func TestNew_NilExtractorReturnsError(t *testing.T) {
+	if _, err := New(nil); err == nil {
+		t.Fatal("expected error for nil extractor")
+	}
+}
+
+func TestRequireScope_EmptyScopePanics(t *testing.T) {
+	defer func() {
+		if recover() == nil {
+			t.Fatal("expected panic for empty scope")
+		}
+	}()
+	mustNew(t, staticExtractor(&fakePrincipal{})).RequireScope("")
+}
+
+func TestAuthorizer_Principal(t *testing.T) {
+	want := &fakePrincipal{subject: "u1"}
+	if got, ok := mustNew(t, staticExtractor(want)).Principal(context.Background()); !ok || got != want {
+		t.Fatalf("Principal() = %v, %v; want %v, true", got, ok, want)
+	}
+	if _, ok := mustNew(t, staticExtractor(nil)).Principal(context.Background()); ok {
+		t.Fatal("expected no principal for unauthenticated request")
+	}
+	var nilA *Authorizer
+	if _, ok := nilA.Principal(context.Background()); ok {
+		t.Fatal("nil Authorizer should return (nil, false)")
+	}
+}
+
+func serve(t *testing.T, mw func(http.Handler) http.Handler) (status int, nextCalled bool) {
+	t.Helper()
+	next := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		nextCalled = true
+		w.WriteHeader(http.StatusOK)
+	})
+	rec := httptest.NewRecorder()
+	mw(next).ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/x", nil))
+	return rec.Code, nextCalled
+}
+
+func TestRequireScope_Enforcement(t *testing.T) {
+	user := &fakePrincipal{subject: "u1", roles: []string{"Trader"}, scopes: []string{"nsw:consignment:read"}}
+	client := &fakePrincipal{subject: "NPQS_TO_NSW", scopes: []string{"nsw:task:write"}} // scopes only, no roles
+
+	cases := []struct {
+		name       string
+		principal  Principal // nil => unauthenticated
+		scope      string
+		wantStatus int
+		wantNext   bool
+	}{
+		{"unauthenticated -> 401", nil, "nsw:consignment:read", http.StatusUnauthorized, false},
+		{"user missing scope -> 403", user, "nsw:consignment:write", http.StatusForbidden, false},
+		{"user has scope -> 200", user, "nsw:consignment:read", http.StatusOK, true},
+		{"client has scope -> 200", client, "nsw:task:write", http.StatusOK, true},
+		{"client missing scope -> 403", client, "nsw:task:read", http.StatusForbidden, false},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			status, nextCalled := serve(t, mustNew(t, staticExtractor(c.principal)).RequireScope(c.scope))
+			if status != c.wantStatus {
+				t.Errorf("status = %d, want %d", status, c.wantStatus)
+			}
+			if nextCalled != c.wantNext {
+				t.Errorf("next called = %v, want %v", nextCalled, c.wantNext)
+			}
+		})
+	}
+}
+
+func TestRequireAnyAndAllScopes(t *testing.T) {
+	a := mustNew(t, staticExtractor(&fakePrincipal{scopes: []string{"a", "b"}}))
+
+	checks := []struct {
+		name       string
+		mw         func(http.Handler) http.Handler
+		wantStatus int
+	}{
+		{"any present", a.RequireAnyScope("x", "b"), http.StatusOK},
+		{"any absent", a.RequireAnyScope("x", "y"), http.StatusForbidden},
+		{"all present", a.RequireAllScopes("a", "b"), http.StatusOK},
+		{"all partial", a.RequireAllScopes("a", "x"), http.StatusForbidden},
+	}
+	for _, c := range checks {
+		t.Run(c.name, func(t *testing.T) {
+			if status, _ := serve(t, c.mw); status != c.wantStatus {
+				t.Errorf("status = %d, want %d", status, c.wantStatus)
+			}
+		})
+	}
+
+	for _, name := range []string{"any", "all"} {
+		t.Run("no scopes panics ("+name+")", func(t *testing.T) {
+			defer func() {
+				if recover() == nil {
+					t.Fatal("expected panic when no scopes provided")
+				}
+			}()
+			if name == "any" {
+				a.RequireAnyScope()
+			} else {
+				a.RequireAllScopes()
+			}
+		})
+	}
+}

--- a/backend/internal/authz/doc.go
+++ b/backend/internal/authz/doc.go
@@ -1,0 +1,15 @@
+// Package authz provides generic, transport-agnostic authorization for HTTP
+// services, driven by the OAuth2 scopes carried on a request's authenticated
+// principal.
+//
+// It is intentionally decoupled from any authentication implementation: it
+// defines a minimal Principal interface (Subject/Roles/Scopes) and receives the
+// principal through an injected Extractor, so it imports nothing from the authn
+// layer (or any other internal package). In this codebase *auth.AuthContext
+// satisfies Principal structurally; the composition root wires
+// auth.GetAuthContext into the Extractor.
+//
+// Authorization decisions use the scopes already granted on the token (for
+// example "nsw:consignment:read"). Application-specific scope strings are defined
+// by the caller, never here.
+package authz

--- a/backend/internal/authz/principal.go
+++ b/backend/internal/authz/principal.go
@@ -1,0 +1,67 @@
+package authz
+
+import (
+	"context"
+	"errors"
+	"slices"
+)
+
+// Principal is the minimal, transport-agnostic identity contract this package
+// needs to make authorization decisions. It is deliberately tiny so an
+// authentication layer's context type satisfies it *structurally* — in this
+// codebase *auth.AuthContext already implements Subject/Roles/Scopes — which is
+// why this package imports nothing from the authn layer. Authorization is driven
+// by the OAuth2 scopes granted on the token; Roles is exposed for callers that
+// need finer, business-level checks at the service layer.
+type Principal interface {
+	// Subject returns a stable identifier for the principal: a user ID for user
+	// principals or a machine client ID for client (M2M) principals.
+	Subject() string
+	// Roles returns the roles granted to the principal, or nil.
+	Roles() []string
+	// Scopes returns the OAuth2 scopes granted to the principal, or nil.
+	Scopes() []string
+}
+
+// Extractor retrieves the authenticated Principal from a request context. It is
+// injected at construction so this package stays decoupled from any specific
+// authentication implementation. It must return (nil, false) when the request is
+// unauthenticated.
+type Extractor func(ctx context.Context) (Principal, bool)
+
+// Sentinel errors for callers performing service-layer authorization. The HTTP
+// middleware in this package translates these conditions into 401/403 itself.
+var (
+	ErrUnauthenticated = errors.New("authz: unauthenticated")
+	ErrForbidden       = errors.New("authz: forbidden")
+)
+
+// HasScope reports whether the principal was granted the exact scope.
+func HasScope(p Principal, scope string) bool {
+	if p == nil || scope == "" {
+		return false
+	}
+	return slices.Contains(p.Scopes(), scope)
+}
+
+// HasAnyScope reports whether the principal holds at least one of the scopes.
+// With no scopes provided it returns false.
+func HasAnyScope(p Principal, scopes ...string) bool {
+	for _, s := range scopes {
+		if HasScope(p, s) {
+			return true
+		}
+	}
+	return false
+}
+
+// HasAllScopes reports whether the principal holds every one of the scopes.
+// With no scopes provided it returns true (vacuously satisfied).
+func HasAllScopes(p Principal, scopes ...string) bool {
+	for _, s := range scopes {
+		if !HasScope(p, s) {
+			return false
+		}
+	}
+	return true
+}


### PR DESCRIPTION
## Summary

Introduces `internal/authz` — a generic, scope-based HTTP authorization layer that complements `internal/auth`. Authorization is driven by the OAuth2 scopes carried on the access token. The package is fully decoupled from the authentication implementation by design: it defines its own minimal `Principal` interface and receives the principal through an injected `Extractor`.

Closes #561

## Type of Change

- [x] New feature (non-breaking change which adds functionality)
- [x] Refactoring (no functional changes)

## Changes Made

- **`internal/authz/principal.go`** — `Principal` interface (`Subject()`, `Roles()`, `Scopes()`), `Extractor` type, `ErrUnauthenticated`/`ErrForbidden` sentinels, and `HasScope`/`HasAnyScope`/`HasAllScopes` helpers for service-layer checks.
- **`internal/authz/authorizer.go`** — `Authorizer` with `New(extract Extractor) (*Authorizer, error)`, `Principal(ctx)`, and `RequireScope`/`RequireAnyScope`/`RequireAllScopes` HTTP middleware (401 unauthenticated · 403 missing scope, house-style JSON errors, `slog` on 403).
- **`internal/authz/doc.go`** — package documentation.
- **`internal/authz/README.md`** — design principles, full API reference, composition-root wiring example, and service-layer usage pattern.

## Architecture

The package imports **nothing from `internal/auth`** or any other internal package (stdlib only). The authn layer's `*auth.AuthContext` satisfies `authz.Principal` *structurally* — the composition root wires `auth.GetAuthContext` into the `Extractor`, keeping the two packages independent.

```go
// Composition root (app bootstrap — not in this PR)
authzr, err := authz.New(func(ctx context.Context) (authz.Principal, bool) {
    ac := auth.GetAuthContext(ctx)
    if ac == nil || ac.Type() == "" { return nil, false }
    return ac, true // *auth.AuthContext satisfies authz.Principal structurally
})

// Per route
mux.Handle("GET /api/v1/consignments",
    withAuth(authzr.RequireScope("nsw:consignment:read")(h)))
```

Scope strings are app-defined constants at the composition root — never in this generic package.

## Testing

- [x] I have tested this change locally
- [x] I have added unit tests for new functionality
- [x] I have tested edge cases
- [x] All existing tests pass

Unit tests (`authz_test.go`) use a local `fakePrincipal` struct (zero authn dependency) to cover:
- `HasScope`/`HasAnyScope`/`HasAllScopes` table cases
- `New(nil)` returns error; factory panics on empty/no-scope args catch wiring bugs at startup
- `RequireScope` enforcement: 401 unauthenticated, 403 missing scope, 200 passthrough — for both user-style (roles + scopes) and client-style (scopes only) principals
- `RequireAnyScope` / `RequireAllScopes` enforcement
- `Principal(ctx)` including nil-receiver safety

Decoupling verified: `go list -deps ./internal/authz | grep internal/auth` → empty (zero dependency on the authn package).

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have checked that there are no merge conflicts

## Related Issues

Closes #561

## Additional Notes

This PR is pure plumbing — no existing handler, route, or service is touched and there is no behavioural change. Wiring `RequireScope` into routes and migrating the `?role=` query-param gate in `consignment/router.go` (TODO on line 85) are follow-up steps.

🤖 Generated with [Claude Code](https://claude.com/claude-code)