### PR TITLE
add support for running dynamic child workflows

### DIFF
--- a/backend/internal/app/bootstrap/app.go
+++ b/backend/internal/app/bootstrap/app.go
@@ -143,7 +143,7 @@ func Build(ctx context.Context, cfg *config.Config) (*App, error) {
 
 	paymentService.SetTaskCompleter(tm)
 
-	consignmentService := consignment.NewService(db, templateService, chaService, companyService, userProfileService, hsCodeService)
+	consignmentService := consignment.NewService(db, templateService, chaService, companyService, userProfileService, hsCodeService, taskV2.Store)
 	consignmentRouter := consignment.NewRouter(consignmentService, chaService, companyService)
 
 	pr, stopParentRunner, err := workflow.WireParentRunner(temporalClient, tm, consignmentService)

--- a/backend/internal/consignment/model.go
+++ b/backend/internal/consignment/model.go
@@ -109,7 +109,6 @@ type DetailDTO struct {
 	CreatedAt       string                          `json:"createdAt"`       // Timestamp of consignment creation
 	UpdatedAt       string                          `json:"updatedAt"`       // Timestamp of last consignment update
 	WorkflowNodes   []model.WorkflowNodeResponseDTO `json:"workflowNodes"`   // Associated workflow nodes with template details
-	Edges           []model.WorkflowEdgeResponseDTO `json:"edges"`           // Edges between workflow nodes
 }
 
 // SummaryDTO represents the consignment data returned in list responses.

--- a/backend/internal/consignment/router_test.go
+++ b/backend/internal/consignment/router_test.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/DATA-DOG/go-sqlmock"
 	workflowManagerV2 "github.com/OpenNSW/go-temporal-workflow"
+	tfstore "github.com/OpenNSW/nsw-task-flow/store"
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
@@ -21,6 +22,7 @@ import (
 	"github.com/OpenNSW/nsw/backend/internal/profile/cha"
 	"github.com/OpenNSW/nsw/backend/internal/profile/company"
 	"github.com/OpenNSW/nsw/backend/internal/profile/user"
+	"github.com/OpenNSW/nsw/backend/internal/workflow/model"
 )
 
 func withAuthContext(ctx context.Context, userID string) context.Context {
@@ -47,7 +49,8 @@ func withAuthContextOU(ctx context.Context, userID, ouHandle string) context.Con
 func TestConsignmentRouter_HandleGetConsignmentByID(t *testing.T) {
 	db, sqlMock := setupTestDB(t)
 	mockWM := new(MockWMV2)
-	svc := NewService(db, nil, nil, nil, nil, nil)
+	mockTaskStore := new(MockTaskStore)
+	svc := NewService(db, nil, nil, nil, nil, nil, mockTaskStore)
 	require.NoError(t, svc.RegisterWorkflowManager(mockWM))
 	r := NewRouter(svc, nil, nil)
 
@@ -59,6 +62,8 @@ func TestConsignmentRouter_HandleGetConsignmentByID(t *testing.T) {
 
 	sqlMock.ExpectQuery("(?i)SELECT .* FROM \"hs_codes\"").WillReturnRows(sqlmock.NewRows([]string{"id"}))
 
+	mockTaskStore.On("GetAllTasks", mock.Anything, consignmentID).Return(([]tfstore.TaskRecord)(nil))
+
 	req, _ := http.NewRequest("GET", "/api/v1/consignments/"+consignmentID, nil)
 	req.SetPathValue("id", consignmentID)
 	req = req.WithContext(withAuthContext(req.Context(), "trader1"))
@@ -66,12 +71,13 @@ func TestConsignmentRouter_HandleGetConsignmentByID(t *testing.T) {
 	w := httptest.NewRecorder()
 	r.HandleGetConsignmentByID(w, req)
 	assert.Equal(t, http.StatusOK, w.Code)
+	mockTaskStore.AssertExpectations(t)
 }
 
 func TestConsignmentRouter_HandleGetConsignments(t *testing.T) {
 	db, sqlMock := setupTestDB(t)
 	mockCompany := new(MockCompanyService)
-	svc := NewService(db, nil, nil, mockCompany, nil, nil)
+	svc := NewService(db, nil, nil, mockCompany, nil, nil, nil)
 	r := NewRouter(svc, nil, mockCompany)
 
 	traderID := "trader1"
@@ -95,7 +101,7 @@ func TestConsignmentRouter_HandleGetConsignments(t *testing.T) {
 func TestConsignmentRouter_HandleGetConsignments_RoleCHA(t *testing.T) {
 	db, sqlMock := setupTestDB(t)
 	mockCompany := new(MockCompanyService)
-	svc := NewService(db, nil, nil, mockCompany, nil, nil)
+	svc := NewService(db, nil, nil, mockCompany, nil, nil, nil)
 	r := NewRouter(svc, nil, mockCompany)
 
 	companyID := "company-cha"
@@ -115,7 +121,8 @@ func TestConsignmentRouter_HandleCreateConsignment(t *testing.T) {
 	db, sqlMock := setupTestDB(t)
 	mockCompany := new(MockCompanyService)
 	mockUser := new(MockUserService)
-	svc := NewService(db, nil, nil, mockCompany, mockUser, nil)
+	mockTaskStore := new(MockTaskStore)
+	svc := NewService(db, nil, nil, mockCompany, mockUser, nil, mockTaskStore)
 	r := NewRouter(svc, nil, mockCompany)
 
 	traderID := "trader1"
@@ -144,6 +151,8 @@ func TestConsignmentRouter_HandleCreateConsignment(t *testing.T) {
 			AddRow(consignmentID, string(FlowImport), traderID, traderCompanyID, chaCompanyID, string(Initialized), []byte("[]")),
 	)
 
+	mockTaskStore.On("GetAllTasks", mock.Anything, consignmentID).Return(([]tfstore.TaskRecord)(nil))
+
 	req, _ := http.NewRequest("POST", "/api/v1/consignments", bytes.NewBuffer(body))
 	req = req.WithContext(withAuthContextOU(req.Context(), traderID, "trader-ou"))
 	w := httptest.NewRecorder()
@@ -151,6 +160,7 @@ func TestConsignmentRouter_HandleCreateConsignment(t *testing.T) {
 	assert.Equal(t, http.StatusCreated, w.Code)
 	mockCompany.AssertExpectations(t)
 	mockUser.AssertExpectations(t)
+	mockTaskStore.AssertExpectations(t)
 }
 
 func TestConsignmentRouter_HandleInitializeConsignment(t *testing.T) {
@@ -158,7 +168,9 @@ func TestConsignmentRouter_HandleInitializeConsignment(t *testing.T) {
 	mockWM := new(MockWMV2)
 	mockCHA := new(MockCHAService)
 	mockCompany := new(MockCompanyService)
-	svc := NewService(db, nil, mockCHA, mockCompany, nil, nil)
+	mockTaskStore := new(MockTaskStore)
+	mockTP := new(MockTemplateProvider)
+	svc := NewService(db, mockTP, mockCHA, mockCompany, nil, nil, mockTaskStore)
 	require.NoError(t, svc.RegisterWorkflowManager(mockWM))
 	r := NewRouter(svc, mockCHA, mockCompany)
 
@@ -184,9 +196,11 @@ func TestConsignmentRouter_HandleInitializeConsignment(t *testing.T) {
 	sqlMock.ExpectQuery("(?i)SELECT .* FROM \"workflow_template_map\"").
 		WillReturnRows(sqlmock.NewRows([]string{"id", "hs_code_id", "consignment_flow", "workflow_template_id"}).
 			AddRow(uuid.NewString(), hsID, "IMPORT", wtID))
-	sqlMock.ExpectQuery("(?i)SELECT .* FROM \"workflow_template_v2\"").
-		WillReturnRows(sqlmock.NewRows([]string{"id", "name", "version", "workflow_definition"}).
-			AddRow(wtID, "tmpl", "v1", []byte(`{"id":"template1"}`)))
+
+	mockTP.On("GetWorkflowTemplateByIDV2", mock.Anything, wtID).Return(&model.WorkflowTemplateV2{
+		WorkflowDefinition: workflowManagerV2.WorkflowDefinition{ID: "template1"},
+	}, nil)
+
 	mockWM.On("StartWorkflow", mock.Anything, id, workflowManagerV2.WorkflowDefinition{ID: "template1"}, mock.Anything).Return(nil)
 	sqlMock.ExpectCommit()
 
@@ -194,19 +208,26 @@ func TestConsignmentRouter_HandleInitializeConsignment(t *testing.T) {
 	mockWM.On("GetStatus", mock.Anything, id).Return(&workflowManagerV2.WorkflowInstance{ID: id}, nil)
 	sqlMock.ExpectQuery("(?i)SELECT .* FROM \"hs_codes\"").WillReturnRows(sqlmock.NewRows([]string{"id"}))
 
+	mockTaskStore.On("GetAllTasks", mock.Anything, id).Return(([]tfstore.TaskRecord)(nil))
+
 	req, _ := http.NewRequest("PUT", "/api/v1/consignments/"+id, bytes.NewBuffer(body))
 	req.SetPathValue("id", id)
 	req = req.WithContext(withAuthContext(req.Context(), "cha1"))
 
 	w := httptest.NewRecorder()
 	r.HandleInitializeConsignment(w, req)
+	if w.Code != http.StatusOK {
+		t.Errorf("w.Code = %d, body = %s", w.Code, w.Body.String())
+	}
 	assert.Equal(t, http.StatusOK, w.Code)
 	mockCHA.AssertExpectations(t)
 	mockCompany.AssertExpectations(t)
+	mockTP.AssertExpectations(t)
+	mockTaskStore.AssertExpectations(t)
 }
 
 func TestConsignmentRouter_HandleInitializeConsignment_NoID(t *testing.T) {
-	svc := NewService(nil, nil, nil, nil, nil, nil)
+	svc := NewService(nil, nil, nil, nil, nil, nil, nil)
 	r := NewRouter(svc, nil, nil)
 
 	req, _ := http.NewRequest("PUT", "/api/v1/consignments/", bytes.NewReader([]byte{}))
@@ -218,7 +239,7 @@ func TestConsignmentRouter_HandleInitializeConsignment_NoID(t *testing.T) {
 }
 
 func TestConsignmentRouter_HandleInitializeConsignment_InvalidBody(t *testing.T) {
-	svc := NewService(nil, nil, nil, nil, nil, nil)
+	svc := NewService(nil, nil, nil, nil, nil, nil, nil)
 	r := NewRouter(svc, nil, nil)
 
 	req, _ := http.NewRequest("PUT", "/api/v1/consignments/id", bytes.NewBufferString("invalid json"))
@@ -232,7 +253,7 @@ func TestConsignmentRouter_HandleInitializeConsignment_InvalidBody(t *testing.T)
 
 func TestConsignmentRouter_HandleGetConsignmentByID_InvalidID(t *testing.T) {
 	db, _ := setupTestDB(t)
-	svc := NewService(db, nil, nil, nil, nil, nil)
+	svc := NewService(db, nil, nil, nil, nil, nil, nil)
 	r := NewRouter(svc, nil, nil)
 
 	req, _ := http.NewRequest("GET", "/api/v1/consignments/invalid-uuid", nil)
@@ -245,7 +266,7 @@ func TestConsignmentRouter_HandleGetConsignmentByID_InvalidID(t *testing.T) {
 
 func TestConsignmentRouter_HandleGetConsignments_PaginationError(t *testing.T) {
 	db, _ := setupTestDB(t)
-	svc := NewService(db, nil, nil, nil, nil, nil)
+	svc := NewService(db, nil, nil, nil, nil, nil, nil)
 	r := NewRouter(svc, nil, nil)
 
 	req, _ := http.NewRequest("GET", "/api/v1/consignments?limit=invalid", nil)
@@ -259,7 +280,7 @@ func TestConsignmentRouter_HandleGetConsignments_PaginationError(t *testing.T) {
 
 func TestConsignmentRouter_HandleGetConsignmentByID_ServiceError(t *testing.T) {
 	db, sqlMock := setupTestDB(t)
-	svc := NewService(db, nil, nil, nil, nil, nil)
+	svc := NewService(db, nil, nil, nil, nil, nil, nil)
 	r := NewRouter(svc, nil, nil)
 
 	id := uuid.NewString()
@@ -277,7 +298,7 @@ func TestConsignmentRouter_HandleGetConsignmentByID_ServiceError(t *testing.T) {
 func TestConsignmentRouter_HandleGetConsignments_ServiceError(t *testing.T) {
 	db, sqlMock := setupTestDB(t)
 	mockCompany := new(MockCompanyService)
-	svc := NewService(db, nil, nil, mockCompany, nil, nil)
+	svc := NewService(db, nil, nil, mockCompany, nil, nil, nil)
 	r := NewRouter(svc, nil, mockCompany)
 
 	mockCompany.On("GetCompanyByOUHandle", mock.Anything, "trader-ou").Return(&company.Record{ID: "trader-company", OUHandle: "trader-ou"}, nil)
@@ -292,7 +313,7 @@ func TestConsignmentRouter_HandleGetConsignments_ServiceError(t *testing.T) {
 
 func TestConsignmentRouter_HandleCreateConsignment_CompanyNotFound(t *testing.T) {
 	mockCompany := new(MockCompanyService)
-	svc := NewService(nil, nil, nil, mockCompany, nil, nil)
+	svc := NewService(nil, nil, nil, mockCompany, nil, nil, nil)
 	r := NewRouter(svc, nil, mockCompany)
 
 	mockCompany.On("GetCompanyByID", mock.Anything, "company-missing").Return(nil, company.ErrCompanyNotFound)
@@ -310,7 +331,7 @@ func TestConsignmentRouter_HandleCreateConsignment_CompanyNotFound(t *testing.T)
 
 func TestConsignmentRouter_HandleCreateConsignment_InvalidPayload(t *testing.T) {
 	db, _ := setupTestDB(t)
-	svc := NewService(db, nil, nil, nil, nil, nil)
+	svc := NewService(db, nil, nil, nil, nil, nil, nil)
 	r := NewRouter(svc, nil, nil)
 
 	req, _ := http.NewRequest("POST", "/api/v1/consignments", bytes.NewBufferString("invalid json"))
@@ -321,7 +342,7 @@ func TestConsignmentRouter_HandleCreateConsignment_InvalidPayload(t *testing.T) 
 }
 
 func TestConsignmentRouter_HandleGetConsignments_InvalidRole(t *testing.T) {
-	svc := NewService(nil, nil, nil, nil, nil, nil)
+	svc := NewService(nil, nil, nil, nil, nil, nil, nil)
 	r := NewRouter(svc, nil, nil)
 
 	req, _ := http.NewRequest("GET", "/api/v1/consignments?role=invalid", nil)
@@ -334,7 +355,7 @@ func TestConsignmentRouter_HandleGetConsignments_InvalidRole(t *testing.T) {
 
 func TestConsignmentRouter_HandleGetConsignments_CompanyNotFound(t *testing.T) {
 	mockCompany := new(MockCompanyService)
-	svc := NewService(nil, nil, nil, mockCompany, nil, nil)
+	svc := NewService(nil, nil, nil, mockCompany, nil, nil, nil)
 	r := NewRouter(svc, nil, mockCompany)
 
 	mockCompany.On("GetCompanyByOUHandle", mock.Anything, "cha-ou").Return(nil, company.ErrCompanyNotFound)
@@ -401,7 +422,7 @@ func TestConsignmentRouter_HandleInitializeConsignment_EmptyHSCodes(t *testing.T
 
 func TestConsignmentRouter_HandleGetConsignments_CompanyLookupError(t *testing.T) {
 	mockCompany := new(MockCompanyService)
-	svc := NewService(nil, nil, nil, mockCompany, nil, nil)
+	svc := NewService(nil, nil, nil, mockCompany, nil, nil, nil)
 	r := NewRouter(svc, nil, mockCompany)
 	mockCompany.On("GetCompanyByOUHandle", mock.Anything, "cha-ou").Return(nil, fmt.Errorf("db down"))
 

--- a/backend/internal/consignment/service.go
+++ b/backend/internal/consignment/service.go
@@ -131,7 +131,7 @@ func (s *Service) CreateConsignmentShell(ctx context.Context, flow Flow, chaComp
 	if err := s.db.WithContext(ctx).First(consignment, "id = ?", consignment.ID).Error; err != nil {
 		return nil, fmt.Errorf("failed to reload consignment: %w", err)
 	}
-	responseDTO, err := s.buildConsignmentDetailDTO(ctx, consignment, nil, make(map[string]hscode.HSCode))
+	responseDTO, err := s.buildConsignmentDetailDTO(ctx, consignment, make(map[string]hscode.HSCode))
 	if err != nil {
 		return nil, err
 	}
@@ -241,10 +241,7 @@ func (s *Service) InitializeConsignmentByID(
 		return nil, fmt.Errorf("failed to reload consignment: %w", err)
 	}
 
-	var workflowInstance *workflowmanager.WorkflowInstance
-
-	workflowInstance, err = s.wm.GetStatus(ctx, consignment.ID)
-	if err != nil {
+	if _, err := s.wm.GetStatus(ctx, consignment.ID); err != nil {
 		return nil, fmt.Errorf("failed to get workflow details: %w", err)
 	}
 
@@ -253,7 +250,7 @@ func (s *Service) InitializeConsignmentByID(
 		return nil, err
 	}
 
-	responseDTO, err := s.buildConsignmentDetailDTO(ctx, &consignment, workflowInstance, hsCodeMap)
+	responseDTO, err := s.buildConsignmentDetailDTO(ctx, &consignment, hsCodeMap)
 	if err != nil {
 		return nil, err
 	}
@@ -269,12 +266,10 @@ func (s *Service) GetConsignmentByID(ctx context.Context, consignmentID string) 
 		return nil, fmt.Errorf("failed to retrieve consignment with ID %s: %w", consignmentID, result.Error)
 	}
 
-	// Load workflow details (nodes + templates) if workflow exists
-	var workflowInstance *workflowmanager.WorkflowInstance
-	var err error
+	// Confirm the workflow is reachable if one exists; node details now come
+	// from task records rather than this status snapshot.
 	if consignment.State != Initialized {
-		workflowInstance, err = s.wm.GetStatus(ctx, consignment.ID)
-		if err != nil {
+		if _, err := s.wm.GetStatus(ctx, consignment.ID); err != nil {
 			return nil, fmt.Errorf("failed to get workflow details: %w", err)
 		}
 	}
@@ -284,7 +279,7 @@ func (s *Service) GetConsignmentByID(ctx context.Context, consignmentID string) 
 		return nil, err
 	}
 
-	responseDTO, err := s.buildConsignmentDetailDTO(ctx, &consignment, workflowInstance, hsCodeMap)
+	responseDTO, err := s.buildConsignmentDetailDTO(ctx, &consignment, hsCodeMap)
 	if err != nil {
 		return nil, fmt.Errorf("failed to build consignment response DTO: %w", err)
 	}
@@ -497,11 +492,9 @@ func (s *Service) getHSCodeMap(ctx context.Context, items []Item) (map[string]hs
 }
 
 // buildConsignmentDetailDTO builds a DetailDTO from a Consignment.
-// The workflow parameter provides the workflow nodes (nil for INITIALIZED consignments).
 func (s *Service) buildConsignmentDetailDTO(
 	ctx context.Context,
 	consignment *Consignment,
-	workflowV2 *workflowmanager.WorkflowInstance,
 	hsCodeMap map[string]hscode.HSCode,
 ) (*DetailDTO, error) {
 	itemResponseDTOs, err := s.buildConsignmentItemResponseDTOs(consignment.Items, hsCodeMap)
@@ -512,18 +505,6 @@ func (s *Service) buildConsignmentDetailDTO(
 	nodeResponseDTOs, err := s.buildNodeDTOsFromTaskRecords(ctx, consignment.ID)
 	if err != nil {
 		return nil, err
-	}
-
-	edgeResponseDTOs := make([]model.WorkflowEdgeResponseDTO, 0)
-	if workflowV2 != nil {
-		for _, edge := range workflowV2.Edges {
-			edgeResponseDTOs = append(edgeResponseDTOs, model.WorkflowEdgeResponseDTO{
-				ID:        edge.ID,
-				SourceID:  edge.SourceID,
-				TargetID:  edge.TargetID,
-				Condition: edge.Condition,
-			})
-		}
 	}
 
 	chaID := ""
@@ -543,7 +524,6 @@ func (s *Service) buildConsignmentDetailDTO(
 		CreatedAt:       consignment.CreatedAt.Format(time.RFC3339),
 		UpdatedAt:       consignment.UpdatedAt.Format(time.RFC3339),
 		WorkflowNodes:   nodeResponseDTOs,
-		Edges:           edgeResponseDTOs,
 	}, nil
 }
 

--- a/backend/internal/consignment/service.go
+++ b/backend/internal/consignment/service.go
@@ -11,6 +11,7 @@ import (
 	"gorm.io/gorm"
 
 	workflowmanager "github.com/OpenNSW/go-temporal-workflow"
+	tfstore "github.com/OpenNSW/nsw-task-flow/store"
 
 	"github.com/OpenNSW/nsw/backend/internal/hscode"
 	"github.com/OpenNSW/nsw/backend/internal/profile/cha"
@@ -20,6 +21,11 @@ import (
 	"github.com/OpenNSW/nsw/backend/internal/workflow/service"
 	"github.com/OpenNSW/nsw/backend/pkg/pagination"
 )
+
+// TaskStore is the narrow interface needed from taskv2 package to load task records.
+type TaskStore interface {
+	GetAllTasks(ctx context.Context, parentWorkflowID string) []tfstore.TaskRecord
+}
 
 // Service handles consignment-related operations.
 // It coordinates between workflow templates, nodes, and the workflow manager.
@@ -34,6 +40,7 @@ type Service struct {
 	companyService   company.Service
 	userService      user.Service
 	hsCodeService    *hscode.Service
+	taskStore        TaskStore
 }
 
 // NewService creates a new instance of Service.
@@ -44,6 +51,7 @@ func NewService(
 	companyService company.Service,
 	userService user.Service,
 	hsCodeService *hscode.Service,
+	taskStore TaskStore,
 ) *Service {
 	return &Service{
 		db:               db,
@@ -52,6 +60,7 @@ func NewService(
 		companyService:   companyService,
 		userService:      userService,
 		hsCodeService:    hsCodeService,
+		taskStore:        taskStore,
 	}
 }
 
@@ -538,29 +547,16 @@ func (s *Service) buildConsignmentDetailDTO(
 	}, nil
 }
 
-// buildNodeDTOsFromTaskRecords queries task_records_v2 by root_workflow_id and converts each
+// buildNodeDTOsFromTaskRecords queries tasks via the TaskStore by root_workflow_id and converts each
 // non-SYSTEM record into a WorkflowNodeResponseDTO for the consignment detail response.
-// This replaces the NodeInfo-based approach: every task record—including those from child
+// This replaces the direct database access: every task record—including those from child
 // workflows spawned by SPLIT_TASK—shares the same root_workflow_id (the consignment ID),
 // so a single exact-match query captures the complete task picture.
 func (s *Service) buildNodeDTOsFromTaskRecords(ctx context.Context, consignmentID string) ([]model.WorkflowNodeResponseDTO, error) {
-	var tasks []struct {
-		TaskID               string          `gorm:"column:task_id"`
-		TaskType             string          `gorm:"column:task_type"`
-		State                string          `gorm:"column:state"`
-		ActiveTaskTemplateID string          `gorm:"column:active_task_template_id"`
-		RenderConfig         json.RawMessage `gorm:"column:render_config"`
-		CreatedAt            time.Time       `gorm:"column:created_at"`
-		UpdatedAt            time.Time       `gorm:"column:updated_at"`
+	if s.taskStore == nil {
+		return nil, fmt.Errorf("task store not initialized")
 	}
-	if err := s.db.WithContext(ctx).
-		Table("task_records_v2").
-		Select("task_id, task_type, state, active_task_template_id, render_config, created_at, updated_at").
-		Where("root_workflow_id = ?", consignmentID).
-		Order("created_at ASC").
-		Find(&tasks).Error; err != nil {
-		return nil, fmt.Errorf("failed to load task records for consignment %s: %w", consignmentID, err)
-	}
+	tasks := s.taskStore.GetAllTasks(ctx, consignmentID)
 
 	dtos := make([]model.WorkflowNodeResponseDTO, 0, len(tasks))
 	for _, t := range tasks {

--- a/backend/internal/consignment/service.go
+++ b/backend/internal/consignment/service.go
@@ -5,7 +5,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"sort"
 	"time"
 
 	"github.com/google/uuid"
@@ -501,79 +500,13 @@ func (s *Service) buildConsignmentDetailDTO(
 		return nil, err
 	}
 
-	nodeResponseDTOs := make([]model.WorkflowNodeResponseDTO, 0)
+	nodeResponseDTOs, err := s.buildNodeDTOsFromTaskRecords(ctx, consignment.ID)
+	if err != nil {
+		return nil, err
+	}
+
 	edgeResponseDTOs := make([]model.WorkflowEdgeResponseDTO, 0)
-
 	if workflowV2 != nil {
-		// Iterate NodeInfo in a deterministic order. Go map iteration is
-		// randomized, which surfaces as flaky WorkflowNodes ordering in API
-		// responses and tests (e.g. TestConsignmentService_InitializeConsignmentByID_Success).
-		// Sorting by node ID is a stable shape; topological order based on
-		// Edges would be more user-meaningful and is a follow-up.
-		nodeIDs := make([]string, 0, len(workflowV2.NodeInfo))
-		for id := range workflowV2.NodeInfo {
-			nodeIDs = append(nodeIDs, id)
-		}
-		sort.Strings(nodeIDs)
-
-		taskTemplateIDs := make([]string, 0, len(workflowV2.NodeInfo))
-		for _, id := range nodeIDs {
-			node := workflowV2.NodeInfo[id]
-			if node.Type == workflowmanager.NodeTypeTask {
-				taskTemplateIDs = append(taskTemplateIDs, node.TaskTemplateID)
-			}
-		}
-		taskTemplates, err := s.templateProvider.GetWorkflowNodeTemplatesByIDs(ctx, taskTemplateIDs)
-		if err != nil {
-			return nil, fmt.Errorf("failed to retrieve workflow node templates for consignment %s: %w", consignment.ID, err)
-		}
-		taskTemplateMap := make(map[string]model.WorkflowNodeTemplate)
-		for _, taskTemplate := range taskTemplates {
-			taskTemplateMap[taskTemplate.ID] = taskTemplate
-		}
-		for _, id := range nodeIDs {
-			node := workflowV2.NodeInfo[id]
-			var taskName, taskDescription, taskType string
-			var nodeState model.WorkflowNodeState
-			if node.Type == workflowmanager.NodeTypeTask {
-				if taskTemplate, ok := taskTemplateMap[node.TaskTemplateID]; ok {
-					taskName = taskTemplate.Name
-					taskDescription = taskTemplate.Description
-					taskType = string(taskTemplate.Type)
-				} else {
-					// Subflow IDs (e.g. FCAU's fcau-pay-app-fee-flow) live in the
-					// file-backed taskv2 registry, not workflow_node_templates.
-					// Fall back to the template ID until a unified template
-					// provider exists.
-					taskName = node.TaskTemplateID
-					taskType = string(workflowmanager.NodeTypeTask)
-				}
-			} else {
-				taskType = string(node.Type)
-			}
-			// TODO: clean up translations once the frontend is updated.
-			switch node.Status {
-			case workflowmanager.NodeStatusRunning:
-				nodeState = model.WorkflowNodeStateInProgress
-			case workflowmanager.NodeStatusCompleted:
-				nodeState = model.WorkflowNodeStateCompleted
-			case workflowmanager.NodeStatusFailed:
-				nodeState = model.WorkflowNodeStateFailed
-			case workflowmanager.NodeStatusNotStarted:
-				nodeState = model.WorkflowNodeStateLocked
-			}
-			nodeResponseDTOs = append(nodeResponseDTOs, model.WorkflowNodeResponseDTO{
-				ID:        node.ID,
-				CreatedAt: node.CreatedAt.Format(time.RFC3339),
-				UpdatedAt: node.UpdatedAt.Format(time.RFC3339),
-				WorkflowNodeTemplate: model.WorkflowNodeTemplateResponseDTO{
-					Name:        taskName,
-					Description: taskDescription,
-					Type:        taskType,
-				},
-				State: nodeState,
-			})
-		}
 		for _, edge := range workflowV2.Edges {
 			edgeResponseDTOs = append(edgeResponseDTOs, model.WorkflowEdgeResponseDTO{
 				ID:        edge.ID,
@@ -603,6 +536,76 @@ func (s *Service) buildConsignmentDetailDTO(
 		WorkflowNodes:   nodeResponseDTOs,
 		Edges:           edgeResponseDTOs,
 	}, nil
+}
+
+// buildNodeDTOsFromTaskRecords queries task_records_v2 by root_workflow_id and converts each
+// non-SYSTEM record into a WorkflowNodeResponseDTO for the consignment detail response.
+// This replaces the NodeInfo-based approach: every task record—including those from child
+// workflows spawned by SPLIT_TASK—shares the same root_workflow_id (the consignment ID),
+// so a single exact-match query captures the complete task picture.
+func (s *Service) buildNodeDTOsFromTaskRecords(ctx context.Context, consignmentID string) ([]model.WorkflowNodeResponseDTO, error) {
+	var tasks []struct {
+		TaskID               string          `gorm:"column:task_id"`
+		TaskType             string          `gorm:"column:task_type"`
+		State                string          `gorm:"column:state"`
+		ActiveTaskTemplateID string          `gorm:"column:active_task_template_id"`
+		RenderConfig         json.RawMessage `gorm:"column:render_config"`
+		CreatedAt            time.Time       `gorm:"column:created_at"`
+		UpdatedAt            time.Time       `gorm:"column:updated_at"`
+	}
+	if err := s.db.WithContext(ctx).
+		Table("task_records_v2").
+		Select("task_id, task_type, state, active_task_template_id, render_config, created_at, updated_at").
+		Where("root_workflow_id = ?", consignmentID).
+		Order("created_at ASC").
+		Find(&tasks).Error; err != nil {
+		return nil, fmt.Errorf("failed to load task records for consignment %s: %w", consignmentID, err)
+	}
+
+	dtos := make([]model.WorkflowNodeResponseDTO, 0, len(tasks))
+	for _, t := range tasks {
+		if t.TaskType == "SYSTEM" {
+			continue
+		}
+		var nodeState model.WorkflowNodeState
+		switch t.State {
+		case "COMPLETED":
+			nodeState = model.WorkflowNodeStateCompleted
+		case "FAILED":
+			nodeState = model.WorkflowNodeStateFailed
+		default:
+			nodeState = model.WorkflowNodeStateInProgress
+		}
+		dtos = append(dtos, model.WorkflowNodeResponseDTO{
+			ID:        t.TaskID,
+			CreatedAt: t.CreatedAt.Format(time.RFC3339),
+			UpdatedAt: t.UpdatedAt.Format(time.RFC3339),
+			WorkflowNodeTemplate: model.WorkflowNodeTemplateResponseDTO{
+				Name: taskDisplayName(t.ActiveTaskTemplateID, t.RenderConfig),
+				Type: t.TaskType,
+			},
+			State: nodeState,
+		})
+	}
+	return dtos, nil
+}
+
+// taskDisplayName extracts the human-readable title from a task's render config workspace
+// section, falling back to the active template ID when no title is present.
+func taskDisplayName(templateID string, renderConfig json.RawMessage) string {
+	if len(renderConfig) > 0 {
+		var rc struct {
+			Sections map[string]struct {
+				Title string `json:"title"`
+			} `json:"sections"`
+		}
+		if err := json.Unmarshal(renderConfig, &rc); err == nil {
+			if ws, ok := rc.Sections["workspace"]; ok && ws.Title != "" {
+				return ws.Title
+			}
+		}
+	}
+	return templateID
 }
 
 // companyRecordToMap converts a company.Record to a map[string]any via its JSON tags. The

--- a/backend/internal/consignment/service_test.go
+++ b/backend/internal/consignment/service_test.go
@@ -14,57 +14,13 @@ import (
 	"gorm.io/gorm"
 
 	workflowManagerV2 "github.com/OpenNSW/go-temporal-workflow"
+	tfstore "github.com/OpenNSW/nsw-task-flow/store"
 	"github.com/OpenNSW/nsw/backend/internal/hscode"
 	"github.com/OpenNSW/nsw/backend/internal/profile/cha"
 	"github.com/OpenNSW/nsw/backend/internal/profile/company"
 	"github.com/OpenNSW/nsw/backend/internal/profile/user"
 	"github.com/OpenNSW/nsw/backend/internal/workflow/model"
 )
-
-// MockTemplateProvider implements service.TemplateProvider for testing.
-type MockTemplateProvider struct {
-	mock.Mock
-}
-
-func (m *MockTemplateProvider) GetWorkflowTemplateByID(ctx context.Context, id string) (*model.WorkflowTemplate, error) {
-	args := m.Called(ctx, id)
-	if args.Get(0) == nil {
-		return nil, args.Error(1)
-	}
-	return args.Get(0).(*model.WorkflowTemplate), args.Error(1)
-}
-
-func (m *MockTemplateProvider) GetWorkflowTemplateByIDV2(ctx context.Context, id string) (*model.WorkflowTemplateV2, error) {
-	args := m.Called(ctx, id)
-	if args.Get(0) == nil {
-		return nil, args.Error(1)
-	}
-	return args.Get(0).(*model.WorkflowTemplateV2), args.Error(1)
-}
-
-func (m *MockTemplateProvider) GetWorkflowNodeTemplatesByIDs(ctx context.Context, ids []string) ([]model.WorkflowNodeTemplate, error) {
-	args := m.Called(ctx, ids)
-	if args.Get(0) == nil {
-		return nil, args.Error(1)
-	}
-	return args.Get(0).([]model.WorkflowNodeTemplate), args.Error(1)
-}
-
-func (m *MockTemplateProvider) GetWorkflowNodeTemplateByID(ctx context.Context, id string) (*model.WorkflowNodeTemplate, error) {
-	args := m.Called(ctx, id)
-	if args.Get(0) == nil {
-		return nil, args.Error(1)
-	}
-	return args.Get(0).(*model.WorkflowNodeTemplate), args.Error(1)
-}
-
-func (m *MockTemplateProvider) GetEndNodeTemplate(ctx context.Context) (*model.WorkflowNodeTemplate, error) {
-	args := m.Called(ctx)
-	if args.Get(0) == nil {
-		return nil, args.Error(1)
-	}
-	return args.Get(0).(*model.WorkflowNodeTemplate), args.Error(1)
-}
 
 // MockCHAService implements cha.Service for testing.
 type MockCHAService struct {
@@ -164,7 +120,7 @@ func (m *MockUserService) Health() error {
 
 func TestConsignmentService_RegisterWorkflowManager(t *testing.T) {
 	db, _ := setupTestDB(t)
-	svc := NewService(db, nil, nil, nil, nil, nil)
+	svc := NewService(db, nil, nil, nil, nil, nil, nil)
 	mockWM := new(MockWMV2)
 
 	// Test registration
@@ -177,7 +133,7 @@ func TestConsignmentService_RegisterWorkflowManager(t *testing.T) {
 	assert.Contains(t, err.Error(), "already registered")
 
 	// Test nil manager
-	svc2 := NewService(db, nil, nil, nil, nil, nil)
+	svc2 := NewService(db, nil, nil, nil, nil, nil, nil)
 	err = svc2.RegisterWorkflowManager(nil)
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "cannot be nil")
@@ -185,7 +141,7 @@ func TestConsignmentService_RegisterWorkflowManager(t *testing.T) {
 
 func TestConsignmentService_CompletionHandler(t *testing.T) {
 	db, sqlMock := setupTestDB(t)
-	svc := NewService(db, nil, nil, nil, nil, nil)
+	svc := NewService(db, nil, nil, nil, nil, nil, nil)
 	consignmentID := uuid.NewString()
 
 	sqlMock.ExpectQuery(`SELECT \* FROM "consignments" WHERE id = \$1`).
@@ -204,7 +160,7 @@ func TestConsignmentService_CompletionHandler(t *testing.T) {
 // --- InitializeConsignmentByID ---
 
 func TestConsignmentService_InitializeConsignmentByID_NoHSCode(t *testing.T) {
-	svc := NewService(nil, nil, nil, nil, nil, nil)
+	svc := NewService(nil, nil, nil, nil, nil, nil, nil)
 	_, err := svc.InitializeConsignmentByID(context.Background(), "id", []string{}, "")
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "at least one HS code ID is required")
@@ -212,7 +168,7 @@ func TestConsignmentService_InitializeConsignmentByID_NoHSCode(t *testing.T) {
 
 func TestConsignmentService_InitializeConsignmentByID_NotFound(t *testing.T) {
 	db, sqlMock := setupTestDB(t)
-	svc := NewService(db, nil, nil, nil, nil, nil)
+	svc := NewService(db, nil, nil, nil, nil, nil, nil)
 	id := uuid.NewString()
 	sqlMock.ExpectQuery(`SELECT \* FROM "consignments" WHERE id = \$1`).
 		WithArgs(id, 1).
@@ -225,7 +181,7 @@ func TestConsignmentService_InitializeConsignmentByID_NotFound(t *testing.T) {
 
 func TestConsignmentService_InitializeConsignmentByID_WrongState(t *testing.T) {
 	db, sqlMock := setupTestDB(t)
-	svc := NewService(db, nil, nil, nil, nil, nil)
+	svc := NewService(db, nil, nil, nil, nil, nil, nil)
 	id := uuid.NewString()
 	sqlMock.ExpectQuery(`SELECT \* FROM "consignments" WHERE id = \$1`).
 		WithArgs(id, 1).
@@ -238,7 +194,7 @@ func TestConsignmentService_InitializeConsignmentByID_WrongState(t *testing.T) {
 
 func TestConsignmentService_InitializeConsignmentByID_MultipleHSCodeError(t *testing.T) {
 	db, sqlMock := setupTestDB(t)
-	svc := NewService(db, nil, nil, nil, nil, nil)
+	svc := NewService(db, nil, nil, nil, nil, nil, nil)
 	id := uuid.NewString()
 	sqlMock.ExpectQuery(`SELECT \* FROM "consignments" WHERE id = \$1`).
 		WithArgs(id, 1).
@@ -256,7 +212,7 @@ func TestConsignmentService_InitializeConsignmentByID_NoTemplate(t *testing.T) {
 	db, sqlMock := setupTestDB(t)
 	mockCHA := new(MockCHAService)
 	mockCompany := new(MockCompanyService)
-	svc := NewService(db, nil, mockCHA, mockCompany, nil, nil)
+	svc := NewService(db, nil, mockCHA, mockCompany, nil, nil, nil)
 	id := uuid.NewString()
 	hsID := "hs1"
 	chaID := "cha1"
@@ -290,7 +246,8 @@ func TestConsignmentService_InitializeConsignmentByID_Success(t *testing.T) {
 	mockHS := hscode.NewService(db)
 	mockCHA := new(MockCHAService)
 	mockCompany := new(MockCompanyService)
-	svc := NewService(db, mockTP, mockCHA, mockCompany, nil, mockHS)
+	mockTaskStore := new(MockTaskStore)
+	svc := NewService(db, mockTP, mockCHA, mockCompany, nil, mockHS, mockTaskStore)
 	require.NoError(t, svc.RegisterWorkflowManager(mockWM))
 
 	id := uuid.NewString()
@@ -343,14 +300,15 @@ func TestConsignmentService_InitializeConsignmentByID_Success(t *testing.T) {
 		},
 	}, nil)
 
-	mockTP.On("GetWorkflowNodeTemplatesByIDs", mock.Anything, []string{"tt1"}).Return([]model.WorkflowNodeTemplate{
-		{BaseModel: model.BaseModel{ID: "tt1"}, Name: "Task 1", Description: "Desc 1", Type: "FORM"},
-	}, nil)
-
 	sqlMock.ExpectQuery(`SELECT \* FROM "hs_codes" WHERE id IN`).
 		WithArgs(hsID).
 		WillReturnRows(sqlmock.NewRows([]string{"id", "hs_code", "description", "category"}).
 			AddRow(hsID, "1234.56", "Test", "Cat"))
+
+	mockTaskStore.On("GetAllTasks", mock.Anything, id).Return([]tfstore.TaskRecord{
+		{TaskID: "node1", TaskType: "FORM", State: "COMPLETED", ActiveTaskTemplateID: "Task 1", CreatedAt: time.Now(), UpdatedAt: time.Now()},
+		{TaskID: "node2", TaskType: "FORM", State: "IN_PROGRESS", ActiveTaskTemplateID: "Task 2", CreatedAt: time.Now(), UpdatedAt: time.Now()},
+	})
 
 	result, err := svc.InitializeConsignmentByID(context.Background(), id, []string{hsID}, chaID)
 	assert.NoError(t, err)
@@ -361,11 +319,12 @@ func TestConsignmentService_InitializeConsignmentByID_Success(t *testing.T) {
 	assert.Equal(t, model.WorkflowNodeStateCompleted, result.WorkflowNodes[0].State)
 	mockCHA.AssertExpectations(t)
 	mockCompany.AssertExpectations(t)
+	mockTaskStore.AssertExpectations(t)
 }
 
 func TestConsignmentService_OnWorkflowStatusChanged(t *testing.T) {
 	db, sqlMock := setupTestDB(t)
-	svc := NewService(db, nil, nil, nil, nil, nil)
+	svc := NewService(db, nil, nil, nil, nil, nil, nil)
 	id := uuid.NewString()
 
 	// Completed
@@ -389,7 +348,8 @@ func TestConsignmentService_CreateConsignmentShell_Success(t *testing.T) {
 	db, sqlMock := setupTestDB(t)
 	mockCompany := new(MockCompanyService)
 	mockUser := new(MockUserService)
-	svc := NewService(db, nil, nil, mockCompany, mockUser, hscode.NewService(db))
+	mockTaskStore := new(MockTaskStore)
+	svc := NewService(db, nil, nil, mockCompany, mockUser, hscode.NewService(db), mockTaskStore)
 	ctx := context.Background()
 	chaCompanyID := uuid.NewString()
 	traderCompanyID := uuid.NewString()
@@ -410,19 +370,22 @@ func TestConsignmentService_CreateConsignmentShell_Success(t *testing.T) {
 		WillReturnRows(sqlmock.NewRows([]string{"id", "flow", "trader_id", "trader_company_id", "cha_company_id", "state", "items"}).
 			AddRow(consignmentID, "IMPORT", traderID, traderCompanyID, chaCompanyID, "INITIALIZED", []byte("[]")))
 
+	mockTaskStore.On("GetAllTasks", mock.Anything, consignmentID).Return(([]tfstore.TaskRecord)(nil))
+
 	result, err := svc.CreateConsignmentShell(ctx, FlowImport, chaCompanyID, traderID)
 	assert.NoError(t, err)
 	assert.NotNil(t, result)
 	assert.Equal(t, consignmentID, result.ID)
 	mockCompany.AssertExpectations(t)
 	mockUser.AssertExpectations(t)
+	mockTaskStore.AssertExpectations(t)
 	assert.NoError(t, sqlMock.ExpectationsWereMet())
 }
 
 func TestConsignmentService_CreateConsignmentShell_CompanyNotCHA(t *testing.T) {
 	db, _ := setupTestDB(t)
 	mockCompany := new(MockCompanyService)
-	svc := NewService(db, nil, nil, mockCompany, nil, nil)
+	svc := NewService(db, nil, nil, mockCompany, nil, nil, nil)
 
 	mockCompany.On("GetCompanyByID", mock.Anything, "company-1").Return(&company.Record{ID: "company-1", HasCHA: false}, nil)
 
@@ -433,7 +396,8 @@ func TestConsignmentService_CreateConsignmentShell_CompanyNotCHA(t *testing.T) {
 func TestConsignmentService_GetConsignmentByID(t *testing.T) {
 	db, sqlMock := setupTestDB(t)
 	mockWM := new(MockWMV2)
-	svc := NewService(db, nil, nil, nil, nil, hscode.NewService(db))
+	mockTaskStore := new(MockTaskStore)
+	svc := NewService(db, nil, nil, nil, nil, hscode.NewService(db), mockTaskStore)
 	require.NoError(t, svc.RegisterWorkflowManager(mockWM))
 
 	ctx := context.Background()
@@ -452,18 +416,21 @@ func TestConsignmentService_GetConsignmentByID(t *testing.T) {
 		WillReturnRows(sqlmock.NewRows([]string{"id", "hs_code", "description", "category"}).
 			AddRow(hsCodeID, "1234.56", "Test Description", "Test Category"))
 
+	mockTaskStore.On("GetAllTasks", mock.Anything, consignmentID).Return(([]tfstore.TaskRecord)(nil))
+
 	result, err := svc.GetConsignmentByID(ctx, consignmentID)
 	assert.NoError(t, err)
 	assert.NotNil(t, result)
 	assert.Equal(t, consignmentID, result.ID)
 	assert.Len(t, result.WorkflowNodes, 0)
 	mockWM.AssertExpectations(t)
+	mockTaskStore.AssertExpectations(t)
 	assert.NoError(t, sqlMock.ExpectationsWereMet())
 }
 
 func TestConsignmentService_ListConsignments_TraderCompany_Empty(t *testing.T) {
 	db, sqlMock := setupTestDB(t)
-	svc := NewService(db, nil, nil, nil, nil, hscode.NewService(db))
+	svc := NewService(db, nil, nil, nil, nil, hscode.NewService(db), nil)
 	ctx := context.Background()
 	companyID := "company-1"
 
@@ -480,7 +447,7 @@ func TestConsignmentService_ListConsignments_TraderCompany_Empty(t *testing.T) {
 
 func TestConsignmentService_ListConsignments_TraderCompany_FindError(t *testing.T) {
 	db, sqlMock := setupTestDB(t)
-	svc := NewService(db, nil, nil, nil, nil, hscode.NewService(db))
+	svc := NewService(db, nil, nil, nil, nil, hscode.NewService(db), nil)
 	ctx := context.Background()
 	companyID := "company-1"
 
@@ -495,7 +462,7 @@ func TestConsignmentService_ListConsignments_TraderCompany_FindError(t *testing.
 
 func TestConsignmentService_ListConsignments_NoIdentity(t *testing.T) {
 	db, _ := setupTestDB(t)
-	svc := NewService(db, nil, nil, nil, nil, nil)
+	svc := NewService(db, nil, nil, nil, nil, nil, nil)
 	_, err := svc.ListConsignments(context.Background(), Filter{})
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "TraderCompanyID or CHACompanyID must be set")
@@ -504,7 +471,7 @@ func TestConsignmentService_ListConsignments_NoIdentity(t *testing.T) {
 func TestConsignmentService_CreateConsignmentShell_CompanyNotFound(t *testing.T) {
 	db, _ := setupTestDB(t)
 	mockCompany := new(MockCompanyService)
-	svc := NewService(db, nil, nil, mockCompany, nil, nil)
+	svc := NewService(db, nil, nil, mockCompany, nil, nil, nil)
 	ctx := context.Background()
 	mockCompany.On("GetCompanyByID", ctx, "missing").Return(nil, company.ErrCompanyNotFound)
 
@@ -516,7 +483,7 @@ func TestConsignmentService_CreateConsignmentShell_InsertError(t *testing.T) {
 	db, sqlMock := setupTestDB(t)
 	mockCompany := new(MockCompanyService)
 	mockUser := new(MockUserService)
-	svc := NewService(db, nil, nil, mockCompany, mockUser, nil)
+	svc := NewService(db, nil, nil, mockCompany, mockUser, nil, nil)
 	ctx := context.Background()
 	chaCompanyID := uuid.NewString()
 	traderID := "trader1"
@@ -539,7 +506,7 @@ func TestConsignmentService_InitializeConsignmentByID_StartWorkflowError(t *test
 	mockCHA := new(MockCHAService)
 	mockCompany := new(MockCompanyService)
 	mockTP := new(MockTemplateProvider)
-	svc := NewService(db, mockTP, mockCHA, mockCompany, nil, nil)
+	svc := NewService(db, mockTP, mockCHA, mockCompany, nil, nil, nil)
 	require.NoError(t, svc.RegisterWorkflowManager(mockWM))
 
 	id := uuid.NewString()
@@ -579,7 +546,7 @@ func TestConsignmentService_InitializeConsignmentByID_TemplateProviderError(t *t
 	mockCHA := new(MockCHAService)
 	mockCompany := new(MockCompanyService)
 	mockTP := new(MockTemplateProvider)
-	svc := NewService(db, mockTP, mockCHA, mockCompany, nil, nil)
+	svc := NewService(db, mockTP, mockCHA, mockCompany, nil, nil, nil)
 
 	id := uuid.NewString()
 	hsID := "hs1"
@@ -614,7 +581,7 @@ func TestConsignmentService_InitializeConsignmentByID_CHACompanyMismatch(t *test
 	db, sqlMock := setupTestDB(t)
 	mockCHA := new(MockCHAService)
 	mockCompany := new(MockCompanyService)
-	svc := NewService(db, nil, mockCHA, mockCompany, nil, nil)
+	svc := NewService(db, nil, mockCHA, mockCompany, nil, nil, nil)
 
 	id := uuid.NewString()
 	hsID := "hs1"
@@ -632,7 +599,7 @@ func TestConsignmentService_InitializeConsignmentByID_CHACompanyMismatch(t *test
 
 func TestConsignmentService_MarkConsignmentAsFinished_NotFound(t *testing.T) {
 	db, sqlMock := setupTestDB(t)
-	svc := NewService(db, nil, nil, nil, nil, nil)
+	svc := NewService(db, nil, nil, nil, nil, nil, nil)
 	id := uuid.NewString()
 	sqlMock.ExpectQuery(`SELECT \* FROM "consignments" WHERE id = \$1`).
 		WithArgs(id, 1).
@@ -646,7 +613,7 @@ func TestConsignmentService_MarkConsignmentAsFinished_NotFound(t *testing.T) {
 func TestConsignmentService_GetConsignmentByID_WMError(t *testing.T) {
 	db, sqlMock := setupTestDB(t)
 	mockWM := new(MockWMV2)
-	svc := NewService(db, nil, nil, nil, nil, hscode.NewService(db))
+	svc := NewService(db, nil, nil, nil, nil, hscode.NewService(db), nil)
 	require.NoError(t, svc.RegisterWorkflowManager(mockWM))
 
 	id := uuid.NewString()
@@ -663,21 +630,25 @@ func TestConsignmentService_GetConsignmentByID_WMError(t *testing.T) {
 func TestConsignmentService_GetConsignmentByID_Initialized_SkipsWM(t *testing.T) {
 	db, sqlMock := setupTestDB(t)
 	// No WM registered — INITIALIZED path must NOT call it.
-	svc := NewService(db, nil, nil, nil, nil, hscode.NewService(db))
+	mockTaskStore := new(MockTaskStore)
+	svc := NewService(db, nil, nil, nil, nil, hscode.NewService(db), mockTaskStore)
 
 	id := uuid.NewString()
 	sqlMock.ExpectQuery(`SELECT \* FROM "consignments" WHERE id = \$1`).
 		WithArgs(id, 1).
 		WillReturnRows(sqlmock.NewRows([]string{"id", "state", "items"}).AddRow(id, "INITIALIZED", []byte("[]")))
 
+	mockTaskStore.On("GetAllTasks", mock.Anything, id).Return(([]tfstore.TaskRecord)(nil))
+
 	result, err := svc.GetConsignmentByID(context.Background(), id)
 	assert.NoError(t, err)
 	assert.Equal(t, Initialized, result.State)
+	mockTaskStore.AssertExpectations(t)
 }
 
 func TestConsignmentService_ListConsignments_WithItems(t *testing.T) {
 	db, sqlMock := setupTestDB(t)
-	svc := NewService(db, nil, nil, nil, nil, hscode.NewService(db))
+	svc := NewService(db, nil, nil, nil, nil, hscode.NewService(db), nil)
 	traderID := "trader1"
 	consignmentID := uuid.NewString()
 	hsID := uuid.NewString()
@@ -706,7 +677,7 @@ func TestConsignmentService_ListConsignments_WithItems(t *testing.T) {
 
 func TestConsignmentService_ListConsignments_FindError(t *testing.T) {
 	db, sqlMock := setupTestDB(t)
-	svc := NewService(db, nil, nil, nil, nil, nil)
+	svc := NewService(db, nil, nil, nil, nil, nil, nil)
 	traderID := "trader1"
 
 	sqlMock.ExpectQuery(`SELECT \* FROM "consignments"`).
@@ -719,7 +690,7 @@ func TestConsignmentService_ListConsignments_FindError(t *testing.T) {
 
 func TestConsignmentService_ListConsignments_NodeCountError(t *testing.T) {
 	db, sqlMock := setupTestDB(t)
-	svc := NewService(db, nil, nil, nil, nil, nil)
+	svc := NewService(db, nil, nil, nil, nil, nil, nil)
 	traderID := "trader1"
 
 	sqlMock.ExpectQuery(`SELECT \* FROM "consignments"`).
@@ -733,7 +704,7 @@ func TestConsignmentService_ListConsignments_NodeCountError(t *testing.T) {
 
 func TestConsignmentService_ListConsignments_EndNodeError(t *testing.T) {
 	db, sqlMock := setupTestDB(t)
-	svc := NewService(db, nil, nil, nil, nil, nil)
+	svc := NewService(db, nil, nil, nil, nil, nil, nil)
 	traderID := "trader1"
 
 	sqlMock.ExpectQuery(`SELECT \* FROM "consignments"`).
@@ -750,7 +721,7 @@ func TestConsignmentService_ListConsignments_EndNodeError(t *testing.T) {
 
 func TestConsignmentService_ListConsignments_CHACompanyPath(t *testing.T) {
 	db, sqlMock := setupTestDB(t)
-	svc := NewService(db, nil, nil, nil, nil, nil)
+	svc := NewService(db, nil, nil, nil, nil, nil, nil)
 	companyID := "company-cha"
 
 	sqlMock.ExpectQuery(`SELECT \* FROM "consignments" WHERE cha_company_id = \$1`).
@@ -762,7 +733,7 @@ func TestConsignmentService_ListConsignments_CHACompanyPath(t *testing.T) {
 }
 
 func TestConsignmentService_BuildItemResponseDTOs_MissingHSCode(t *testing.T) {
-	svc := NewService(nil, nil, nil, nil, nil, nil)
+	svc := NewService(nil, nil, nil, nil, nil, nil, nil)
 	_, err := svc.buildConsignmentItemResponseDTOs([]Item{{HSCodeID: "missing"}}, map[string]hscode.HSCode{})
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "HS code not found")

--- a/backend/internal/consignment/test_utils_test.go
+++ b/backend/internal/consignment/test_utils_test.go
@@ -6,11 +6,71 @@ import (
 
 	"github.com/DATA-DOG/go-sqlmock"
 	workflowManagerV2 "github.com/OpenNSW/go-temporal-workflow"
+	tfstore "github.com/OpenNSW/nsw-task-flow/store"
+	"github.com/OpenNSW/nsw/backend/internal/workflow/model"
 	"github.com/stretchr/testify/mock"
 	"gorm.io/driver/postgres"
 	"gorm.io/gorm"
 	"gorm.io/gorm/logger"
 )
+
+// MockTemplateProvider implements service.TemplateProvider for testing.
+type MockTemplateProvider struct {
+	mock.Mock
+}
+
+func (m *MockTemplateProvider) GetWorkflowTemplateByID(ctx context.Context, id string) (*model.WorkflowTemplate, error) {
+	args := m.Called(ctx, id)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).(*model.WorkflowTemplate), args.Error(1)
+}
+
+func (m *MockTemplateProvider) GetWorkflowTemplateByIDV2(ctx context.Context, id string) (*model.WorkflowTemplateV2, error) {
+	args := m.Called(ctx, id)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).(*model.WorkflowTemplateV2), args.Error(1)
+}
+
+func (m *MockTemplateProvider) GetWorkflowNodeTemplatesByIDs(ctx context.Context, ids []string) ([]model.WorkflowNodeTemplate, error) {
+	args := m.Called(ctx, ids)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).([]model.WorkflowNodeTemplate), args.Error(1)
+}
+
+func (m *MockTemplateProvider) GetWorkflowNodeTemplateByID(ctx context.Context, id string) (*model.WorkflowNodeTemplate, error) {
+	args := m.Called(ctx, id)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).(*model.WorkflowNodeTemplate), args.Error(1)
+}
+
+func (m *MockTemplateProvider) GetEndNodeTemplate(ctx context.Context) (*model.WorkflowNodeTemplate, error) {
+	args := m.Called(ctx)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).(*model.WorkflowNodeTemplate), args.Error(1)
+}
+
+// MockTaskStore implements consignment.TaskStore for testing.
+type MockTaskStore struct {
+	mock.Mock
+}
+
+func (m *MockTaskStore) GetAllTasks(ctx context.Context, parentWorkflowID string) []tfstore.TaskRecord {
+	args := m.Called(ctx, parentWorkflowID)
+	if args.Get(0) == nil {
+		return nil
+	}
+	return args.Get(0).([]tfstore.TaskRecord)
+}
 
 // MockWMV2 implements workflowManagerV2.TemporalManager for testing.
 type MockWMV2 struct {

--- a/backend/internal/taskv2/plugins/external_review.go
+++ b/backend/internal/taskv2/plugins/external_review.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"log/slog"
+	"strings"
 
 	"github.com/OpenNSW/nsw-task-flow/store"
 	"github.com/OpenNSW/nsw/backend/pkg/remote"
@@ -75,8 +76,25 @@ func buildSubmissionBody(record *store.TaskRecord, data any, taskCode *string, c
 	return map[string]any{
 		"taskCode":      taskCode,
 		"taskId":        record.TaskID,
-		"consignmentId": record.ParentWorkflowID,
+		"consignmentId": rootWorkflowID(record.ParentWorkflowID),
 		"serviceUrl":    callbackURL,
 		"data":          data,
 	}
+}
+
+// rootWorkflowID recovers the top-level consignment ID from a (possibly
+// child-workflow-mangled) parent workflow ID by taking everything before the
+// first "--" separator that FormatChildWorkflowID introduces for SPLIT_TASK
+// branches (format: "{root}--{nodeID}--{branchID}").
+//
+// TODO: this is a stop-gap string-parsing derivation that duplicates the one
+// in internal/taskv2/store/model.go. Replace both once the engine threads a
+// RootWorkflowID through TaskPayload/TaskRecord natively (see SPLIT_TASK /
+// dynamic_split.go childVars propagation) so external dispatch can read
+// record.RootWorkflowID directly instead of reconstructing it.
+func rootWorkflowID(parentWorkflowID string) string {
+	if idx := strings.Index(parentWorkflowID, "--"); idx != -1 {
+		return parentWorkflowID[:idx]
+	}
+	return parentWorkflowID
 }

--- a/backend/internal/taskv2/store/gorm_store.go
+++ b/backend/internal/taskv2/store/gorm_store.go
@@ -73,7 +73,7 @@ func (s *GormTaskStore) GetAllTasks(ctx context.Context, parentWorkflowID string
 	var models []TaskRecordModel
 	query := s.db.WithContext(ctx)
 	if parentWorkflowID != "" {
-		query = query.Where("parent_workflow_id = ?", parentWorkflowID)
+		query = query.Where("root_workflow_id = ?", parentWorkflowID)
 	}
 	if err := query.Find(&models).Error; err != nil {
 		slog.Error("taskv2 store: GetAllTasks db error", "parentWorkflowId", parentWorkflowID, "error", err)

--- a/backend/internal/taskv2/store/model.go
+++ b/backend/internal/taskv2/store/model.go
@@ -3,6 +3,7 @@ package store
 import (
 	"encoding/json"
 	"log/slog"
+	"strings"
 	"time"
 
 	"github.com/OpenNSW/nsw-task-flow/store"
@@ -15,6 +16,7 @@ type TaskRecordModel struct {
 	State                 string          `gorm:"column:state;type:text"`
 	RenderConfig          json.RawMessage `gorm:"column:render_config;type:jsonb;serializer:json"`
 	ParentWorkflowID      string          `gorm:"column:parent_workflow_id;type:text;index"`
+	RootWorkflowID        string          `gorm:"column:root_workflow_id;type:text;not null;default:''"`
 	ParentRunID           string          `gorm:"column:parent_run_id;type:text"`
 	ParentNodeID          string          `gorm:"column:parent_node_id;type:text"`
 	TaskWorkflowID        string          `gorm:"column:task_workflow_id;type:text;index"`
@@ -66,12 +68,26 @@ func FromDomain(r store.TaskRecord) TaskRecordModel {
 	if err != nil {
 		slog.Error("taskv2 store: FromDomain failed to marshal Data", "taskId", r.TaskID, "error", err)
 	}
+	// root_workflow_id is the top-level consignment ID — the first segment of
+	// parent_workflow_id before any "--" separator introduced by SPLIT_TASK
+	// child workflow IDs (format: "{root}--{nodeID}--{branchID}").
+	//
+	// TODO: this is a stop-gap string-parsing derivation (duplicated in
+	// internal/taskv2/plugins/external_review.go's rootWorkflowID). Replace
+	// both once the engine threads a RootWorkflowID through
+	// TaskPayload/TaskRecord natively (propagated via SPLIT_TASK /
+	// dynamic_split.go childVars) so we can copy r.RootWorkflowID directly.
+	rootWorkflowID := r.ParentWorkflowID
+	if idx := strings.Index(r.ParentWorkflowID, "--"); idx != -1 {
+		rootWorkflowID = r.ParentWorkflowID[:idx]
+	}
 	return TaskRecordModel{
 		TaskID:                r.TaskID,
 		TaskType:              r.TaskType,
 		State:                 r.State,
 		RenderConfig:          r.RenderConfig,
 		ParentWorkflowID:      r.ParentWorkflowID,
+		RootWorkflowID:        rootWorkflowID,
 		ParentRunID:           r.ParentRunID,
 		ParentNodeID:          r.ParentNodeID,
 		TaskWorkflowID:        r.TaskWorkflowID,

--- a/backend/internal/workflow/model/workflow_node.go
+++ b/backend/internal/workflow/model/workflow_node.go
@@ -58,13 +58,6 @@ type WorkflowNodeResponseDTO struct {
 	Outcome              *string                         `json:"outcome,omitempty"`       // Outcome sub-state when COMPLETED
 }
 
-type WorkflowEdgeResponseDTO struct {
-	ID        string `json:"id"`
-	SourceID  string `json:"source_id"`
-	TargetID  string `json:"target_id"`
-	Condition string `json:"condition,omitempty"` // Optional condition for the edge (used for conditional unlocks)
-}
-
 // WorkflowNodeTemplateResponseDTO represents workflow node template details in the response.
 type WorkflowNodeTemplateResponseDTO struct {
 	Name        string `json:"name"`        // Name of the workflow node template


### PR DESCRIPTION
## Summary
Enables tracking and execution of dynamically generated child workflows (e.g. spawned via `SPLIT_TASK`) by unifying task record querying under a top-level `root_workflow_id`.
## Key Changes
* **Database & Store**: Added `root_workflow_id` to `TaskRecordModel` (parsed from `parent_workflow_id` before the `--` separator) and updated `GetAllTasks` to query using it.
* **Consignment Service**: Replaced `NodeInfo`-based node mapping with querying `task_records_v2` by `root_workflow_id`, ensuring child workflow tasks are aggregated and displayed.
* **External Review**: Updated callback payloads to resolve and use the root consignment ID (stripping child branch suffixes).

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ x ] New feature (non-breaking change which adds functionality)
- [ x ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Other (please describe):

## Changes Made

See above

## Testing

- [ x ] I have tested this change locally
- [ x ] I have added unit tests for new functionality
- [ x ] I have tested edge cases
- [ x ] All existing tests pass

## Checklist

- [ x ] My code follows the project's style guidelines
- [ x ] I have performed a self-review of my code
- [ x ] I have commented my code, particularly in hard-to-understand areas
- [ x ] I have made corresponding changes to the documentation
- [ x ] My changes generate no new warnings
- [ x ] I have checked that there are no merge conflicts
