### PR TITLE
Migrate to OpenNSW/core in consignment/router

### DIFF
--- a/.github/workflows/backend-ci.yml
+++ b/.github/workflows/backend-ci.yml
@@ -32,7 +32,7 @@ jobs:
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v7
         with:
-          version: v2.4.0
+          version: v2.12.2
           working-directory: ./backend
           args: --timeout=5m
 

--- a/backend/.golangci.yml
+++ b/backend/.golangci.yml
@@ -5,7 +5,7 @@ version: "2"
 run:
   timeout: 5m
   modules-download-mode: readonly
-  go: "1.25"
+  go: "1.26.3"
 
 formatters:
   enable:

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.25-bookworm AS builder
+FROM golang:1.26-bookworm AS builder
 
 WORKDIR /app
 

--- a/backend/go.mod
+++ b/backend/go.mod
@@ -1,9 +1,10 @@
 module github.com/OpenNSW/nsw/backend
 
-go 1.25.7
+go 1.26.3
 
 require (
 	github.com/DATA-DOG/go-sqlmock v1.5.2
+	github.com/OpenNSW/core v0.0.0-20260608092108-7ca654c29b5d
 	github.com/OpenNSW/go-temporal-workflow v0.4.0
 	github.com/OpenNSW/nsw-task-flow v0.0.0-20260526134015-a84391d97c36
 	github.com/aws/aws-sdk-go-v2 v1.41.7
@@ -14,7 +15,7 @@ require (
 	github.com/google/uuid v1.6.0
 	github.com/shopspring/decimal v1.4.0
 	github.com/stretchr/testify v1.11.1
-	go.temporal.io/sdk v1.43.0
+	go.temporal.io/sdk v1.44.1
 	gorm.io/driver/postgres v1.6.0
 	gorm.io/gorm v1.31.1
 )
@@ -52,7 +53,7 @@ require (
 	github.com/robfig/cron v1.2.0 // indirect
 	github.com/rogpeppe/go-internal v1.14.1 // indirect
 	github.com/stretchr/objx v0.5.3 // indirect
-	go.temporal.io/api v1.62.11 // indirect
+	go.temporal.io/api v1.62.12 // indirect
 	golang.org/x/net v0.53.0 // indirect
 	golang.org/x/sync v0.20.0 // indirect
 	golang.org/x/sys v0.43.0 // indirect

--- a/backend/go.sum
+++ b/backend/go.sum
@@ -1,5 +1,7 @@
 github.com/DATA-DOG/go-sqlmock v1.5.2 h1:OcvFkGmslmlZibjAjaHm3L//6LiuBgolP7OputlJIzU=
 github.com/DATA-DOG/go-sqlmock v1.5.2/go.mod h1:88MAG/4G7SMwSE3CeA0ZKzrT5CiOU3OJ+JlNzwDqpNU=
+github.com/OpenNSW/core v0.0.0-20260608092108-7ca654c29b5d h1:cY3YuRdmDdQvB/2+PG3yDflpDO7nz00rJEU3pATej3E=
+github.com/OpenNSW/core v0.0.0-20260608092108-7ca654c29b5d/go.mod h1:F1Vyhh8F9Q9TOgzJwZjhGdf2MPHj0oUHcFzLgAbIKoI=
 github.com/OpenNSW/go-temporal-workflow v0.4.0 h1:a8G+XCcDRP+H/vaLS5b3HkU1B6o7s8HQ5TOtOTPMn4k=
 github.com/OpenNSW/go-temporal-workflow v0.4.0/go.mod h1:YryMiRQ9MBkQUpAz8CwYnW56uFEYqb/cmmOd/YaYmao=
 github.com/OpenNSW/nsw-task-flow v0.0.0-20260526134015-a84391d97c36 h1:Al1vGb+/YYLJpqcJh8vDTzNS6ivtFg1XIcujRK2BOYk=
@@ -120,10 +122,10 @@ go.opentelemetry.io/otel/sdk/metric v1.43.0 h1:S88dyqXjJkuBNLeMcVPRFXpRw2fuwdvfC
 go.opentelemetry.io/otel/sdk/metric v1.43.0/go.mod h1:C/RJtwSEJ5hzTiUz5pXF1kILHStzb9zFlIEe85bhj6A=
 go.opentelemetry.io/otel/trace v1.43.0 h1:BkNrHpup+4k4w+ZZ86CZoHHEkohws8AY+WTX09nk+3A=
 go.opentelemetry.io/otel/trace v1.43.0/go.mod h1:/QJhyVBUUswCphDVxq+8mld+AvhXZLhe+8WVFxiFff0=
-go.temporal.io/api v1.62.11 h1:MWDaooDvOJCIRb1atqeZX2ErDPNTsNc3/mMEVEvvaVU=
-go.temporal.io/api v1.62.11/go.mod h1:iaxoP/9OXMJcQkETTECfwYq4cw/bj4nwov8b3ZLVnXM=
-go.temporal.io/sdk v1.43.0 h1:jHX/T2ZyBVjAtpQ/69NoMS6a+J0CpJAe+naqSB1gkvY=
-go.temporal.io/sdk v1.43.0/go.mod h1:w9XuJzV25JhnJqUzxJWJISpp5q/EyeCtRKHvhW3lIoQ=
+go.temporal.io/api v1.62.12 h1:627rVnItegQmrszg1bH4vfyc/1uNo5qCereCNkvZefw=
+go.temporal.io/api v1.62.12/go.mod h1:iaxoP/9OXMJcQkETTECfwYq4cw/bj4nwov8b3ZLVnXM=
+go.temporal.io/sdk v1.44.1 h1:Mt2OZLZpqkzDIdg9YyQzO0Rb/HqCDnnqHlIAGAJ5gqM=
+go.temporal.io/sdk v1.44.1/go.mod h1:vkApR12F9/Y8OR+hkxe7WyXQFuCX6clhzqnAk6rzDAM=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
 golang.org/x/crypto v0.0.0-20191011191535-87dc89f01550/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
 golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=

--- a/backend/internal/consignment/router.go
+++ b/backend/internal/consignment/router.go
@@ -6,10 +6,10 @@ import (
 	"log/slog"
 	"net/http"
 
-	"github.com/OpenNSW/nsw/backend/internal/auth"
+	"github.com/OpenNSW/core/authn"
+	"github.com/OpenNSW/core/pagination"
 	"github.com/OpenNSW/nsw/backend/internal/profile/cha"
 	"github.com/OpenNSW/nsw/backend/internal/profile/company"
-	"github.com/OpenNSW/nsw/backend/pkg/pagination"
 )
 
 type Router struct {
@@ -27,7 +27,7 @@ func NewRouter(cs *Service, chaService cha.Service, companyService company.Servi
 // Legacy: body { flow, items } → creates and initializes workflow
 func (c *Router) HandleCreateConsignment(w http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
-	authCtx := auth.GetAuthContext(ctx)
+	authCtx := authn.GetAuthContext(ctx)
 	if authCtx == nil || authCtx.User == nil {
 		http.Error(w, "Unauthorized", http.StatusUnauthorized)
 		return
@@ -75,7 +75,7 @@ func (c *Router) HandleCreateConsignment(w http.ResponseWriter, r *http.Request)
 // is collected up front; the workflow's own tasks collect those later. Response: DetailDTO.
 func (c *Router) HandleStartConsignment(w http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
-	authCtx := auth.GetAuthContext(ctx)
+	authCtx := authn.GetAuthContext(ctx)
 	if authCtx == nil || authCtx.User == nil {
 		http.Error(w, "Unauthorized", http.StatusUnauthorized)
 		return
@@ -103,7 +103,7 @@ func (c *Router) HandleStartConsignment(w http.ResponseWriter, r *http.Request) 
 // Pagination: offset, limit. Optional filters: state, flow.
 func (c *Router) HandleGetConsignments(w http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
-	authCtx := auth.GetAuthContext(ctx)
+	authCtx := authn.GetAuthContext(ctx)
 	if authCtx == nil || authCtx.User == nil {
 		http.Error(w, "Unauthorized", http.StatusUnauthorized)
 		return
@@ -176,7 +176,7 @@ func (c *Router) HandleGetConsignments(w http.ResponseWriter, r *http.Request) {
 // Body: InitializeConsignmentDTO { hsCodeIds: []uuid }. Response: DetailDTO.
 func (c *Router) HandleInitializeConsignment(w http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
-	authCtx := auth.GetAuthContext(ctx)
+	authCtx := authn.GetAuthContext(ctx)
 	if authCtx == nil || authCtx.User == nil {
 		http.Error(w, "Unauthorized", http.StatusUnauthorized)
 		return
@@ -237,7 +237,7 @@ func (c *Router) HandleInitializeConsignment(w http.ResponseWriter, r *http.Requ
 // Response: DetailDTO
 func (c *Router) HandleGetConsignmentByID(w http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
-	authCtx := auth.GetAuthContext(ctx)
+	authCtx := authn.GetAuthContext(ctx)
 	if authCtx == nil || authCtx.User == nil {
 		http.Error(w, "Unauthorized", http.StatusUnauthorized)
 		return

--- a/backend/internal/consignment/router.go
+++ b/backend/internal/consignment/router.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/OpenNSW/core/authn"
 	"github.com/OpenNSW/core/pagination"
+
 	"github.com/OpenNSW/nsw/backend/internal/profile/cha"
 	"github.com/OpenNSW/nsw/backend/internal/profile/company"
 )

--- a/backend/internal/consignment/router_test.go
+++ b/backend/internal/consignment/router_test.go
@@ -18,7 +18,7 @@ import (
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 
-	"github.com/OpenNSW/nsw/backend/internal/auth"
+	"github.com/OpenNSW/core/authn"
 	"github.com/OpenNSW/nsw/backend/internal/profile/cha"
 	"github.com/OpenNSW/nsw/backend/internal/profile/company"
 	"github.com/OpenNSW/nsw/backend/internal/profile/user"
@@ -26,24 +26,24 @@ import (
 )
 
 func withAuthContext(ctx context.Context, userID string) context.Context {
-	authCtx := &auth.AuthContext{
-		User: &auth.UserContext{
+	authCtx := &authn.AuthContext{
+		User: &authn.UserContext{
 			ID:    userID,
 			Email: userID + "@example.com",
 		},
 	}
-	return context.WithValue(ctx, auth.AuthContextKey, authCtx)
+	return context.WithValue(ctx, authn.AuthContextKey, authCtx)
 }
 
 func withAuthContextOU(ctx context.Context, userID, ouHandle string) context.Context {
-	authCtx := &auth.AuthContext{
-		User: &auth.UserContext{
+	authCtx := &authn.AuthContext{
+		User: &authn.UserContext{
 			ID:       userID,
 			Email:    userID + "@example.com",
 			OUHandle: ouHandle,
 		},
 	}
-	return context.WithValue(ctx, auth.AuthContextKey, authCtx)
+	return context.WithValue(ctx, authn.AuthContextKey, authCtx)
 }
 
 func TestConsignmentRouter_HandleGetConsignmentByID(t *testing.T) {

--- a/backend/internal/consignment/router_test.go
+++ b/backend/internal/consignment/router_test.go
@@ -19,6 +19,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/OpenNSW/core/authn"
+
 	"github.com/OpenNSW/nsw/backend/internal/profile/cha"
 	"github.com/OpenNSW/nsw/backend/internal/profile/company"
 	"github.com/OpenNSW/nsw/backend/internal/profile/user"


### PR DESCRIPTION
Updated the consignment/router.go to use the OpenNSW/core/authn instead of internal/auth