### PR TITLE
fix: date-time renderer RFC 3339 + JSONForms dev playground

### DIFF
--- a/portals/packages/jsonforms-renderers/dev/ajv.ts
+++ b/portals/packages/jsonforms-renderers/dev/ajv.ts
@@ -1,0 +1,7 @@
+import { createAjv } from '@jsonforms/core'
+
+// Shared Ajv instance for every JsonForms usage. createAjv applies JsonForms'
+// own defaults (format validators etc.); useDefaults: true additionally lets
+// Ajv populate schema `default` values into the data during validation, so
+// defaulted fields are present without the user touching them.
+export const ajv = createAjv({ useDefaults: true })

--- a/portals/packages/jsonforms-renderers/dev/fixtures.ts
+++ b/portals/packages/jsonforms-renderers/dev/fixtures.ts
@@ -1,0 +1,247 @@
+import type { JsonSchema, UISchemaElement } from '@jsonforms/core'
+
+export type Fixture = {
+  id: string
+  name: string
+  schema: JsonSchema
+  uischema: UISchemaElement
+  data?: Record<string, unknown>
+}
+
+// One fixture per renderer/component. Selecting a fixture loads its schema +
+// uischema into the editors; both are live-editable from there.
+export const fixtures: Fixture[] = [
+  {
+    id: 'text',
+    name: 'Text',
+    schema: {
+      type: 'object',
+      properties: {
+        name: { type: 'string', description: 'A plain text field' },
+        bio: { type: 'string', description: 'Multi-line via options.multi' },
+      },
+      required: ['name'],
+    },
+    uischema: {
+      type: 'VerticalLayout',
+      elements: [
+        { type: 'Control', scope: '#/properties/name' },
+        { type: 'Control', scope: '#/properties/bio', options: { multi: true } },
+      ],
+    } as UISchemaElement,
+  },
+  {
+    id: 'number',
+    name: 'Number',
+    schema: {
+      type: 'object',
+      properties: {
+        price: { type: 'number', description: 'Decimal value' },
+        quantity: { type: 'integer', minimum: 0, description: 'Whole number ≥ 0' },
+      },
+    },
+    uischema: {
+      type: 'VerticalLayout',
+      elements: [
+        { type: 'Control', scope: '#/properties/price' },
+        { type: 'Control', scope: '#/properties/quantity' },
+      ],
+    } as UISchemaElement,
+  },
+  {
+    id: 'boolean',
+    name: 'Boolean',
+    schema: {
+      type: 'object',
+      properties: {
+        agree: { type: 'boolean', description: 'Terms & conditions' },
+      },
+      required: ['agree'],
+    },
+    uischema: {
+      type: 'VerticalLayout',
+      elements: [{ type: 'Control', scope: '#/properties/agree' }],
+    } as UISchemaElement,
+  },
+  {
+    id: 'radio',
+    name: 'Radio',
+    schema: {
+      type: 'object',
+      properties: {
+        size: { type: 'string', enum: ['Small', 'Medium', 'Large'], description: 'Pick one' },
+      },
+    },
+    uischema: {
+      type: 'VerticalLayout',
+      elements: [{ type: 'Control', scope: '#/properties/size', options: { format: 'radio' } }],
+    } as UISchemaElement,
+  },
+  {
+    id: 'select',
+    name: 'Select',
+    schema: {
+      type: 'object',
+      properties: {
+        country: { type: 'string', enum: ['Sri Lanka', 'India', 'Maldives'], description: 'Dropdown' },
+      },
+    },
+    uischema: {
+      type: 'VerticalLayout',
+      elements: [{ type: 'Control', scope: '#/properties/country' }],
+    } as UISchemaElement,
+  },
+  {
+    id: 'date',
+    name: 'Date / Time',
+    schema: {
+      type: 'object',
+      properties: {
+        eventDate: { type: 'string', format: 'date', description: 'Date only (yyyy-MM-dd)' },
+        appointment: { type: 'string', format: 'date-time', description: 'Date + time (RFC 3339)' },
+        openingTime: { type: 'string', format: 'time', description: 'Time only (native picker)' },
+      },
+      required: ['eventDate'],
+    },
+    uischema: {
+      type: 'VerticalLayout',
+      elements: [
+        { type: 'Control', scope: '#/properties/eventDate' },
+        { type: 'Control', scope: '#/properties/appointment' },
+        { type: 'Control', scope: '#/properties/openingTime' },
+      ],
+    } as UISchemaElement,
+  },
+  {
+    id: 'file',
+    name: 'File',
+    schema: {
+      type: 'object',
+      properties: {
+        avatar: { type: 'string', format: 'file', description: 'Single file' },
+        attachments: {
+          type: 'array',
+          items: { type: 'string', format: 'file' },
+          description: 'Multiple files',
+        },
+      },
+    },
+    uischema: {
+      type: 'VerticalLayout',
+      elements: [
+        { type: 'Control', scope: '#/properties/avatar' },
+        { type: 'Control', scope: '#/properties/attachments' },
+      ],
+    } as UISchemaElement,
+  },
+  {
+    id: 'array',
+    name: 'Array (objects)',
+    schema: {
+      type: 'object',
+      properties: {
+        items: {
+          type: 'array',
+          description: 'List of line items',
+          items: {
+            type: 'object',
+            properties: {
+              description: { type: 'string' },
+              qty: { type: 'integer', minimum: 1 },
+            },
+            required: ['description'],
+          },
+        },
+      },
+    },
+    uischema: {
+      type: 'VerticalLayout',
+      elements: [{ type: 'Control', scope: '#/properties/items' }],
+    } as UISchemaElement,
+    data: { items: [{ description: 'First item', qty: 1 }] },
+  },
+  {
+    id: 'horizontal',
+    name: 'Horizontal layout',
+    schema: {
+      type: 'object',
+      properties: {
+        firstName: { type: 'string' },
+        lastName: { type: 'string' },
+      },
+    },
+    uischema: {
+      type: 'HorizontalLayout',
+      elements: [
+        { type: 'Control', scope: '#/properties/firstName' },
+        { type: 'Control', scope: '#/properties/lastName' },
+      ],
+    } as UISchemaElement,
+  },
+  {
+    id: 'group',
+    name: 'Group layout',
+    schema: {
+      type: 'object',
+      properties: {
+        street: { type: 'string' },
+        city: { type: 'string' },
+      },
+    },
+    uischema: {
+      type: 'Group',
+      label: 'Address',
+      elements: [
+        { type: 'Control', scope: '#/properties/street' },
+        { type: 'Control', scope: '#/properties/city' },
+      ],
+    } as UISchemaElement,
+  },
+  {
+    id: 'categorization',
+    name: 'Categorization',
+    schema: {
+      type: 'object',
+      properties: {
+        name: { type: 'string' },
+        email: { type: 'string' },
+        notes: { type: 'string' },
+      },
+    },
+    uischema: {
+      type: 'Categorization',
+      elements: [
+        {
+          type: 'Category',
+          label: 'Personal',
+          elements: [
+            { type: 'Control', scope: '#/properties/name' },
+            { type: 'Control', scope: '#/properties/email' },
+          ],
+        },
+        {
+          type: 'Category',
+          label: 'More',
+          elements: [{ type: 'Control', scope: '#/properties/notes', options: { multi: true } }],
+        },
+      ],
+    } as UISchemaElement,
+  },
+  {
+    id: 'label',
+    name: 'Label',
+    schema: {
+      type: 'object',
+      properties: {
+        name: { type: 'string' },
+      },
+    },
+    uischema: {
+      type: 'VerticalLayout',
+      elements: [
+        { type: 'Label', text: 'Section heading via Label renderer' },
+        { type: 'Control', scope: '#/properties/name' },
+      ],
+    } as UISchemaElement,
+  },
+]

