### PR TITLE
Add missing ConsignmentService functionality for CHA/HSCode removal flow

### DIFF
--- a/backend/internal/consignment/model.go
+++ b/backend/internal/consignment/model.go
@@ -43,9 +43,11 @@ type Consignment struct {
 	TraderID        string `gorm:"type:varchar(100);column:trader_id;not null" json:"traderId"`                // Trader user who created the consignment
 	TraderCompanyID string `gorm:"type:varchar(100);column:trader_company_id;not null" json:"traderCompanyId"` // Company the trader belongs to
 
-	// CHA (company chosen at Stage 1; specific CHA assigned at Stage 2)
-	CHACompanyID string  `gorm:"type:varchar(100);column:cha_company_id;not null" json:"chaCompanyId"` // CHA company selected by the trader at Stage 1
-	CHAID        *string `gorm:"type:varchar(100);column:cha_id" json:"chaId,omitempty"`               // CHA who claimed the consignment at Stage 2
+	// CHA (company chosen at Stage 1; specific CHA assigned at Stage 2). Both are nil for
+	// direct-start consignments (e.g. trade-export-v1), where CHA selection happens inside
+	// the workflow itself rather than as an upfront trader/CHA handoff.
+	CHACompanyID *string `gorm:"type:varchar(100);column:cha_company_id" json:"chaCompanyId,omitempty"` // CHA company selected by the trader at Stage 1
+	CHAID        *string `gorm:"type:varchar(100);column:cha_id" json:"chaId,omitempty"`                // CHA who claimed the consignment at Stage 2
 
 	// Relationships
 	Workflow *model.Workflow `gorm:"foreignKey:ID;references:ID" json:"-"` // Associated Workflow (1:1, same ID)

--- a/backend/internal/consignment/router.go
+++ b/backend/internal/consignment/router.go
@@ -70,6 +70,33 @@ func (c *Router) HandleCreateConsignment(w http.ResponseWriter, r *http.Request)
 	}
 }
 
+// HandleStartConsignment handles POST /api/v1/consignments/start
+// Creates an export consignment and starts its workflow directly — no CHA company or HS code
+// is collected up front; the workflow's own tasks collect those later. Response: DetailDTO.
+func (c *Router) HandleStartConsignment(w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+	authCtx := auth.GetAuthContext(ctx)
+	if authCtx == nil || authCtx.User == nil {
+		http.Error(w, "Unauthorized", http.StatusUnauthorized)
+		return
+	}
+
+	traderID := authCtx.User.ID
+	consignment, err := c.cs.CreateAndStartConsignment(ctx, traderID)
+	if err != nil {
+		slog.Error("failed to create and start consignment", "error", err)
+		http.Error(w, "failed to create consignment: "+err.Error(), http.StatusInternalServerError)
+		return
+	}
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusCreated)
+	if err := json.NewEncoder(w).Encode(consignment); err != nil {
+		slog.Error("failed to encode response for consignment", "error", err)
+		http.Error(w, "failed to encode response", http.StatusInternalServerError)
+		return
+	}
+}
+
 // HandleGetConsignments handles GET /api/v1/consignments
 // Query params: role=trader | role=cha (defaults to trader).
 // When role=cha the CHA is resolved from the authenticated user's email.

--- a/backend/internal/consignment/service.go
+++ b/backend/internal/consignment/service.go
@@ -299,24 +299,17 @@ func (s *Service) CreateAndStartConsignment(ctx context.Context, traderID string
 	}
 
 	tx := s.db.WithContext(ctx).Begin()
-	defer func() {
-		if r := recover(); r != nil {
-			tx.Rollback()
-		}
-	}()
+	defer tx.Rollback()
 
 	if err := tx.Create(consignment).Error; err != nil {
-		tx.Rollback()
 		return nil, fmt.Errorf("failed to create consignment: %w", err)
 	}
 
 	if err := s.wm.StartWorkflow(ctx, consignment.ID, wt.WorkflowDefinition, initialVars); err != nil {
-		tx.Rollback()
 		return nil, fmt.Errorf("failed to register workflow: %w", err)
 	}
 
 	if err := tx.Commit().Error; err != nil {
-		tx.Rollback()
 		return nil, fmt.Errorf("failed to commit: %w", err)
 	}
 

