### PR TITLE
feat(authz): enforce mandatory auth and scope-based authorization on protected routes

### DIFF
--- a/backend/internal/app/bootstrap/app.go
+++ b/backend/internal/app/bootstrap/app.go
@@ -199,7 +199,7 @@ func Build(ctx context.Context, cfg *config.Config) (*App, error) {
 	taskV2Handler := taskv2.NewHTTPHandler(tm, taskV2.Store, taskV2.Assembler)
 
 	// withAuth wraps an individual handler with the authentication middleware.
-	withAuth := authManager.Middleware()
+	withAuth := authManager.RequireAuthMiddleware()
 
 	// authzr gates routes by the OAuth2 scopes carried on the token.
 	// The extractor bridges the authn layer (auth.GetAuthContext) into the

--- a/backend/internal/app/bootstrap/app.go
+++ b/backend/internal/app/bootstrap/app.go
@@ -11,7 +11,9 @@ import (
 	flowplugins "github.com/OpenNSW/nsw-task-flow/plugins"
 	"github.com/OpenNSW/nsw/backend/internal/workflow"
 
+	"github.com/OpenNSW/nsw/backend/internal/app/scopes"
 	"github.com/OpenNSW/nsw/backend/internal/auth"
+	"github.com/OpenNSW/nsw/backend/internal/authz"
 	"github.com/OpenNSW/nsw/backend/internal/config"
 	"github.com/OpenNSW/nsw/backend/internal/consignment"
 	"github.com/OpenNSW/nsw/backend/internal/database"
@@ -199,6 +201,30 @@ func Build(ctx context.Context, cfg *config.Config) (*App, error) {
 	// withAuth wraps an individual handler with the authentication middleware.
 	withAuth := authManager.Middleware()
 
+	// authzr gates routes by the OAuth2 scopes carried on the token.
+	// The extractor bridges the authn layer (auth.GetAuthContext) into the
+	// generic authz.Principal interface — authz imports nothing from internal/auth.
+	authzr, err := authz.New(func(ctx context.Context) (authz.Principal, bool) {
+		ac := auth.GetAuthContext(ctx)
+		if ac == nil || ac.Type() == "" {
+			return nil, false
+		}
+		return ac, true
+	})
+	if err != nil {
+		_ = stopParentRunner()
+		_ = stopTaskV2()
+		temporalClient.Close()
+		_ = authManager.Close()
+		_ = database.Close(db)
+		return nil, fmt.Errorf("failed to create authz: %w", err)
+	}
+	// withScope returns a middleware requiring the given scope; compose after withAuth
+	// so the auth context is already injected when the scope check runs.
+	withScope := func(scope string) func(http.Handler) http.Handler {
+		return authzr.RequireScope(scope)
+	}
+
 	mux := http.NewServeMux()
 
 	// Health check is public and returns JSON in all cases.
@@ -229,28 +255,28 @@ func Build(ctx context.Context, cfg *config.Config) (*App, error) {
 		})
 	})
 
-	// API routes. Each handler is individually wrapped with auth,
-	// so public or differently-authenticated routes can be added
-	// alongside these without restructuring the mux.
-	mux.Handle("GET /api/v1/tasks/{id}", withAuth(http.HandlerFunc(taskV2Handler.HandleGetTask)))
-	mux.Handle("POST /api/v1/tasks/{id}", withAuth(http.HandlerFunc(taskV2Handler.HandleCompleteTaskStep)))
+	// API routes. Each handler is wrapped with auth (JWT validation) then a
+	// scope gate. Order matters: withAuth injects the AuthContext; withScope
+	// reads it. Public routes (payments, local-dev storage) are below.
+	mux.Handle("GET /api/v1/tasks/{id}", withAuth(withScope(scopes.TaskRead)(http.HandlerFunc(taskV2Handler.HandleGetTask))))
+	mux.Handle("POST /api/v1/tasks/{id}", withAuth(withScope(scopes.TaskWrite)(http.HandlerFunc(taskV2Handler.HandleCompleteTaskStep))))
 	// TODO(oga-callback): remove once OGA POSTs directly to /api/v1/tasks/{id}
 	// with the bare reviewer payload. This legacy route accepts OGA's
 	// {task_id, workflow_id, payload:{action, content}} envelope and the
 	// handler unwraps payload.content + falls back to body-level task_id.