--- a/portals/packages/jsonforms-renderers/dev/index.html
+++ b/portals/packages/jsonforms-renderers/dev/index.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>JSONForms renderers — playground</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/main.tsx"></script>
+  </body>
+</html>

--- a/portals/packages/jsonforms-renderers/dev/main.tsx
+++ b/portals/packages/jsonforms-renderers/dev/main.tsx
@@ -1,0 +1,184 @@
+import { StrictMode, useMemo, useState } from 'react'
+import { createRoot } from 'react-dom/client'
+import { Theme, Flex, Box, Heading, Card, Text, Separator, TextArea, Badge } from '@radix-ui/themes'
+import '@radix-ui/themes/styles.css'
+import { JsonForms } from '@jsonforms/react'
+import type { JsonSchema, UISchemaElement } from '@jsonforms/core'
+import { radixRenderers } from '../src'
+import { ajv } from './ajv'
+import { fixtures, type Fixture } from './fixtures'
+
+// Parse JSON text, returning the parsed value or an error message — never throws.
+const parse = (text: string): { value?: unknown; error?: string } => {
+  try {
+    return { value: JSON.parse(text) }
+  } catch (e) {
+    return { error: e instanceof Error ? e.message : String(e) }
+  }
+}
+
+type EditorProps = {
+  label: string
+  text: string
+  error?: string
+  onChange: (next: string) => void
+}
+
+const JsonEditor = ({ label, text, error, onChange }: EditorProps) => (
+  <Box>
+    <Flex justify="between" align="center" mb="1">
+      <Text size="2" weight="bold">
+        {label}
+      </Text>
+      {error ? <Badge color="red">invalid JSON</Badge> : <Badge color="green">ok</Badge>}
+    </Flex>
+    <TextArea
+      value={text}
+      onChange={(e) => onChange(e.target.value)}
+      resize="vertical"
+      style={{ fontFamily: 'monospace', fontSize: 12, minHeight: 220 }}
+      color={error ? 'red' : undefined}
+    />
+    {error && (
+      <Text size="1" color="red">
+        {error}
+      </Text>
+    )}
+  </Box>
+)
+
+function Playground() {
+  const [selectedId, setSelectedId] = useState<string>(fixtures[0].id)
+
+  // Editable JSON text for schema + uischema. Data is live read-only output.
+  const [schemaText, setSchemaText] = useState(() => JSON.stringify(fixtures[0].schema, null, 2))
+  const [uiText, setUiText] = useState(() => JSON.stringify(fixtures[0].uischema, null, 2))
+  const [data, setData] = useState<Record<string, unknown>>(() => fixtures[0].data ?? {})
+
+  // Last successfully parsed schema/uischema drive the form; a bad edit keeps
+  // the previous good render and just surfaces the parse error.
+  const [schema, setSchema] = useState<JsonSchema>(() => fixtures[0].schema)
+  const [uischema, setUischema] = useState<UISchemaElement>(() => fixtures[0].uischema)
+  const [schemaError, setSchemaError] = useState<string>()
+  const [uiError, setUiError] = useState<string>()
+
+  const loadFixture = (f: Fixture) => {
+    setSelectedId(f.id)
+    setSchemaText(JSON.stringify(f.schema, null, 2))
+    setUiText(JSON.stringify(f.uischema, null, 2))
+    setSchema(f.schema)
+    setUischema(f.uischema)
+    setData(f.data ?? {})
+    setSchemaError(undefined)
+    setUiError(undefined)
+  }
+
+  const onSchemaText = (next: string) => {
+    setSchemaText(next)
+    const { value, error } = parse(next)
+    if (error) setSchemaError(error)
+    else {
+      setSchema(value as JsonSchema)
+      setSchemaError(undefined)
+    }
+  }
+
+  const onUiText = (next: string) => {
+    setUiText(next)
+    const { value, error } = parse(next)
+    if (error) setUiError(error)
+    else {
+      setUischema(value as UISchemaElement)
+      setUiError(undefined)
+    }
+  }
+
+  // Remount JsonForms when the structural schema/uischema change so it doesn't
+  // hold onto stale internal state between edits.
+  const formKey = useMemo(() => `${selectedId}:${schemaText.length}:${uiText.length}`, [selectedId, schemaText, uiText])
+
+  return (
+    <Flex align="start" style={{ minHeight: '100vh' }}>
+      {/* Sidebar: one entry per component fixture */}
+      <Box
+        p="3"
+        style={{ width: 200, flexShrink: 0, borderRight: '1px solid var(--gray-5)', position: 'sticky', top: 0 }}
+      >
+        <Heading size="3" mb="2">
+          Components
+        </Heading>
+        <Flex direction="column" gap="1">
+          {fixtures.map((f) => {
+            const active = f.id === selectedId
+            return (
+              <Text
+                key={f.id}
+                as="div"
+                size="2"
+                onClick={() => loadFixture(f)}
+                style={{
+                  cursor: 'pointer',
+                  padding: '6px 8px',
+                  borderRadius: 6,
+                  background: active ? 'var(--accent-4)' : 'transparent',
+                  fontWeight: active ? 600 : 400,
+                }}
+              >
+                {f.name}
+              </Text>
+            )
+          })}
+        </Flex>
+      </Box>
+
+      {/* Main area */}
+      <Box p="5" style={{ flex: 1 }}>
+        <Heading mb="1">JSONForms renderers — playground</Heading>
+        <Text size="2" color="gray">
+          Pick a component on the left, then edit its Schema or UI Schema below — the form updates in real time.
+        </Text>
+        <Separator my="4" size="4" />
+
+        <Flex gap="4" align="start" wrap="wrap">
+          {/* Rendered form + live data */}
+          <Flex direction="column" gap="4" style={{ flex: '1 1 360px' }}>
+            <Card>
+              <Text size="2" weight="bold" mb="2" as="div">
+                Rendered form
+              </Text>
+              <JsonForms
+                key={formKey}
+                schema={schema}
+                uischema={uischema}
+                data={data}
+                renderers={radixRenderers}
+                ajv={ajv}
+                onChange={({ data }) => setData(data as Record<string, unknown>)}
+              />
+            </Card>
+            <Card>
+              <Text size="2" weight="bold" as="div">
+                Live data
+              </Text>
+              <pre style={{ margin: 0, fontSize: 13, whiteSpace: 'pre-wrap' }}>{JSON.stringify(data, null, 2)}</pre>
+            </Card>
+          </Flex>
+
+          {/* Editors */}
+          <Flex direction="column" gap="4" style={{ flex: '1 1 360px' }}>
+            <JsonEditor label="Schema" text={schemaText} error={schemaError} onChange={onSchemaText} />
+            <JsonEditor label="UI Schema" text={uiText} error={uiError} onChange={onUiText} />
+          </Flex>
+        </Flex>
+      </Box>
+    </Flex>
+  )
+}
+
+createRoot(document.getElementById('root')!).render(
+  <StrictMode>
+    <Theme>
+      <Playground />
+    </Theme>
+  </StrictMode>,
+)

