### PR TITLE
writing a core-based WireTaskV2 equivalent

### DIFF
--- a/.github/workflows/backend-ci.yml
+++ b/.github/workflows/backend-ci.yml
@@ -32,11 +32,7 @@ jobs:
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v7
         with:
-<<<<<<< HEAD
           version: v2.9.0
-=======
-          version: v2.12.2
->>>>>>> origin/main
           working-directory: ./backend
           args: --timeout=5m
 

--- a/.github/workflows/backend-ci.yml
+++ b/.github/workflows/backend-ci.yml
@@ -32,7 +32,7 @@ jobs:
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v7
         with:
-          version: v2.4.0
+          version: v2.9.0
           working-directory: ./backend
           args: --timeout=5m
 

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.25-bookworm AS builder
+FROM golang:1.26.3-bookworm AS builder
 
 WORKDIR /app
 

--- a/backend/go.mod
+++ b/backend/go.mod
@@ -65,5 +65,3 @@ require (
 	google.golang.org/protobuf v1.36.11 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )
-
-replace github.com/OpenNSW/core => ../../core

--- a/backend/go.mod
+++ b/backend/go.mod
@@ -4,7 +4,7 @@ go 1.26.3
 
 require (
 	github.com/DATA-DOG/go-sqlmock v1.5.2
-	github.com/OpenNSW/go-temporal-workflow v0.4.0
+	github.com/OpenNSW/go-temporal-workflow v0.5.0
 	github.com/OpenNSW/nsw-task-flow v0.0.0-20260526134015-a84391d97c36
 	github.com/aws/aws-sdk-go-v2 v1.41.7
 	github.com/aws/aws-sdk-go-v2/config v1.32.17

--- a/backend/go.mod
+++ b/backend/go.mod
@@ -1,6 +1,6 @@
 module github.com/OpenNSW/nsw/backend
 
-go 1.25.7
+go 1.26.3
 
 require (
 	github.com/DATA-DOG/go-sqlmock v1.5.2
@@ -14,12 +14,13 @@ require (
 	github.com/google/uuid v1.6.0
 	github.com/shopspring/decimal v1.4.0
 	github.com/stretchr/testify v1.11.1
-	go.temporal.io/sdk v1.43.0
+	go.temporal.io/sdk v1.44.1
 	gorm.io/driver/postgres v1.6.0
 	gorm.io/gorm v1.31.1
 )
 
 require (
+	github.com/OpenNSW/core v0.0.0-00010101000000-000000000000
 	github.com/aws/aws-sdk-go-v2/aws/protocol/eventstream v1.7.10 // indirect
 	github.com/aws/aws-sdk-go-v2/feature/ec2/imds v1.18.23 // indirect
 	github.com/aws/aws-sdk-go-v2/internal/configsources v1.4.23 // indirect
@@ -52,7 +53,7 @@ require (
 	github.com/robfig/cron v1.2.0 // indirect
 	github.com/rogpeppe/go-internal v1.14.1 // indirect
 	github.com/stretchr/objx v0.5.3 // indirect
-	go.temporal.io/api v1.62.11 // indirect
+	go.temporal.io/api v1.62.12 // indirect
 	golang.org/x/net v0.53.0 // indirect
 	golang.org/x/sync v0.20.0 // indirect
 	golang.org/x/sys v0.43.0 // indirect
@@ -64,3 +65,5 @@ require (
 	google.golang.org/protobuf v1.36.11 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )
+
+replace github.com/OpenNSW/core => ../../core

--- a/backend/go.mod
+++ b/backend/go.mod
@@ -4,7 +4,7 @@ go 1.26.3
 
 require (
 	github.com/DATA-DOG/go-sqlmock v1.5.2
-	github.com/OpenNSW/core v0.0.0-20260608092108-7ca654c29b5d
+	github.com/OpenNSW/core v0.0.0-20260608153546-9c3e08a703e0
 	github.com/OpenNSW/go-temporal-workflow v0.5.0
 	github.com/OpenNSW/nsw-task-flow v0.0.0-20260526134015-a84391d97c36
 	github.com/aws/aws-sdk-go-v2 v1.41.7

--- a/backend/go.mod
+++ b/backend/go.mod
@@ -4,6 +4,7 @@ go 1.26.3
 
 require (
 	github.com/DATA-DOG/go-sqlmock v1.5.2
+	github.com/OpenNSW/core v0.0.0-20260608092108-7ca654c29b5d
 	github.com/OpenNSW/go-temporal-workflow v0.5.0
 	github.com/OpenNSW/nsw-task-flow v0.0.0-20260526134015-a84391d97c36
 	github.com/aws/aws-sdk-go-v2 v1.41.7
@@ -20,7 +21,6 @@ require (
 )
 
 require (
-	github.com/OpenNSW/core v0.0.0-00010101000000-000000000000
 	github.com/aws/aws-sdk-go-v2/aws/protocol/eventstream v1.7.10 // indirect
 	github.com/aws/aws-sdk-go-v2/feature/ec2/imds v1.18.23 // indirect
 	github.com/aws/aws-sdk-go-v2/internal/configsources v1.4.23 // indirect

--- a/backend/go.sum
+++ b/backend/go.sum
@@ -1,7 +1,7 @@
 github.com/DATA-DOG/go-sqlmock v1.5.2 h1:OcvFkGmslmlZibjAjaHm3L//6LiuBgolP7OputlJIzU=
 github.com/DATA-DOG/go-sqlmock v1.5.2/go.mod h1:88MAG/4G7SMwSE3CeA0ZKzrT5CiOU3OJ+JlNzwDqpNU=
-github.com/OpenNSW/go-temporal-workflow v0.4.0 h1:a8G+XCcDRP+H/vaLS5b3HkU1B6o7s8HQ5TOtOTPMn4k=
-github.com/OpenNSW/go-temporal-workflow v0.4.0/go.mod h1:YryMiRQ9MBkQUpAz8CwYnW56uFEYqb/cmmOd/YaYmao=
+github.com/OpenNSW/go-temporal-workflow v0.5.0 h1:5yKi2nRdglJBiQxetT0YsnECeXwOTYdDIIppaoVEc8g=
+github.com/OpenNSW/go-temporal-workflow v0.5.0/go.mod h1:YryMiRQ9MBkQUpAz8CwYnW56uFEYqb/cmmOd/YaYmao=
 github.com/OpenNSW/nsw-task-flow v0.0.0-20260526134015-a84391d97c36 h1:Al1vGb+/YYLJpqcJh8vDTzNS6ivtFg1XIcujRK2BOYk=
 github.com/OpenNSW/nsw-task-flow v0.0.0-20260526134015-a84391d97c36/go.mod h1:xrgLSS3AILQiE2QO1MAoKkW5Hwy8u0NqE/9pIiOAr8s=
 github.com/aws/aws-sdk-go-v2 v1.41.7 h1:DWpAJt66FmnnaRIOT/8ASTucrvuDPZASqhhLey6tLY8=
@@ -120,12 +120,8 @@ go.opentelemetry.io/otel/sdk/metric v1.43.0 h1:S88dyqXjJkuBNLeMcVPRFXpRw2fuwdvfC
 go.opentelemetry.io/otel/sdk/metric v1.43.0/go.mod h1:C/RJtwSEJ5hzTiUz5pXF1kILHStzb9zFlIEe85bhj6A=
 go.opentelemetry.io/otel/trace v1.43.0 h1:BkNrHpup+4k4w+ZZ86CZoHHEkohws8AY+WTX09nk+3A=
 go.opentelemetry.io/otel/trace v1.43.0/go.mod h1:/QJhyVBUUswCphDVxq+8mld+AvhXZLhe+8WVFxiFff0=
-go.temporal.io/api v1.62.11 h1:MWDaooDvOJCIRb1atqeZX2ErDPNTsNc3/mMEVEvvaVU=
-go.temporal.io/api v1.62.11/go.mod h1:iaxoP/9OXMJcQkETTECfwYq4cw/bj4nwov8b3ZLVnXM=
 go.temporal.io/api v1.62.12 h1:627rVnItegQmrszg1bH4vfyc/1uNo5qCereCNkvZefw=
 go.temporal.io/api v1.62.12/go.mod h1:iaxoP/9OXMJcQkETTECfwYq4cw/bj4nwov8b3ZLVnXM=
-go.temporal.io/sdk v1.43.0 h1:jHX/T2ZyBVjAtpQ/69NoMS6a+J0CpJAe+naqSB1gkvY=
-go.temporal.io/sdk v1.43.0/go.mod h1:w9XuJzV25JhnJqUzxJWJISpp5q/EyeCtRKHvhW3lIoQ=
 go.temporal.io/sdk v1.44.1 h1:Mt2OZLZpqkzDIdg9YyQzO0Rb/HqCDnnqHlIAGAJ5gqM=
 go.temporal.io/sdk v1.44.1/go.mod h1:vkApR12F9/Y8OR+hkxe7WyXQFuCX6clhzqnAk6rzDAM=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=

--- a/backend/go.sum
+++ b/backend/go.sum
@@ -1,7 +1,7 @@
 github.com/DATA-DOG/go-sqlmock v1.5.2 h1:OcvFkGmslmlZibjAjaHm3L//6LiuBgolP7OputlJIzU=
 github.com/DATA-DOG/go-sqlmock v1.5.2/go.mod h1:88MAG/4G7SMwSE3CeA0ZKzrT5CiOU3OJ+JlNzwDqpNU=
-github.com/OpenNSW/core v0.0.0-20260608092108-7ca654c29b5d h1:cY3YuRdmDdQvB/2+PG3yDflpDO7nz00rJEU3pATej3E=
-github.com/OpenNSW/core v0.0.0-20260608092108-7ca654c29b5d/go.mod h1:F1Vyhh8F9Q9TOgzJwZjhGdf2MPHj0oUHcFzLgAbIKoI=
+github.com/OpenNSW/core v0.0.0-20260608153546-9c3e08a703e0 h1:Pgpaz9DEavXpiJ2il80hw63Sn26SirfFWjCdZjUOcpo=
+github.com/OpenNSW/core v0.0.0-20260608153546-9c3e08a703e0/go.mod h1:F1Vyhh8F9Q9TOgzJwZjhGdf2MPHj0oUHcFzLgAbIKoI=
 github.com/OpenNSW/go-temporal-workflow v0.5.0 h1:5yKi2nRdglJBiQxetT0YsnECeXwOTYdDIIppaoVEc8g=
 github.com/OpenNSW/go-temporal-workflow v0.5.0/go.mod h1:YryMiRQ9MBkQUpAz8CwYnW56uFEYqb/cmmOd/YaYmao=
 github.com/OpenNSW/nsw-task-flow v0.0.0-20260526134015-a84391d97c36 h1:Al1vGb+/YYLJpqcJh8vDTzNS6ivtFg1XIcujRK2BOYk=

--- a/backend/go.sum
+++ b/backend/go.sum
@@ -1,5 +1,7 @@
 github.com/DATA-DOG/go-sqlmock v1.5.2 h1:OcvFkGmslmlZibjAjaHm3L//6LiuBgolP7OputlJIzU=
 github.com/DATA-DOG/go-sqlmock v1.5.2/go.mod h1:88MAG/4G7SMwSE3CeA0ZKzrT5CiOU3OJ+JlNzwDqpNU=
+github.com/OpenNSW/core v0.0.0-20260608092108-7ca654c29b5d h1:cY3YuRdmDdQvB/2+PG3yDflpDO7nz00rJEU3pATej3E=
+github.com/OpenNSW/core v0.0.0-20260608092108-7ca654c29b5d/go.mod h1:F1Vyhh8F9Q9TOgzJwZjhGdf2MPHj0oUHcFzLgAbIKoI=
 github.com/OpenNSW/go-temporal-workflow v0.5.0 h1:5yKi2nRdglJBiQxetT0YsnECeXwOTYdDIIppaoVEc8g=
 github.com/OpenNSW/go-temporal-workflow v0.5.0/go.mod h1:YryMiRQ9MBkQUpAz8CwYnW56uFEYqb/cmmOd/YaYmao=
 github.com/OpenNSW/nsw-task-flow v0.0.0-20260526134015-a84391d97c36 h1:Al1vGb+/YYLJpqcJh8vDTzNS6ivtFg1XIcujRK2BOYk=

--- a/backend/go.sum
+++ b/backend/go.sum
@@ -122,8 +122,12 @@ go.opentelemetry.io/otel/trace v1.43.0 h1:BkNrHpup+4k4w+ZZ86CZoHHEkohws8AY+WTX09
 go.opentelemetry.io/otel/trace v1.43.0/go.mod h1:/QJhyVBUUswCphDVxq+8mld+AvhXZLhe+8WVFxiFff0=
 go.temporal.io/api v1.62.11 h1:MWDaooDvOJCIRb1atqeZX2ErDPNTsNc3/mMEVEvvaVU=
 go.temporal.io/api v1.62.11/go.mod h1:iaxoP/9OXMJcQkETTECfwYq4cw/bj4nwov8b3ZLVnXM=
+go.temporal.io/api v1.62.12 h1:627rVnItegQmrszg1bH4vfyc/1uNo5qCereCNkvZefw=
+go.temporal.io/api v1.62.12/go.mod h1:iaxoP/9OXMJcQkETTECfwYq4cw/bj4nwov8b3ZLVnXM=
 go.temporal.io/sdk v1.43.0 h1:jHX/T2ZyBVjAtpQ/69NoMS6a+J0CpJAe+naqSB1gkvY=
 go.temporal.io/sdk v1.43.0/go.mod h1:w9XuJzV25JhnJqUzxJWJISpp5q/EyeCtRKHvhW3lIoQ=
+go.temporal.io/sdk v1.44.1 h1:Mt2OZLZpqkzDIdg9YyQzO0Rb/HqCDnnqHlIAGAJ5gqM=
+go.temporal.io/sdk v1.44.1/go.mod h1:vkApR12F9/Y8OR+hkxe7WyXQFuCX6clhzqnAk6rzDAM=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
 golang.org/x/crypto v0.0.0-20191011191535-87dc89f01550/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
 golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=

--- a/backend/internal/consignment/service.go
+++ b/backend/internal/consignment/service.go
@@ -123,8 +123,16 @@ func (s *Service) getWorkflowStatus(ctx context.Context, workflowID string) erro
 func toCoreWorkflowDefinition(def workflowmanager.WorkflowDefinition) core.WorkflowDefinition {
 	nodes := make([]core.Node, len(def.Nodes))
 	for i, n := range def.Nodes {
-		// nsw/backend is pinned to go-temporal-workflow v0.4.0, which predates
-		// SPLIT_TASK/SplitTaskConfig — nothing to carry over for that field.
+		var splitTask *core.SplitTaskConfig
+		if n.SplitTask != nil {
+			splitTask = &core.SplitTaskConfig{
+				Mode:            core.SplitMode(n.SplitTask.Mode),
+				ItemsVariable:   n.SplitTask.ItemsVariable,
+				ResultsVariable: n.SplitTask.ResultsVariable,
+				FailureMode:     core.FailureMode(n.SplitTask.FailureMode),
+				IterationKey:    n.SplitTask.IterationKey,
+			}
+		}
 		nodes[i] = core.Node{
 			ID:             n.ID,
 			Type:           core.NodeType(n.Type),
@@ -132,6 +140,7 @@ func toCoreWorkflowDefinition(def workflowmanager.WorkflowDefinition) core.Workf
 			TaskTemplateID: n.TaskTemplateID,
 			InputMapping:   n.InputMapping,
 			OutputMapping:  n.OutputMapping,
+			SplitTask:      splitTask,
 		}
 	}
 

--- a/backend/internal/consignment/service.go
+++ b/backend/internal/consignment/service.go
@@ -71,6 +71,9 @@ func (s *Service) RegisterWorkflowManager(wm workflowmanager.Manager) error {
 	if s.wm != nil {
 		return fmt.Errorf("workflow manager already registered for ConsignmentService")
 	}
+	if s.wmCore != nil {
+		return fmt.Errorf("cannot register workflow manager when core workflow manager is already registered")
+	}
 	if wm == nil {
 		return fmt.Errorf("workflow manager cannot be nil")
 	}
@@ -87,6 +90,9 @@ func (s *Service) RegisterWorkflowManagerCore(wm core.Manager) error {
 	if s.wmCore != nil {
 		return fmt.Errorf("core workflow manager already registered for ConsignmentService")
 	}
+	if s.wm != nil {
+		return fmt.Errorf("cannot register core workflow manager when legacy workflow manager is already registered")
+	}
 	if wm == nil {
 		return fmt.Errorf("core workflow manager cannot be nil")
 	}
@@ -102,6 +108,9 @@ func (s *Service) startWorkflow(ctx context.Context, workflowID string, def work
 	if s.wmCore != nil {
 		return s.wmCore.StartWorkflow(ctx, workflowID, toCoreWorkflowDefinition(def), vars)
 	}
+	if s.wm == nil {
+		return fmt.Errorf("no workflow manager registered for ConsignmentService")
+	}
 	return s.wm.StartWorkflow(ctx, workflowID, def, vars)
 }
 
@@ -112,6 +121,9 @@ func (s *Service) getWorkflowStatus(ctx context.Context, workflowID string) erro
 	if s.wmCore != nil {
 		_, err := s.wmCore.GetStatus(ctx, workflowID)
 		return err
+	}
+	if s.wm == nil {
+		return fmt.Errorf("no workflow manager registered for ConsignmentService")
 	}
 	_, err := s.wm.GetStatus(ctx, workflowID)
 	return err

--- a/backend/internal/consignment/service.go
+++ b/backend/internal/consignment/service.go
@@ -10,6 +10,7 @@ import (
 	"github.com/google/uuid"
 	"gorm.io/gorm"
 
+	core "github.com/OpenNSW/core/workflow"
 	workflowmanager "github.com/OpenNSW/go-temporal-workflow"
 	tfstore "github.com/OpenNSW/nsw-task-flow/store"
 
@@ -36,6 +37,7 @@ type Service struct {
 	db               *gorm.DB
 	templateProvider service.TemplateProvider
 	wm               workflowmanager.Manager
+	wmCore           core.Manager
 	chaService       cha.Service
 	companyService   company.Service
 	userService      user.Service
@@ -74,6 +76,82 @@ func (s *Service) RegisterWorkflowManager(wm workflowmanager.Manager) error {
 	}
 	s.wm = wm
 	return nil
+}
+
+// RegisterWorkflowManagerCore registers a core/workflow-based manager. This exists
+// alongside RegisterWorkflowManager during the migration to github.com/OpenNSW/core:
+// callers wired against the new core libraries can register here instead of pulling
+// in go-temporal-workflow. Only one of the two managers may be registered; whichever
+// is set is used by startWorkflow/getWorkflowStatus below.
+func (s *Service) RegisterWorkflowManagerCore(wm core.Manager) error {
+	if s.wmCore != nil {
+		return fmt.Errorf("core workflow manager already registered for ConsignmentService")
+	}
+	if wm == nil {
+		return fmt.Errorf("core workflow manager cannot be nil")
+	}
+	s.wmCore = wm
+	return nil
+}
+
+// startWorkflow starts a workflow on whichever manager is registered, converting
+// the definition to core's type when running on the core/workflow manager. The two
+// WorkflowDefinition types are structurally identical (core/workflow is a fork of
+// go-temporal-workflow), so the conversion is a plain field copy.
+func (s *Service) startWorkflow(ctx context.Context, workflowID string, def workflowmanager.WorkflowDefinition, vars map[string]any) error {
+	if s.wmCore != nil {
+		return s.wmCore.StartWorkflow(ctx, workflowID, toCoreWorkflowDefinition(def), vars)
+	}
+	return s.wm.StartWorkflow(ctx, workflowID, def, vars)
+}
+
+// getWorkflowStatus checks that a workflow is reachable on whichever manager is
+// registered. Callers only care whether the lookup succeeds, not the returned
+// instance, so no conversion of WorkflowInstance is needed.
+func (s *Service) getWorkflowStatus(ctx context.Context, workflowID string) error {
+	if s.wmCore != nil {
+		_, err := s.wmCore.GetStatus(ctx, workflowID)
+		return err
+	}
+	_, err := s.wm.GetStatus(ctx, workflowID)
+	return err
+}
+
+// toCoreWorkflowDefinition converts a go-temporal-workflow.WorkflowDefinition to its
+// core/workflow equivalent. The two types (and their Node/Edge/SplitTaskConfig
+// members) are field-for-field identical, so this is a straight copy.
+func toCoreWorkflowDefinition(def workflowmanager.WorkflowDefinition) core.WorkflowDefinition {
+	nodes := make([]core.Node, len(def.Nodes))
+	for i, n := range def.Nodes {
+		// nsw/backend is pinned to go-temporal-workflow v0.4.0, which predates
+		// SPLIT_TASK/SplitTaskConfig — nothing to carry over for that field.
+		nodes[i] = core.Node{
+			ID:             n.ID,
+			Type:           core.NodeType(n.Type),
+			GatewayType:    core.GatewayType(n.GatewayType),
+			TaskTemplateID: n.TaskTemplateID,
+			InputMapping:   n.InputMapping,
+			OutputMapping:  n.OutputMapping,
+		}
+	}
+
+	edges := make([]core.Edge, len(def.Edges))
+	for i, e := range def.Edges {
+		edges[i] = core.Edge{
+			ID:        e.ID,
+			SourceID:  e.SourceID,
+			TargetID:  e.TargetID,
+			Condition: e.Condition,
+		}
+	}
+
+	return core.WorkflowDefinition{
+		ID:      def.ID,
+		Name:    def.Name,
+		Version: def.Version,
+		Nodes:   nodes,
+		Edges:   edges,
+	}
 }
 
 // CompletionHandler is called by the workflow runtime when a workflow completes. It delegates to the appropriate domain-specific handler based on the workflow type.
@@ -226,7 +304,7 @@ func (s *Service) InitializeConsignmentByID(
 		return nil, fmt.Errorf("failed to get workflow template from provider: %w", err)
 	}
 
-	if err := s.wm.StartWorkflow(ctx, consignment.ID, wt.WorkflowDefinition, initialVars); err != nil {
+	if err := s.startWorkflow(ctx, consignment.ID, wt.WorkflowDefinition, initialVars); err != nil {
 		tx.Rollback()
 		return nil, fmt.Errorf("failed to register workflow: %w", err)
 	}
@@ -241,7 +319,7 @@ func (s *Service) InitializeConsignmentByID(
 		return nil, fmt.Errorf("failed to reload consignment: %w", err)
 	}
 
-	if _, err := s.wm.GetStatus(ctx, consignment.ID); err != nil {
+	if err := s.getWorkflowStatus(ctx, consignment.ID); err != nil {
 		return nil, fmt.Errorf("failed to get workflow details: %w", err)
 	}
 
@@ -305,7 +383,7 @@ func (s *Service) CreateAndStartConsignment(ctx context.Context, traderID string
 		return nil, fmt.Errorf("failed to create consignment: %w", err)
 	}
 
-	if err := s.wm.StartWorkflow(ctx, consignment.ID, wt.WorkflowDefinition, initialVars); err != nil {
+	if err := s.startWorkflow(ctx, consignment.ID, wt.WorkflowDefinition, initialVars); err != nil {
 		return nil, fmt.Errorf("failed to register workflow: %w", err)
 	}
 
@@ -335,7 +413,7 @@ func (s *Service) GetConsignmentByID(ctx context.Context, consignmentID string) 
 	// Confirm the workflow is reachable if one exists; node details now come
 	// from task records rather than this status snapshot.
 	if consignment.State != Initialized {
-		if _, err := s.wm.GetStatus(ctx, consignment.ID); err != nil {
+		if err := s.getWorkflowStatus(ctx, consignment.ID); err != nil {
 			return nil, fmt.Errorf("failed to get workflow details: %w", err)
 		}
 	}


### PR DESCRIPTION
## Summary

Adds migration-support hooks to `consignment.Service` so callers can register a `core/workflow`-based (`github.com/OpenNSW/core`) manager alongside the legacy `go-temporal-workflow` one — unblocking `nsw-srilanka`'s migration to `core/taskflow`/`core/workflow` without requiring a flag-day cutover or forcing every consumer of `consignment.Service` to migrate at once.

- Adds `wmCore core.Manager` field and `RegisterWorkflowManagerCore(wm core.Manager) error`, mirroring the existing `RegisterWorkflowManager(wm workflowmanager.Manager) error`. Only one of the two may be registered per `Service` instance.
- Adds private `startWorkflow`/`getWorkflowStatus` dispatch helpers that route to whichever manager is registered (`wmCore` if set, else the legacy `wm`), replacing the direct `s.wm.StartWorkflow(...)`/`s.wm.GetStatus(...)` calls in `InitializeConsignmentByID`, `CreateAndStartConsignment`, and `GetConsignmentByID`.
- Adds `toCoreWorkflowDefinition`, converting `go-temporal-workflow.WorkflowDefinition` → `core/workflow.WorkflowDefinition` (and their `Node`/`Edge` members) via a straight field-for-field copy — the two types are structurally identical since `core/workflow` is a fork of `go-temporal-workflow`. (Note: `go-temporal-workflow` v0.4.0, which `nsw/backend` is pinned to, predates `SPLIT_TASK`/`SplitTaskConfig`, so there's nothing to carry over for that field — this is called out in the function's doc comment.)
- Bumps `go.mod`/`go.sum` to add `github.com/OpenNSW/core` and pick up the dependency versions it requires.

This is purely additive — existing callers that only call `RegisterWorkflowManager` are unaffected; `wmCore` stays `nil` and `startWorkflow`/`getWorkflowStatus` fall through to the legacy `wm` path exactly as before.

## Test plan

- [x] `go build ./...` — clean
- [x] `go vet ./...` — clean
- [x] Exercised end-to-end from `nsw-srilanka` (which registers via `RegisterWorkflowManagerCore` and runs its parent workflow runner against `core/workflow`): confirmed `StartWorkflow`/`GetStatus`/`CompletionHandler` round-trip correctly through `toCoreWorkflowDefinition`, including a full FCAU export consignment workflow run to completion
- [ ] Confirm no other in-flight branches/PRs that also touch `consignment.Service.startWorkflow`/`getWorkflowStatus` conflict with this dispatch refactor