--- a/backend/internal/consignment/service.go
+++ b/backend/internal/consignment/service.go
@@ -120,7 +120,7 @@ func (s *Service) CreateConsignmentShell(ctx context.Context, flow Flow, chaComp
 		Flow:            flow,
 		TraderID:        traderID,
 		TraderCompanyID: traderCompany.ID,
-		CHACompanyID:    chaCompany.ID,
+		CHACompanyID:    &chaCompany.ID,
 		State:           Initialized,
 		Items:           []Item{},
 	}
@@ -171,7 +171,7 @@ func (s *Service) InitializeConsignmentByID(
 	if err != nil {
 		return nil, fmt.Errorf("CHA lookup failed: %w", err)
 	}
-	if chaRecord.CompanyID != consignment.CHACompanyID {
+	if consignment.CHACompanyID == nil || chaRecord.CompanyID != *consignment.CHACompanyID {
 		return nil, ErrCHACompanyMismatch
 	}
 
@@ -255,6 +255,79 @@ func (s *Service) InitializeConsignmentByID(
 		return nil, err
 	}
 
+	return responseDTO, nil
+}
+
+// directStartExportWorkflowTemplateID is the top-level workflow started immediately by
+// CreateAndStartConsignment. CHA and HS code selection happen inside this workflow's own
+// tasks (trade_1_cha_selection, trade_2_hscode_selection) as workflow variables
+// (trade.cha_id, trade.hs_codes) rather than as an upfront trader/CHA handoff.
+const directStartExportWorkflowTemplateID = "trade-export-v1"
+
+// CreateAndStartConsignment creates an export consignment and starts its workflow directly,
+// in one step — replacing the two-stage trader-creates-shell → CHA-claims-with-HS-code handoff
+// for flows whose entire CHA/HS-code selection now happens inside the workflow itself.
+func (s *Service) CreateAndStartConsignment(ctx context.Context, traderID string) (*DetailDTO, error) {
+	traderUser, err := s.userService.GetUser(traderID)
+	if err != nil {
+		return nil, fmt.Errorf("trader user lookup failed: %w", err)
+	}
+
+	traderCompany, err := s.companyService.GetCompanyByOUHandle(ctx, traderUser.OUHandle)
+	if err != nil {
+		return nil, fmt.Errorf("trader company lookup failed: %w", err)
+	}
+
+	traderCompanyVars, err := companyRecordToMap(traderCompany)
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal trader company: %w", err)
+	}
+	initialVars := map[string]any{"traderCompany": traderCompanyVars}
+
+	wt, err := s.templateProvider.GetWorkflowTemplateByIDV2(ctx, directStartExportWorkflowTemplateID)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get workflow template: %w", err)
+	}
+
+	consignment := &Consignment{
+		ID:              uuid.NewString(),
+		Flow:            FlowExport,
+		TraderID:        traderID,
+		TraderCompanyID: traderCompany.ID,
+		State:           InProgress,
+		Items:           []Item{},
+	}
+
+	tx := s.db.WithContext(ctx).Begin()
+	defer func() {
+		if r := recover(); r != nil {
+			tx.Rollback()
+		}
+	}()
+
+	if err := tx.Create(consignment).Error; err != nil {
+		tx.Rollback()
+		return nil, fmt.Errorf("failed to create consignment: %w", err)
+	}
+
+	if err := s.wm.StartWorkflow(ctx, consignment.ID, wt.WorkflowDefinition, initialVars); err != nil {
+		tx.Rollback()
+		return nil, fmt.Errorf("failed to register workflow: %w", err)
+	}
+
+	if err := tx.Commit().Error; err != nil {
+		tx.Rollback()
+		return nil, fmt.Errorf("failed to commit: %w", err)
+	}
+
+	if err := s.db.WithContext(ctx).First(consignment, "id = ?", consignment.ID).Error; err != nil {
+		return nil, fmt.Errorf("failed to reload consignment: %w", err)
+	}
+
+	responseDTO, err := s.buildConsignmentDetailDTO(ctx, consignment, make(map[string]hscode.HSCode))
+	if err != nil {
+		return nil, err
+	}
 	return responseDTO, nil
 }
 