--- a/portals/packages/jsonforms-renderers/dev/main.tsx
+++ b/portals/packages/jsonforms-renderers/dev/main.tsx
@@ -93,9 +93,8 @@ function Playground() {
     }
   }
 
-  // Remount JsonForms when the structural schema/uischema change so it doesn't
-  // hold onto stale internal state between edits.
-  const formKey = useMemo(() => `${selectedId}:${schemaText.length}:${uiText.length}`, [selectedId, schemaText, uiText])
+  // Remount JsonForms when switching fixtures so it doesn't hold onto stale internal state.
+  const formKey = selectedId
 
   return (
     <Flex align="start" style={{ minHeight: '100vh' }}>

--- a/portals/packages/jsonforms-renderers/package.json
+++ b/portals/packages/jsonforms-renderers/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opennsw/jsonforms-renderers",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "type": "module",
   "main": "dist/renderers.cjs.js",
   "module": "dist/renderers.es.js",
@@ -17,20 +17,22 @@
     "README.md"
   ],
   "scripts": {
+    "dev": "vite",
     "build": "tsc -b && vite build",
     "lint": "eslint .",
     "type-check": "tsc -b --noEmit"
   },
   "peerDependencies": {
-    "react": "^19.2.0",
-    "react-dom": "^19.2.0",
     "@jsonforms/core": "^3.2.1",
     "@jsonforms/react": "^3.2.1",
+    "@radix-ui/react-icons": "^1.3.2",
     "@radix-ui/themes": "^3.2.1",
-    "@radix-ui/react-icons": "^1.3.2"
+    "react": "^19.2.0",
+    "react-dom": "^19.2.0"
   },
   "devDependencies": {
     "@eslint/js": "^9.39.1",
+    "@tailwindcss/vite": "^4.0.9",
     "@types/node": "^22.10.2",
     "@types/react": "^19.2.5",
     "@types/react-dom": "^19.2.3",
@@ -39,11 +41,14 @@
     "eslint-plugin-react-hooks": "^7.0.1",
     "eslint-plugin-react-refresh": "^0.4.24",
     "globals": "^16.5.0",
+    "tailwindcss": "^4.0.9",
     "typescript": "~5.7.2",
     "typescript-eslint": "^8.46.4",
     "vite": "^6.2.0",
-    "vite-plugin-dts": "^4.5.0",
-    "tailwindcss": "^4.0.9",
-    "@tailwindcss/vite": "^4.0.9"
+    "vite-plugin-dts": "^4.5.0"
+  },
+  "dependencies": {
+    "dayjs": "^1.11.21",
+    "react-day-picker": "^10.0.1"
   }
 }