-	mux.Handle("POST /api/v1/tasks", withAuth(http.HandlerFunc(taskV2Handler.HandleCompleteTaskStep)))
-	mux.Handle("GET /api/v1/hscodes", withAuth(http.HandlerFunc(hsCodeRouter.HandleGetAll)))
-	mux.Handle("GET /api/v1/chas", withAuth(http.HandlerFunc(chaHandler.HandleGetCHAs)))
-	mux.Handle("GET /api/v1/companies", withAuth(http.HandlerFunc(companyHandler.HandleGetCompanies)))
-	mux.Handle("POST /api/v1/consignments", withAuth(http.HandlerFunc(consignmentRouter.HandleCreateConsignment)))
-	mux.Handle("GET /api/v1/consignments/{id}", withAuth(http.HandlerFunc(consignmentRouter.HandleGetConsignmentByID)))
-	mux.Handle("PUT /api/v1/consignments/{id}", withAuth(http.HandlerFunc(consignmentRouter.HandleInitializeConsignment)))
-	mux.Handle("GET /api/v1/consignments", withAuth(http.HandlerFunc(consignmentRouter.HandleGetConsignments)))
+	mux.Handle("POST /api/v1/tasks", withAuth(withScope(scopes.TaskWrite)(http.HandlerFunc(taskV2Handler.HandleCompleteTaskStep))))
+	mux.Handle("GET /api/v1/hscodes", withAuth(withScope(scopes.HSCodeRead)(http.HandlerFunc(hsCodeRouter.HandleGetAll))))
+	mux.Handle("GET /api/v1/chas", withAuth(withScope(scopes.CHARead)(http.HandlerFunc(chaHandler.HandleGetCHAs))))
+	mux.Handle("GET /api/v1/companies", withAuth(withScope(scopes.CompanyRead)(http.HandlerFunc(companyHandler.HandleGetCompanies))))
+	mux.Handle("POST /api/v1/consignments", withAuth(withScope(scopes.ConsignmentWrite)(http.HandlerFunc(consignmentRouter.HandleCreateConsignment))))
+	mux.Handle("GET /api/v1/consignments/{id}", withAuth(withScope(scopes.ConsignmentRead)(http.HandlerFunc(consignmentRouter.HandleGetConsignmentByID))))
+	mux.Handle("PUT /api/v1/consignments/{id}", withAuth(withScope(scopes.ConsignmentWrite)(http.HandlerFunc(consignmentRouter.HandleInitializeConsignment))))
+	mux.Handle("GET /api/v1/consignments", withAuth(withScope(scopes.ConsignmentRead)(http.HandlerFunc(consignmentRouter.HandleGetConsignments))))
 
 	// Storage
-	mux.Handle("POST /api/v1/storage", withAuth(http.HandlerFunc(storageHandler.Upload)))
-	mux.Handle("GET /api/v1/storage/{key}", withAuth(http.HandlerFunc(storageHandler.Download)))
-	mux.Handle("DELETE /api/v1/storage/{key}", withAuth(http.HandlerFunc(storageHandler.Delete)))
+	mux.Handle("POST /api/v1/storage", withAuth(withScope(scopes.StorageWrite)(http.HandlerFunc(storageHandler.Upload))))
+	mux.Handle("GET /api/v1/storage/{key}", withAuth(withScope(scopes.StorageRead)(http.HandlerFunc(storageHandler.Download))))
+	mux.Handle("DELETE /api/v1/storage/{key}", withAuth(withScope(scopes.StorageDelete)(http.HandlerFunc(storageHandler.Delete))))
 
 	// External Webhooks bypass standard JWT auth.
 	// They should use webhook signatures, implemented in the handler directly or via specialized middleware.