@@ -430,6 +503,10 @@ func (s *Service) listConsignmentsWithBaseQuery(ctx context.Context, baseQuery *
 		if c.CHAID != nil {
 			chaID = *c.CHAID
 		}
+		chaCompanyID := ""
+		if c.CHACompanyID != nil {
+			chaCompanyID = *c.CHACompanyID
+		}
 
 		consignmentDTOs = append(consignmentDTOs, SummaryDTO{
 			ID:                         c.ID,
@@ -437,7 +514,7 @@ func (s *Service) listConsignmentsWithBaseQuery(ctx context.Context, baseQuery *
 			State:                      c.State,
 			TraderID:                   c.TraderID,
 			TraderCompanyID:            c.TraderCompanyID,
-			ChaCompanyID:               c.CHACompanyID,
+			ChaCompanyID:               chaCompanyID,
 			ChaID:                      chaID,
 			Items:                      itemResponseDTOs,
 			CreatedAt:                  c.CreatedAt.Format(time.RFC3339),
@@ -511,6 +588,10 @@ func (s *Service) buildConsignmentDetailDTO(
 	if consignment.CHAID != nil {
 		chaID = *consignment.CHAID
 	}
+	chaCompanyID := ""
+	if consignment.CHACompanyID != nil {
+		chaCompanyID = *consignment.CHACompanyID
+	}
 
 	return &DetailDTO{
 		ID:              consignment.ID,
@@ -518,7 +599,7 @@ func (s *Service) buildConsignmentDetailDTO(
 		State:           consignment.State,
 		TraderID:        consignment.TraderID,
 		TraderCompanyID: consignment.TraderCompanyID,
-		ChaCompanyID:    consignment.CHACompanyID,
+		ChaCompanyID:    chaCompanyID,
 		ChaID:           chaID,
 		Items:           itemResponseDTOs,
 		CreatedAt:       consignment.CreatedAt.Format(time.RFC3339),


### PR DESCRIPTION
## Summary

Adds `Service.CreateAndStartConsignment` and `Router.HandleStartConsignment`, which create an export consignment and start its workflow in one step (`POST /consignments/start`), and makes `Consignment.CHACompanyID` nullable to support this. This is consumed by `nsw-srilanka`'s direct-start consignment flow (branch `cha-hscode-ui-fixes`), where CHA and HS-code selection happen inside the workflow itself rather than as an upfront trader/CHA handoff.

## Type of Change

- [x] New feature (non-breaking change which adds functionality)

## Changes Made

- Added `Service.CreateAndStartConsignment`: creates a consignment and starts its `trade-export-v1` workflow directly, without an upfront CHA company.
- Added `Router.HandleStartConsignment`: HTTP handler for `POST /consignments/start`.
- Changed `Consignment.CHACompanyID` from `string` to `*string` (nullable) — direct-start consignments don't have a CHA company at creation time; it's set later when CHA selection completes inside the workflow.

## Testing

- [x] I have tested this change locally
- [ ] I have added unit tests for new functionality
- [ ] I have tested edge cases
- [x] All existing tests pass

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have checked that there are no merge conflicts

## Related Issues

Related to the direct-start consignment work on `nsw-srilanka` (`cha-hscode-ui-fixes`).

## Additional Notes

`CHACompanyID` is now nullable at the model level — consumers reading this field must handle `nil` (the existing two-stage flow always sets it, so no behavior change there).

## Deployment Notes

Requires a migration to drop the `NOT NULL` constraint on `consignments.cha_company_id` — already present in `nsw-srilanka` (`migrations/006_make_cha_company_id_nullable.*`); not duplicated here since `nsw/backend` itself doesn't own that table's migrations for this deployment.