--- a/portals/packages/jsonforms-renderers/src/renderers/DateControl.tsx
+++ b/portals/packages/jsonforms-renderers/src/renderers/DateControl.tsx
@@ -1,32 +1,56 @@
-import { type ControlProps, isDateControl, type RankedTester, rankWith } from '@jsonforms/core'
+import {
+  type ControlProps,
+  isDateControl,
+  isDateTimeControl,
+  isTimeControl,
+  or,
+  type RankedTester,
+  rankWith,
+} from '@jsonforms/core'
 import { withJsonFormsControlProps } from '@jsonforms/react'
-import { TextField, Text, Flex, Box } from '@radix-ui/themes'
+import { TextField, Text, Flex, Box, Popover, Button } from '@radix-ui/themes'
+import { CalendarIcon } from '@radix-ui/react-icons'
+import { useState, type ReactNode } from 'react'
+import { DayPicker } from 'react-day-picker'
+import 'react-day-picker/style.css'
+import dayjs from 'dayjs'
 
-export const DateControl = ({ data, handleChange, path, label, required, errors, schema, enabled }: ControlProps) => {
+const toISODate = (d: Date) => dayjs(d).format('YYYY-MM-DD')
+
+// Parse with an explicit midnight so the string is read as local time — a bare
+// 'YYYY-MM-DD' is parsed as UTC and can shift the picked day by one.
+const fromISODate = (s?: string) => {
+  if (!s) return undefined
+  const d = dayjs(`${s}T00:00:00`)
+  return d.isValid() ? d.toDate() : undefined
+}
+
+// dayjs().format() defaults to RFC 3339 (e.g. 2026-06-05T12:30:00+05:30) with
+// seconds + local offset, which ajv's strict "date-time" format check requires.
+const toISODateTime = (dateStr: string, timeStr: string) => dayjs(`${dateStr}T${timeStr}`).format()
+
+type ShellProps = Pick<ControlProps, 'path' | 'label' | 'required' | 'errors'> & {
+  description?: string
+  children: ReactNode
+}
+
+const FieldShell = ({ path, label, required, errors, description, children }: ShellProps) => {
   const isValid = errors.length === 0
-
   return (
     <Box mb="4">
       <Flex direction="column" gap="1">
         <Text as="label" size="2" weight="bold" htmlFor={path}>
           {label} {required && <Text color="red">*</Text>}
         </Text>
-        <TextField.Root
-          type="date"
-          value={data || ''}
-          onChange={(e) => handleChange(path, e.target.value)}
-          disabled={!enabled}
-          color={!isValid ? 'red' : undefined}
-          id={path}
-        />
+        {children}
         {!isValid && errors !== 'is a required property' && (
           <Text color="red" size="1">
             {errors}
           </Text>
         )}
-        {schema.description && (
+        {description && (
           <Text size="1" color="gray">
-            {schema.description}
+            {description}
           </Text>
         )}
       </Flex>
@@ -34,6 +58,82 @@ export const DateControl = ({ data, handleChange, path, label, required, errors,
   )
 }
 
-export const DateControlTester: RankedTester = rankWith(2, isDateControl)
+export const DateControl = ({ data, handleChange, path, label, required, errors, schema, enabled }: ControlProps) => {
+  const isValid = errors.length === 0
+  const [open, setOpen] = useState(false)
+  const value: string = typeof data === 'string' ? data : ''
+
+  const shell = (children: ReactNode) => (
+    <FieldShell path={path} label={label} required={required} errors={errors} description={schema.description}>
+      {children}
+    </FieldShell>
+  )
+
+  // Time-only: native picker is plenty.
+  if (schema.format === 'time') {
+    return shell(
+      <TextField.Root
+        type="time"
+        value={value}
+        onChange={(e) => handleChange(path, e.target.value)}
+        disabled={!enabled}
+        color={!isValid ? 'red' : undefined}
+        id={path}
+      />,
+    )
+  }
+
+  // date and date-time share the calendar; date-time appends a native time input.
+  const hasTime = schema.format === 'date-time'
+  const [datePart = '', timeRaw = ''] = value.split('T')
+  const selected = fromISODate(datePart)
+  // The native <input type="time"> only understands HH:MM(:SS); strip any
+  // timezone suffix from the stored RFC 3339 value before feeding it back.
+  const timeForInput = timeRaw.slice(0, 5)
+
+  const commit = (nextDate: string, nextTime: string) => {
+    if (!nextDate) {
+      handleChange(path, undefined)
+      return
+    }
+    handleChange(path, hasTime ? toISODateTime(nextDate, nextTime || '00:00') : nextDate)
+  }
+
+  return shell(
+    <Flex gap="2" align="center">
+      <Popover.Root open={open} onOpenChange={setOpen}>
+        <Popover.Trigger>
+          <Button id={path} type="button" variant="surface" color={!isValid ? 'red' : 'gray'} disabled={!enabled}>
+            <CalendarIcon />
+            {selected ? selected.toLocaleDateString() : 'Select date'}
+          </Button>
+        </Popover.Trigger>
+        <Popover.Content>
+          <DayPicker
+            mode="single"
+            captionLayout="dropdown"
+            selected={selected}
+            defaultMonth={selected}
+            onSelect={(d) => {
+              commit(d ? toISODate(d) : '', timeForInput)
+              if (d) setOpen(false)
+            }}
+          />
+        </Popover.Content>
+      </Popover.Root>
+      {hasTime && (
+        <TextField.Root
+          type="time"
+          value={timeForInput}
+          disabled={!enabled || !datePart}
+          color={!isValid ? 'red' : undefined}
+          onChange={(e) => commit(datePart, e.target.value)}
+        />
+      )}
+    </Flex>,
+  )
+}
+
+export const DateControlTester: RankedTester = rankWith(2, or(isDateControl, isDateTimeControl, isTimeControl))
 
 export default withJsonFormsControlProps(DateControl)

--- a/portals/packages/jsonforms-renderers/src/renderers/DateControl.tsx
+++ b/portals/packages/jsonforms-renderers/src/renderers/DateControl.tsx
@@ -112,6 +112,8 @@ export const DateControl = ({ data, handleChange, path, label, required, errors,
           <DayPicker
             mode="single"
             captionLayout="dropdown"
+            startMonth={new Date(1900, 0)}
+            endMonth={new Date(new Date().getFullYear() + 100, 11)}
             selected={selected}
             defaultMonth={selected}
             onSelect={(d) => {

--- a/portals/packages/jsonforms-renderers/vite.config.ts
+++ b/portals/packages/jsonforms-renderers/vite.config.ts
@@ -5,15 +5,23 @@ import * as path from 'node:path'
 import tailwindcss from '@tailwindcss/vite'
 
 // https://vite.dev/config/
-export default defineConfig({
+// `vite build` builds the library; `vite` (serve) runs the dev playground in dev/.
+export default defineConfig(({ command }) => ({
+  // In serve mode, treat dev/ as the app root so dev/index.html is the entry.
+  ...(command === 'serve' ? { root: 'dev' } : {}),
   plugins: [
     react(),
     tailwindcss(),
-    dts({
-      include: ['src'],
-      tsconfigPath: './tsconfig.app.json',
-      rollupTypes: true,
-    }),
+    // Type declarations are only needed for the library build.
+    ...(command === 'build'
+      ? [
+          dts({
+            include: ['src'],
+            tsconfigPath: './tsconfig.app.json',
+            rollupTypes: true,
+          }),
+        ]
+      : []),
   ],
   build: {
     lib: {
@@ -35,4 +43,4 @@ export default defineConfig({
       ],
     },
   },
-})
+}))

--- a/portals/pnpm-lock.yaml
+++ b/portals/pnpm-lock.yaml
@@ -138,7 +138,7 @@ importers:
         version: 9.39.2
       '@tailwindcss/vite':
         specifier: ^4.1.18
-        version: 4.1.18(vite@7.3.1(@types/node@24.10.9)(jiti@2.6.1)(lightningcss@1.30.2))
+        version: 4.1.18(vite@7.3.1(@types/node@24.10.9)(jiti@2.6.1)(lightningcss@1.30.2)(yaml@2.8.3))
       '@types/node':
         specifier: ^24.10.1
         version: 24.10.9
@@ -150,7 +150,7 @@ importers:
         version: 19.2.3(@types/react@19.2.9)
       '@vitejs/plugin-react-swc':
         specifier: ^4.2.2
-        version: 4.2.2(vite@7.3.1(@types/node@24.10.9)(jiti@2.6.1)(lightningcss@1.30.2))
+        version: 4.2.2(vite@7.3.1(@types/node@24.10.9)(jiti@2.6.1)(lightningcss@1.30.2)(yaml@2.8.3))
       eslint:
         specifier: ^9.39.1
         version: 9.39.2(jiti@2.6.1)
@@ -174,7 +174,7 @@ importers:
         version: 8.53.1(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3)
       vite:
         specifier: ^7.2.4
-        version: 7.3.1(@types/node@24.10.9)(jiti@2.6.1)(lightningcss@1.30.2)
+        version: 7.3.1(@types/node@24.10.9)(jiti@2.6.1)(lightningcss@1.30.2)(yaml@2.8.3)
 
   packages/jsonforms-renderers:
     dependencies:
@@ -190,9 +190,15 @@ importers:
       '@radix-ui/themes':
         specifier: ^3.2.1
         version: 3.2.1(@types/react-dom@19.2.3(@types/react@19.2.9))(@types/react@19.2.9)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      dayjs:
+        specifier: ^1.11.21
+        version: 1.11.21
       react:
         specifier: ^19.2.0
         version: 19.2.3
+      react-day-picker:
+        specifier: ^10.0.1
+        version: 10.0.1(@types/react@19.2.9)(react@19.2.3)
       react-dom:
         specifier: ^19.2.0
         version: 19.2.3(react@19.2.3)
@@ -407,6 +413,9 @@ packages:
   '@babel/types@7.28.6':
     resolution: {integrity: sha512-0ZrskXVEHSWIqZM/sQZ4EV3jZJXRkio/WCxaqKZP1g//CEWEPSfeZFcms4XeKBCHU0ZKnIkdJeU/kF+eRp5lBg==}
     engines: {node: '>=6.9.0'}
+
+  '@date-fns/tz@1.5.0':
+    resolution: {integrity: sha512-lwYN/vDPeNRULcepoE/LO2Pgx+7/RV+S9ARfbc9lr2DtGkOD7pAiruHvbR1RX3Qyf6ja47EWJDMsNK5vK08DJg==}
 
   '@emotion/babel-plugin@11.13.5':
     resolution: {integrity: sha512-pxHCpT2ex+0q+HH91/zsdHkw/lXd468DIN2zvfvLtPKLLMo6gQj7oLObq8PhkrxOZb/gGCq03S3Z7PDhS8pduQ==}
@@ -2516,6 +2525,12 @@ packages:
   csstype@3.2.3:
     resolution: {integrity: sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==}
 
+  date-fns@4.4.0:
+    resolution: {integrity: sha512-+1UMbeh68lH1SegH83CGWwpb6OHHbpSgr3+s5Eww5M4CAgswBpoWS0AjTOfEJ33HiYKz1hdj/KTFprzXHmq/6w==}
+
+  dayjs@1.11.21:
+    resolution: {integrity: sha512-98IT+HOahAisibz/yjKbzuOBwYcjJ7BCLPzARyHiyEBmRz4fatF+KPJszEHXsGYjUG234aH/cOjW1wwTbKUZlA==}
+
   de-indent@1.0.2:
     resolution: {integrity: sha512-e/1zu3xH5MQryN2zdVaF0OrdNLUbvWxzMbi+iNA6Bky7l1RoP8a2fIbRocyHclXt/arDrrR6lL3TqFD9pMQTsg==}
 
@@ -3361,6 +3376,16 @@ packages:
   randomfill@1.0.4:
     resolution: {integrity: sha512-87lcbR8+MhcWcUiQ+9e+Rwx8MyR2P7qnt15ynUlbm3TU/fjbgz4GsvfSUDTemtCCtVCqb4ZcEFlyPNTh9bBTLw==}
 
+  react-day-picker@10.0.1:
+    resolution: {integrity: sha512-eNh6BlwcYInWaJtRv18mXQ06Ys/H6rdTZAnTaSdOYJuTpwP1JMCHNd1FDRadA+gbeinq+psdULN5Xnowy9mV8w==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@types/react': '>=16.8.0'
+      react: '>=16.8.0'
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
   react-dom@19.1.4:
     resolution: {integrity: sha512-s2868ab/xo2SI6H4106A7aFI8Mrqa4xC6HZT/pBzYyQ3cBLqa88hu47xYD8xf+uECleN698Awn7RCWlkTiKnqQ==}
     peerDependencies:
@@ -4007,6 +4032,8 @@ snapshots:
     dependencies:
       '@babel/helper-string-parser': 7.27.1
       '@babel/helper-validator-identifier': 7.28.5
+
+  '@date-fns/tz@1.5.0': {}
 
   '@emotion/babel-plugin@11.13.5':
     dependencies:
@@ -5478,13 +5505,6 @@ snapshots:
       tailwindcss: 4.1.18
       vite: 7.3.1(@types/node@24.10.9)(jiti@2.6.1)(lightningcss@1.30.2)(yaml@2.8.3)
 
-  '@tailwindcss/vite@4.1.18(vite@7.3.1(@types/node@24.10.9)(jiti@2.6.1)(lightningcss@1.30.2))':
-    dependencies:
-      '@tailwindcss/node': 4.1.18
-      '@tailwindcss/oxide': 4.1.18
-      tailwindcss: 4.1.18
-      vite: 7.3.1(@types/node@24.10.9)(jiti@2.6.1)(lightningcss@1.30.2)
-
   '@types/argparse@1.0.38': {}
 
   '@types/babel__core@7.20.5':
@@ -5733,14 +5753,6 @@ snapshots:
       '@rolldown/pluginutils': 1.0.0-beta.47
       '@swc/core': 1.15.10
       vite: 7.3.1(@types/node@24.10.9)(jiti@2.6.1)(lightningcss@1.30.2)(yaml@2.8.3)
-    transitivePeerDependencies:
-      - '@swc/helpers'
-
-  '@vitejs/plugin-react-swc@4.2.2(vite@7.3.1(@types/node@24.10.9)(jiti@2.6.1)(lightningcss@1.30.2))':
-    dependencies:
-      '@rolldown/pluginutils': 1.0.0-beta.47
-      '@swc/core': 1.15.10
-      vite: 7.3.1(@types/node@24.10.9)(jiti@2.6.1)(lightningcss@1.30.2)
     transitivePeerDependencies:
       - '@swc/helpers'
 
@@ -6090,6 +6102,10 @@ snapshots:
       randomfill: 1.0.4
 
   csstype@3.2.3: {}
+
+  date-fns@4.4.0: {}
+
+  dayjs@1.11.21: {}
 
   de-indent@1.0.2: {}
 
@@ -7175,6 +7191,14 @@ snapshots:
       randombytes: 2.1.0
       safe-buffer: 5.2.1
 
+  react-day-picker@10.0.1(@types/react@19.2.9)(react@19.2.3):
+    dependencies:
+      '@date-fns/tz': 1.5.0
+      date-fns: 4.4.0
+      react: 19.2.3
+    optionalDependencies:
+      '@types/react': 19.2.9
+
   react-dom@19.1.4(react@19.2.3):
     dependencies:
       react: 19.2.3
@@ -7604,20 +7628,6 @@ snapshots:
       jiti: 2.6.1
       lightningcss: 1.30.2
       yaml: 2.8.3
-
-  vite@7.3.1(@types/node@24.10.9)(jiti@2.6.1)(lightningcss@1.30.2):
-    dependencies:
-      esbuild: 0.27.2
-      fdir: 6.5.0(picomatch@4.0.3)
-      picomatch: 4.0.3
-      postcss: 8.5.6
-      rollup: 4.56.0
-      tinyglobby: 0.2.15
-    optionalDependencies:
-      '@types/node': 24.10.9
-      fsevents: 2.3.3
-      jiti: 2.6.1
-      lightningcss: 1.30.2
 
   vite@7.3.1(@types/node@24.10.9)(jiti@2.6.1)(lightningcss@1.30.2)(yaml@2.8.3):
     dependencies:


### PR DESCRIPTION
## Summary

Fixes the date-time control in `@opennsw/jsonforms-renderers`, which emitted values that failed ajv's strict `date-time` format check (so the validation error appeared after picking a date and never cleared), and adds an isolated dev playground for previewing and tweaking the renderers without running a full app.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [x] Refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Other (please describe):

## Changes Made

- **DateControl date-time fix:** emit RFC 3339 with seconds + local offset (e.g. `2026-06-05T14:00:00+05:30`) so values pass ajv's `date-time` format check; normalize the stored value back to `HH:mm` for the native time input.
- **dayjs adoption:** replace the hand-rolled date padding / timezone-offset string building with `dayjs` (`format('YYYY-MM-DD')`, `dayjs(...).format()` for RFC 3339). Added as a runtime `dependency` (bundled into the lib build).
- **Dev playground (`pnpm dev`)** under `dev/`: sidebar with one fixture per renderer, live-editable Schema + UI Schema textareas, real-time render, and a live data panel. Invalid JSON is guarded so the last good render is kept.
- **Build config:** `vite.config.ts` branches on command — `serve` roots at `dev/` (playground), `build` keeps the library build + `dts`. Added a `dev` script.
- **Playground-scoped Ajv:** `dev/ajv.ts` uses `createAjv({ useDefaults: true })`. Intentionally not exported — consumers initialize their own Ajv.

## Testing

- [x] I have tested this change locally
- [ ] I have added unit tests for new functionality
- [x] I have tested edge cases
- [ ] All existing tests pass
- `pnpm type-check` passes for the package (and the dev files type-check cleanly).
- Verified in the playground: picking a date-only value is now valid (no lingering error), and editing the time keeps it valid and round-trips correctly. The package has no unit-test suite yet, so those boxes are left unchecked.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have checked that there are no merge conflicts

## Related Issues

Closes #592

## Screenshots/Demo

(Playground: select a component on the left, edit its Schema / UI Schema, form updates live.)

## Additional Notes

- The `dev/` playground is **not shipped** — `"files": ["dist", "README.md"]` excludes it, so nothing here changes the published surface except `DateControl` behavior and the bundled `dayjs`.
- No version bump included. In-repo consumers use `workspace:*` so they pick this up automatically; if/when the package is published for the extracted trader-app repo, this warrants a patch bump (`0.2.0` → `0.2.1`).

## Deployment Notes

None.