--- a/backend/internal/app/scopes/scopes.go
+++ b/backend/internal/app/scopes/scopes.go
@@ -1,0 +1,31 @@
+// Package scopes defines the NSW API OAuth2 scope constants.
+//
+// These values must stay in sync with the NSW_API resource server defined in
+// idp/02-sample-resources.sh (nsw:* namespace). Each constant corresponds to
+// a permission derived from a resource + action handle in the IdP, following
+// the pattern "nsw:<resource>:<action>".
+//
+// Scope constants are defined here (not in internal/authz) so they can be
+// imported from the composition root, tests, and any future service-layer
+// checks without coupling the generic authz package to this application.
+package scopes
+
+const (
+	// Consignment resource.
+	ConsignmentRead  = "nsw:consignment:read"
+	ConsignmentWrite = "nsw:consignment:write"
+
+	// Task resource.
+	TaskRead  = "nsw:task:read"
+	TaskWrite = "nsw:task:write"
+
+	// Reference data (read-only).
+	HSCodeRead  = "nsw:hscode:read"
+	CompanyRead = "nsw:company:read"
+	CHARead     = "nsw:cha:read"
+
+	// Storage resource.
+	StorageRead   = "nsw:storage:read"
+	StorageWrite  = "nsw:storage:write"
+	StorageDelete = "nsw:storage:delete"
+)


### PR DESCRIPTION
## Summary

Closes two security issues in one PR:

- **Closes #363** — enforces mandatory authentication (`RequireAuthMiddleware`) on all protected routes; previously optional auth (`Middleware`) meant a misconfigured route could be reached anonymously.
- **Closes #344** — introduces a route-level scope policy matrix via `internal/authz` and per-route scope constants; the policy explicitly determines which principal types (user/M2M) may call which routes based on the OAuth2 scopes carried on the token.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

## Changes Made

**`backend/internal/app/scopes/scopes.go`** (new)
All NSW_API OAuth2 scope constants in a dedicated importable package (`nsw:<resource>:<action>` format), matching the resource server defined in `idp/02-sample-resources.sh`. Separate package keeps constants importable from tests and future service-layer checks without coupling to `internal/authz`.

**`backend/internal/app/bootstrap/app.go`**

1. **Mandatory auth (#363):** `authManager.Middleware()` → `authManager.RequireAuthMiddleware()`. All protected `/api/v1` routes now return **401** immediately on a missing or invalid token rather than continuing with an empty auth context.

2. **Scope policy (#344):** Constructs `authz.Authorizer` with an `Extractor` that bridges `auth.GetAuthContext` into `authz.Principal` structurally — `authz` imports nothing from `internal/auth`. Adds a `withScope` local helper and wraps every protected route with `withAuth(withScope(scopes.X)(handler))`.

Route → scope matrix:

| Route | Required scope | Allowed principals |
|---|---|---|
| `GET /api/v1/tasks/{id}` | `nsw:task:read` | Trader, CHA, M2M |
| `POST /api/v1/tasks/{id}` | `nsw:task:write` | M2M (OGA systems) |
| `POST /api/v1/tasks` (legacy) | `nsw:task:write` | M2M (OGA systems) |
| `GET /api/v1/hscodes` | `nsw:hscode:read` | Trader, CHA |
| `GET /api/v1/chas` | `nsw:cha:read` | Trader, CHA |
| `GET /api/v1/companies` | `nsw:company:read` | Trader, CHA |
| `POST /api/v1/consignments` | `nsw:consignment:write` | Trader, CHA |
| `GET /api/v1/consignments/{id}` | `nsw:consignment:read` | Trader, CHA, M2M |
| `PUT /api/v1/consignments/{id}` | `nsw:consignment:write` | Trader, CHA |
| `GET /api/v1/consignments` | `nsw:consignment:read` | Trader, CHA, M2M |
| `POST /api/v1/storage` | `nsw:storage:write` | Trader, CHA, M2M |
| `GET /api/v1/storage/{key}` | `nsw:storage:read` | Trader, CHA, M2M |
| `DELETE /api/v1/storage/{key}` | `nsw:storage:delete` | Trader, CHA |

Public routes (health, payments webhook/validate, local-dev storage content) are explicitly unchanged — no auth or scope gate.

## What does NOT change
The `?role=` query-param logic in `consignment/router.go` is untouched — it is business-level data filtering (trader vs CHA company scoping), not an authz gate. Service-layer `authzr.Principal()` checks for finer-grained decisions are a follow-up.

## Testing

- [x] I have tested this change locally
- [x] All existing tests pass

`go build ./...`, `go vet ./...`, `go test ./...` all clean. `golangci-lint` — 0 issues.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have checked that there are no merge conflicts

## Related Issues

Depends on #588 (authz package), #589 (IdP scopes), #590 (auth scope surfacing)

🤖 Generated with [Claude Code](https://claude.com/claude-code)