### PR TITLE
fix(storage): rewrite S3 presigned URLs using PublicURL proxy and add SLTB IDP seed configuration

### DIFF
--- a/backend/go.mod
+++ b/backend/go.mod
@@ -4,7 +4,7 @@ go 1.26.3
 
 require (
 	github.com/DATA-DOG/go-sqlmock v1.5.2
-	github.com/OpenNSW/core v0.0.0-20260608153546-9c3e08a703e0
+	github.com/OpenNSW/core v0.0.0-20260611050252-2e0fe5b99b55
 	github.com/OpenNSW/go-temporal-workflow v0.5.0
 	github.com/OpenNSW/nsw-task-flow v0.0.0-20260526134015-a84391d97c36
 	github.com/aws/aws-sdk-go-v2 v1.41.7

--- a/backend/go.sum
+++ b/backend/go.sum
@@ -1,7 +1,7 @@
 github.com/DATA-DOG/go-sqlmock v1.5.2 h1:OcvFkGmslmlZibjAjaHm3L//6LiuBgolP7OputlJIzU=
 github.com/DATA-DOG/go-sqlmock v1.5.2/go.mod h1:88MAG/4G7SMwSE3CeA0ZKzrT5CiOU3OJ+JlNzwDqpNU=
-github.com/OpenNSW/core v0.0.0-20260608153546-9c3e08a703e0 h1:Pgpaz9DEavXpiJ2il80hw63Sn26SirfFWjCdZjUOcpo=
-github.com/OpenNSW/core v0.0.0-20260608153546-9c3e08a703e0/go.mod h1:F1Vyhh8F9Q9TOgzJwZjhGdf2MPHj0oUHcFzLgAbIKoI=
+github.com/OpenNSW/core v0.0.0-20260611050252-2e0fe5b99b55 h1:TAEkbtdAY4043RpvRgoM9eImabHrf2IJD+tBZe7TuaY=
+github.com/OpenNSW/core v0.0.0-20260611050252-2e0fe5b99b55/go.mod h1:F1Vyhh8F9Q9TOgzJwZjhGdf2MPHj0oUHcFzLgAbIKoI=
 github.com/OpenNSW/go-temporal-workflow v0.5.0 h1:5yKi2nRdglJBiQxetT0YsnECeXwOTYdDIIppaoVEc8g=
 github.com/OpenNSW/go-temporal-workflow v0.5.0/go.mod h1:YryMiRQ9MBkQUpAz8CwYnW56uFEYqb/cmmOd/YaYmao=
 github.com/OpenNSW/nsw-task-flow v0.0.0-20260526134015-a84391d97c36 h1:Al1vGb+/YYLJpqcJh8vDTzNS6ivtFg1XIcujRK2BOYk=

--- a/backend/pkg/storage/drivers/s3_driver.go
+++ b/backend/pkg/storage/drivers/s3_driver.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"net/url"
 	"time"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
@@ -88,7 +89,11 @@ func (d *S3Driver) presignGet(ctx context.Context, key string) (string, error) {
 }
 
 func (d *S3Driver) GetDownloadURL(ctx context.Context, key string) (string, error) {
-	return d.presignGet(ctx, key)
+	u, err := d.presignGet(ctx, key)
+	if err != nil {
+		return "", err
+	}
+	return d.rewriteHost(u)
 }
 
 // presignPut returns a presigned PUT URL for the key and constraints.
@@ -108,5 +113,29 @@ func (d *S3Driver) presignPut(ctx context.Context, key, contentType string, maxS
 }
 
 func (d *S3Driver) GetUploadURL(ctx context.Context, key string, contentType string, maxSizeBytes int64) (string, error) {
-	return d.presignPut(ctx, key, contentType, maxSizeBytes)
+	u, err := d.presignPut(ctx, key, contentType, maxSizeBytes)
+	if err != nil {
+		return "", err
+	}
+	return d.rewriteHost(u)
+}
+
+// rewriteHost replaces the host (and scheme) of rawURL with the host from PublicURL.
+// This lets the SDK sign against the real S3 endpoint while returning a browser-reachable
+// proxy URL.
+func (d *S3Driver) rewriteHost(rawURL string) (string, error) {
+	if d.PublicURL == "" {
+		return rawURL, nil
+	}
+	u, err := url.Parse(rawURL)
+	if err != nil {
+		return "", fmt.Errorf("failed to parse raw URL: %w", err)
+	}
+	pub, err := url.Parse(d.PublicURL)
+	if err != nil {
+		return "", fmt.Errorf("failed to parse public URL: %w", err)
+	}
+	u.Scheme = pub.Scheme
+	u.Host = pub.Host
+	return u.String(), nil
 }

--- a/backend/pkg/storage/drivers/s3_driver_test.go
+++ b/backend/pkg/storage/drivers/s3_driver_test.go
@@ -1,0 +1,64 @@
+package drivers
+
+import (
+	"testing"
+)
+
+func TestS3Driver_RewriteHost(t *testing.T) {
+	tests := []struct {
+		name      string
+		publicURL string
+		rawURL    string
+		wantURL   string
+		wantErr   bool
+	}{
+		{
+			name:      "no public url",
+			publicURL: "",
+			rawURL:    "https://real-s3.com/bucket/file?sig=123",
+			wantURL:   "https://real-s3.com/bucket/file?sig=123",
+			wantErr:   false,
+		},
+		{
+			name:      "with public url",
+			publicURL: "https://proxy.com",
+			rawURL:    "https://real-s3.com/bucket/file?sig=123",
+			wantURL:   "https://proxy.com/bucket/file?sig=123",
+			wantErr:   false,
+		},
+		{
+			name:      "with public url and HTTP scheme",
+			publicURL: "http://proxy-http.com",
+			rawURL:    "https://real-s3.com/bucket/file?sig=123",
+			wantURL:   "http://proxy-http.com/bucket/file?sig=123",
+			wantErr:   false,
+		},
+		{
+			name:      "invalid raw URL",
+			publicURL: "https://proxy.com",
+			rawURL:    "://invalid-url",
+			wantErr:   true,
+		},
+		{
+			name:      "invalid public URL",
+			publicURL: "://invalid-public",
+			rawURL:    "https://real-s3.com/bucket/file",
+			wantErr:   true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			d := &S3Driver{
+				PublicURL: tt.publicURL,
+			}
+			got, err := d.rewriteHost(tt.rawURL)
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("rewriteHost() error = %v, wantErr %v", err, tt.wantErr)
+			}
+			if !tt.wantErr && got != tt.wantURL {
+				t.Errorf("rewriteHost() = %q, want %q", got, tt.wantURL)
+			}
+		})
+	}
+}

--- a/idp/02-sample-resources.sh
+++ b/idp/02-sample-resources.sh
@@ -22,13 +22,11 @@ NARESH_PASSWORD="${SAMPLE_NARESH_PASSWORD:-${SAMPLE_USER_PASSWORD}}"
 NPQS_USER_PASSWORD="${SAMPLE_NPQS_USER_PASSWORD:-${SAMPLE_USER_PASSWORD}}"
 FCAU_USER_PASSWORD="${SAMPLE_FCAU_USER_PASSWORD:-${SAMPLE_USER_PASSWORD}}"
 IRD_USER_PASSWORD="${SAMPLE_IRD_USER_PASSWORD:-${SAMPLE_USER_PASSWORD}}"
-SLTB_USER_PASSWORD="${SAMPLE_SLTB_USER_PASSWORD:-${SAMPLE_USER_PASSWORD}}"
 CDA_USER_PASSWORD="${SAMPLE_CDA_USER_PASSWORD:-${SAMPLE_USER_PASSWORD}}"
 M2M_CLIENT_SECRET="${M2M_CLIENT_SECRET:-1234}"
 NPQS_M2M_CLIENT_SECRET="${M2M_NPQS_SECRET:-${M2M_CLIENT_SECRET}}"
 FCAU_M2M_CLIENT_SECRET="${M2M_FCAU_SECRET:-${M2M_CLIENT_SECRET}}"
 IRD_M2M_CLIENT_SECRET="${M2M_IRD_SECRET:-${M2M_CLIENT_SECRET}}"
-SLTB_M2M_CLIENT_SECRET="${M2M_SLTB_SECRET:-${M2M_CLIENT_SECRET}}"
 CDA_M2M_CLIENT_SECRET="${M2M_CDA_SECRET:-${M2M_CLIENT_SECRET}}"
 
 # ----------------------------------------------------------------------------
@@ -328,10 +326,6 @@ create_spa_application() {
                     ]
                 },
                 "scopeClaims": {
-                    "openid": [
-                        "ouId",
-                        "ouHandle"
-                    ],
                     "profile": [
                         "name",
                         "given_name",
@@ -962,7 +956,6 @@ GOVERNMENT_ORG_OU_HANDLE="government-organization"
 NPQS_OU_HANDLE="npqs"
 FCAU_OU_HANDLE="fcau"
 IRD_OU_HANDLE="ird"
-SLTB_OU_HANDLE="sltb"
 CDA_OU_HANDLE="cda"
 
 log_info "Creating Government Organization root organization unit..."
@@ -1142,50 +1135,6 @@ if [[ -z "$IRD_OU_ID" ]]; then
 fi
 
 log_info "IRD OU ID: $IRD_OU_ID"
-
-echo ""
-log_info "Creating SLTB organization unit..."
-
-read -r -d '' SLTB_OU_PAYLOAD <<JSON || true
-{
-    "handle": "${SLTB_OU_HANDLE}",
-    "name": "SLTB",
-    "description": "Sri Lanka Tea Board",
-    "parentId": "${GOVERNMENT_ORG_OU_ID}"
-}
-JSON
-
-RESPONSE=$(api_call POST "/organization-units" "${SLTB_OU_PAYLOAD}")
-HTTP_CODE="${RESPONSE: -3}"
-BODY="${RESPONSE%???}"
-
-if [[ "$HTTP_CODE" == "201" ]] || [[ "$HTTP_CODE" == "200" ]] || [[ "$HTTP_CODE" == "202" ]]; then
-    log_success "SLTB organization unit created successfully"
-    SLTB_OU_ID=$(extract_first_id "$BODY")
-elif [[ "$HTTP_CODE" == "409" ]]; then
-    log_warning "SLTB organization unit already exists, retrieving ID..."
-    RESPONSE=$(api_call GET "/organization-units/tree/${GOVERNMENT_ORG_OU_HANDLE}/${SLTB_OU_HANDLE}")
-    HTTP_CODE="${RESPONSE: -3}"
-    BODY="${RESPONSE%???}"
-    if [[ "$HTTP_CODE" == "200" ]]; then
-        SLTB_OU_ID=$(extract_first_id "$BODY")
-    else
-        log_error "Failed to fetch SLTB OU (HTTP $HTTP_CODE)"
-        echo "Response: $BODY"
-        exit 1
-    fi
-else
-    log_error "Failed to create SLTB organization unit (HTTP $HTTP_CODE)"
-    echo "Response: $BODY"
-    exit 1
-fi
-
-if [[ -z "$SLTB_OU_ID" ]]; then
-    log_error "Could not determine SLTB organization unit ID"
-    exit 1
-fi
-
-log_info "SLTB OU ID: $SLTB_OU_ID"
 
 echo ""
 log_info "Creating CDA organization unit..."
@@ -1634,9 +1583,6 @@ USER_FCAU_ID="$CREATED_USER_ID"
 create_user_in_ou "Government_User" "$IRD_OU_ID" "ird_user" "ird_user@government.dev" "IRD" "User" "$IRD_USER_PASSWORD" "+94771234562"
 USER_IRD_ID="$CREATED_USER_ID"
 
-create_user_in_ou "Government_User" "$SLTB_OU_ID" "sltb_user" "sltb_user@government.dev" "SLTB" "User" "$SLTB_USER_PASSWORD" "+94771234564"
-USER_SLTB_ID="$CREATED_USER_ID"
-
 create_user_in_ou "Government_User" "$CDA_OU_ID" "cda_user" "cda_user@government.dev" "CDA" "User" "$CDA_USER_PASSWORD" "+94771234563"
 USER_CDA_ID="$CREATED_USER_ID"
 
@@ -1658,7 +1604,6 @@ ensure_user_in_group "$CHA_GROUP_ID" "$USER_NARESH" "CHA" "naresh"
 ensure_user_in_group "$OGA_REVIEWERS_GROUP_ID" "$USER_NPQS_ID" "OGA Reviewers" "npqs_user"
 ensure_user_in_group "$OGA_REVIEWERS_GROUP_ID" "$USER_FCAU_ID" "OGA Reviewers" "fcau_user"
 ensure_user_in_group "$OGA_REVIEWERS_GROUP_ID" "$USER_IRD_ID" "OGA Reviewers" "ird_user"
-ensure_user_in_group "$OGA_REVIEWERS_GROUP_ID" "$USER_SLTB_ID" "OGA Reviewers" "sltb_user"
 ensure_user_in_group "$OGA_REVIEWERS_GROUP_ID" "$USER_CDA_ID" "OGA Reviewers" "cda_user"
 
 echo ""
@@ -1712,14 +1657,12 @@ DEFAULT_OU_ID_FOR_TRADER=$(get_ou_id_by_handle "default")
 NPQS_OU_ID_FOR_APP=$(get_ou_id_by_handle "government-organization/npqs")
 FCAU_OU_ID_FOR_APP=$(get_ou_id_by_handle "government-organization/fcau")
 IRD_OU_ID_FOR_APP=$(get_ou_id_by_handle "government-organization/ird")
-SLTB_OU_ID_FOR_APP=$(get_ou_id_by_handle "government-organization/sltb")
 CDA_OU_ID_FOR_APP=$(get_ou_id_by_handle "government-organization/cda")
 
 create_spa_application "TraderApp" "Application for trader portal built with React" "TRADER_PORTAL_APP" "5173" "Private_User" "${DEFAULT_OU_ID_FOR_TRADER}" "${TRADER_NSW_SCOPES}"
 create_spa_application "NPQSPortalApp" "Application for NPQS portal built with React" "OGA_PORTAL_APP_NPQS" "5174" "Government_User" "${NPQS_OU_ID_FOR_APP}" "${AGENCY_REVIEWER_SCOPES}"
 create_spa_application "FCAUPortalApp" "Application for FCAU portal built with React" "OGA_PORTAL_APP_FCAU" "5175" "Government_User" "${FCAU_OU_ID_FOR_APP}" "${AGENCY_REVIEWER_SCOPES}"
 create_spa_application "IRDPortalApp" "Application for IRD portal built with React" "OGA_PORTAL_APP_IRD" "5176" "Government_User" "${IRD_OU_ID_FOR_APP}" "${AGENCY_REVIEWER_SCOPES}"
-create_spa_application "SLTBPortalApp" "Application for SLTB portal built with React" "OGA_PORTAL_APP_SLTB" "5178" "Government_User" "${SLTB_OU_ID_FOR_APP}" "${AGENCY_REVIEWER_SCOPES}"
 create_spa_application "CDAPortalApp" "Application for CDA portal built with React" "OGA_PORTAL_APP_CDA" "5177" "Government_User" "${CDA_OU_ID_FOR_APP}" "${AGENCY_REVIEWER_SCOPES}"
 
 echo ""
@@ -1758,10 +1701,6 @@ create_m2m_application "IRD_TO_NSW_M2M" "Machine-to-machine integration for IRD 
 IRD_TO_NSW_M2M_APP_ID="$CREATED_M2M_APP_ID"
 assign_role_to_app "$AGENCY_M2M_ROLE_ID" "$IRD_TO_NSW_M2M_APP_ID" "AgencyM2M" "IRD_TO_NSW_M2M"
 
-create_m2m_application "SLTB_TO_NSW_M2M" "Machine-to-machine integration for SLTB to NSW" "SLTB_TO_NSW" "${SLTB_M2M_CLIENT_SECRET}" "${DEFAULT_OU_ID_FOR_M2M}" "${M2M_NSW_SCOPES}"
-SLTB_TO_NSW_M2M_APP_ID="$CREATED_M2M_APP_ID"
-assign_role_to_app "$AGENCY_M2M_ROLE_ID" "$SLTB_TO_NSW_M2M_APP_ID" "AgencyM2M" "SLTB_TO_NSW_M2M"
-
 create_m2m_application "CDA_TO_NSW_M2M" "Machine-to-machine integration for CDA to NSW" "CDA_TO_NSW" "${CDA_M2M_CLIENT_SECRET}" "${DEFAULT_OU_ID_FOR_M2M}" "${M2M_NSW_SCOPES}"
 CDA_TO_NSW_M2M_APP_ID="$CREATED_M2M_APP_ID"
 assign_role_to_app "$AGENCY_M2M_ROLE_ID" "$CDA_TO_NSW_M2M_APP_ID" "AgencyM2M" "CDA_TO_NSW_M2M"
@@ -1777,7 +1716,7 @@ log_info "Private Sector OU path: ${PRIVATE_SECTOR_OU_HANDLE}"
 log_info "ADAM PVT LTD OU path: ${ADAM_PVT_LTD_OU_PATH}"
 log_info "EDWARD PVT LTD OU path: ${EDWARD_PVT_LTD_OU_PATH}"
 log_info "Government Organization OU path: ${GOVERNMENT_ORG_OU_HANDLE}"
-log_info "Government child OUs: ${NPQS_OU_HANDLE}, ${FCAU_OU_HANDLE}, ${IRD_OU_HANDLE}, ${SLTB_OU_HANDLE}, ${CDA_OU_HANDLE}"
+log_info "Government child OUs: ${NPQS_OU_HANDLE}, ${FCAU_OU_HANDLE}, ${IRD_OU_HANDLE}, ${CDA_OU_HANDLE}"
 log_info "Private user type: Private_User"
 log_info "Government user type: Government_User"
 log_info "Traders group -> Trader role (NSW_API scopes)"
@@ -1787,9 +1726,9 @@ log_info "suresh in groups: Traders, CHA"
 log_info "ramesh in groups: CHA"
 log_info "gomesh in groups: Traders"
 log_info "naresh (EDWARD PVT LTD) in groups: CHA"
-log_info "Government users: npqs_user, fcau_user, ird_user, sltb_user, cda_user"
-log_info "App client IDs: TRADER_PORTAL_APP, OGA_PORTAL_APP_NPQS, OGA_PORTAL_APP_FCAU, OGA_PORTAL_APP_IRD, OGA_PORTAL_APP_SLTB, OGA_PORTAL_APP_CDA"
-log_info "M2M client IDs: NPQS_TO_NSW, FCAU_TO_NSW, IRD_TO_NSW, SLTB_TO_NSW, CDA_TO_NSW"
+log_info "Government users: npqs_user, fcau_user, ird_user, cda_user"
+log_info "App client IDs: TRADER_PORTAL_APP, OGA_PORTAL_APP_NPQS, OGA_PORTAL_APP_FCAU, OGA_PORTAL_APP_IRD, OGA_PORTAL_APP_CDA"
+log_info "M2M client IDs: NPQS_TO_NSW, FCAU_TO_NSW, IRD_TO_NSW, CDA_TO_NSW"
 log_info "M2M auth method: client_secret_basic"
 echo ""
 log_info "Resource servers (token audiences):"

--- a/idp/02-sample-resources.sh
+++ b/idp/02-sample-resources.sh
@@ -22,11 +22,13 @@ NARESH_PASSWORD="${SAMPLE_NARESH_PASSWORD:-${SAMPLE_USER_PASSWORD}}"
 NPQS_USER_PASSWORD="${SAMPLE_NPQS_USER_PASSWORD:-${SAMPLE_USER_PASSWORD}}"
 FCAU_USER_PASSWORD="${SAMPLE_FCAU_USER_PASSWORD:-${SAMPLE_USER_PASSWORD}}"
 IRD_USER_PASSWORD="${SAMPLE_IRD_USER_PASSWORD:-${SAMPLE_USER_PASSWORD}}"
+SLTB_USER_PASSWORD="${SAMPLE_SLTB_USER_PASSWORD:-${SAMPLE_USER_PASSWORD}}"
 CDA_USER_PASSWORD="${SAMPLE_CDA_USER_PASSWORD:-${SAMPLE_USER_PASSWORD}}"
 M2M_CLIENT_SECRET="${M2M_CLIENT_SECRET:-1234}"
 NPQS_M2M_CLIENT_SECRET="${M2M_NPQS_SECRET:-${M2M_CLIENT_SECRET}}"
 FCAU_M2M_CLIENT_SECRET="${M2M_FCAU_SECRET:-${M2M_CLIENT_SECRET}}"
 IRD_M2M_CLIENT_SECRET="${M2M_IRD_SECRET:-${M2M_CLIENT_SECRET}}"
+SLTB_M2M_CLIENT_SECRET="${M2M_SLTB_SECRET:-${M2M_CLIENT_SECRET}}"
 CDA_M2M_CLIENT_SECRET="${M2M_CDA_SECRET:-${M2M_CLIENT_SECRET}}"
 
 # ----------------------------------------------------------------------------
@@ -326,6 +328,10 @@ create_spa_application() {
                     ]
                 },
                 "scopeClaims": {
+                    "openid": [
+                        "ouId",
+                        "ouHandle"
+                    ],
                     "profile": [
                         "name",
                         "given_name",
@@ -956,6 +962,7 @@ GOVERNMENT_ORG_OU_HANDLE="government-organization"
 NPQS_OU_HANDLE="npqs"
 FCAU_OU_HANDLE="fcau"
 IRD_OU_HANDLE="ird"
+SLTB_OU_HANDLE="sltb"
 CDA_OU_HANDLE="cda"
 
 log_info "Creating Government Organization root organization unit..."
@@ -1135,6 +1142,50 @@ if [[ -z "$IRD_OU_ID" ]]; then
 fi
 
 log_info "IRD OU ID: $IRD_OU_ID"
+
+echo ""
+log_info "Creating SLTB organization unit..."
+
+read -r -d '' SLTB_OU_PAYLOAD <<JSON || true
+{
+    "handle": "${SLTB_OU_HANDLE}",
+    "name": "SLTB",
+    "description": "Sri Lanka Tea Board",
+    "parentId": "${GOVERNMENT_ORG_OU_ID}"
+}
+JSON
+
+RESPONSE=$(api_call POST "/organization-units" "${SLTB_OU_PAYLOAD}")
+HTTP_CODE="${RESPONSE: -3}"
+BODY="${RESPONSE%???}"
+
+if [[ "$HTTP_CODE" == "201" ]] || [[ "$HTTP_CODE" == "200" ]] || [[ "$HTTP_CODE" == "202" ]]; then
+    log_success "SLTB organization unit created successfully"
+    SLTB_OU_ID=$(extract_first_id "$BODY")
+elif [[ "$HTTP_CODE" == "409" ]]; then
+    log_warning "SLTB organization unit already exists, retrieving ID..."
+    RESPONSE=$(api_call GET "/organization-units/tree/${GOVERNMENT_ORG_OU_HANDLE}/${SLTB_OU_HANDLE}")
+    HTTP_CODE="${RESPONSE: -3}"
+    BODY="${RESPONSE%???}"
+    if [[ "$HTTP_CODE" == "200" ]]; then
+        SLTB_OU_ID=$(extract_first_id "$BODY")
+    else
+        log_error "Failed to fetch SLTB OU (HTTP $HTTP_CODE)"
+        echo "Response: $BODY"
+        exit 1
+    fi
+else
+    log_error "Failed to create SLTB organization unit (HTTP $HTTP_CODE)"
+    echo "Response: $BODY"
+    exit 1
+fi
+
+if [[ -z "$SLTB_OU_ID" ]]; then
+    log_error "Could not determine SLTB organization unit ID"
+    exit 1
+fi
+
+log_info "SLTB OU ID: $SLTB_OU_ID"
 
 echo ""
 log_info "Creating CDA organization unit..."
@@ -1583,6 +1634,9 @@ USER_FCAU_ID="$CREATED_USER_ID"
 create_user_in_ou "Government_User" "$IRD_OU_ID" "ird_user" "ird_user@government.dev" "IRD" "User" "$IRD_USER_PASSWORD" "+94771234562"
 USER_IRD_ID="$CREATED_USER_ID"
 
+create_user_in_ou "Government_User" "$SLTB_OU_ID" "sltb_user" "sltb_user@government.dev" "SLTB" "User" "$SLTB_USER_PASSWORD" "+94771234564"
+USER_SLTB_ID="$CREATED_USER_ID"
+
 create_user_in_ou "Government_User" "$CDA_OU_ID" "cda_user" "cda_user@government.dev" "CDA" "User" "$CDA_USER_PASSWORD" "+94771234563"
 USER_CDA_ID="$CREATED_USER_ID"
 
@@ -1604,6 +1658,7 @@ ensure_user_in_group "$CHA_GROUP_ID" "$USER_NARESH" "CHA" "naresh"
 ensure_user_in_group "$OGA_REVIEWERS_GROUP_ID" "$USER_NPQS_ID" "OGA Reviewers" "npqs_user"
 ensure_user_in_group "$OGA_REVIEWERS_GROUP_ID" "$USER_FCAU_ID" "OGA Reviewers" "fcau_user"
 ensure_user_in_group "$OGA_REVIEWERS_GROUP_ID" "$USER_IRD_ID" "OGA Reviewers" "ird_user"
+ensure_user_in_group "$OGA_REVIEWERS_GROUP_ID" "$USER_SLTB_ID" "OGA Reviewers" "sltb_user"
 ensure_user_in_group "$OGA_REVIEWERS_GROUP_ID" "$USER_CDA_ID" "OGA Reviewers" "cda_user"
 
 echo ""
@@ -1657,12 +1712,14 @@ DEFAULT_OU_ID_FOR_TRADER=$(get_ou_id_by_handle "default")
 NPQS_OU_ID_FOR_APP=$(get_ou_id_by_handle "government-organization/npqs")
 FCAU_OU_ID_FOR_APP=$(get_ou_id_by_handle "government-organization/fcau")
 IRD_OU_ID_FOR_APP=$(get_ou_id_by_handle "government-organization/ird")
+SLTB_OU_ID_FOR_APP=$(get_ou_id_by_handle "government-organization/sltb")
 CDA_OU_ID_FOR_APP=$(get_ou_id_by_handle "government-organization/cda")
 
 create_spa_application "TraderApp" "Application for trader portal built with React" "TRADER_PORTAL_APP" "5173" "Private_User" "${DEFAULT_OU_ID_FOR_TRADER}" "${TRADER_NSW_SCOPES}"
 create_spa_application "NPQSPortalApp" "Application for NPQS portal built with React" "OGA_PORTAL_APP_NPQS" "5174" "Government_User" "${NPQS_OU_ID_FOR_APP}" "${AGENCY_REVIEWER_SCOPES}"
 create_spa_application "FCAUPortalApp" "Application for FCAU portal built with React" "OGA_PORTAL_APP_FCAU" "5175" "Government_User" "${FCAU_OU_ID_FOR_APP}" "${AGENCY_REVIEWER_SCOPES}"
 create_spa_application "IRDPortalApp" "Application for IRD portal built with React" "OGA_PORTAL_APP_IRD" "5176" "Government_User" "${IRD_OU_ID_FOR_APP}" "${AGENCY_REVIEWER_SCOPES}"
+create_spa_application "SLTBPortalApp" "Application for SLTB portal built with React" "OGA_PORTAL_APP_SLTB" "5178" "Government_User" "${SLTB_OU_ID_FOR_APP}" "${AGENCY_REVIEWER_SCOPES}"
 create_spa_application "CDAPortalApp" "Application for CDA portal built with React" "OGA_PORTAL_APP_CDA" "5177" "Government_User" "${CDA_OU_ID_FOR_APP}" "${AGENCY_REVIEWER_SCOPES}"
 
 echo ""
@@ -1701,6 +1758,10 @@ create_m2m_application "IRD_TO_NSW_M2M" "Machine-to-machine integration for IRD 
 IRD_TO_NSW_M2M_APP_ID="$CREATED_M2M_APP_ID"
 assign_role_to_app "$AGENCY_M2M_ROLE_ID" "$IRD_TO_NSW_M2M_APP_ID" "AgencyM2M" "IRD_TO_NSW_M2M"
 
+create_m2m_application "SLTB_TO_NSW_M2M" "Machine-to-machine integration for SLTB to NSW" "SLTB_TO_NSW" "${SLTB_M2M_CLIENT_SECRET}" "${DEFAULT_OU_ID_FOR_M2M}" "${M2M_NSW_SCOPES}"
+SLTB_TO_NSW_M2M_APP_ID="$CREATED_M2M_APP_ID"
+assign_role_to_app "$AGENCY_M2M_ROLE_ID" "$SLTB_TO_NSW_M2M_APP_ID" "AgencyM2M" "SLTB_TO_NSW_M2M"
+
 create_m2m_application "CDA_TO_NSW_M2M" "Machine-to-machine integration for CDA to NSW" "CDA_TO_NSW" "${CDA_M2M_CLIENT_SECRET}" "${DEFAULT_OU_ID_FOR_M2M}" "${M2M_NSW_SCOPES}"
 CDA_TO_NSW_M2M_APP_ID="$CREATED_M2M_APP_ID"
 assign_role_to_app "$AGENCY_M2M_ROLE_ID" "$CDA_TO_NSW_M2M_APP_ID" "AgencyM2M" "CDA_TO_NSW_M2M"
@@ -1716,7 +1777,7 @@ log_info "Private Sector OU path: ${PRIVATE_SECTOR_OU_HANDLE}"
 log_info "ADAM PVT LTD OU path: ${ADAM_PVT_LTD_OU_PATH}"
 log_info "EDWARD PVT LTD OU path: ${EDWARD_PVT_LTD_OU_PATH}"
 log_info "Government Organization OU path: ${GOVERNMENT_ORG_OU_HANDLE}"
-log_info "Government child OUs: ${NPQS_OU_HANDLE}, ${FCAU_OU_HANDLE}, ${IRD_OU_HANDLE}, ${CDA_OU_HANDLE}"
+log_info "Government child OUs: ${NPQS_OU_HANDLE}, ${FCAU_OU_HANDLE}, ${IRD_OU_HANDLE}, ${SLTB_OU_HANDLE}, ${CDA_OU_HANDLE}"
 log_info "Private user type: Private_User"
 log_info "Government user type: Government_User"
 log_info "Traders group -> Trader role (NSW_API scopes)"
@@ -1726,9 +1787,9 @@ log_info "suresh in groups: Traders, CHA"
 log_info "ramesh in groups: CHA"
 log_info "gomesh in groups: Traders"
 log_info "naresh (EDWARD PVT LTD) in groups: CHA"
-log_info "Government users: npqs_user, fcau_user, ird_user, cda_user"
-log_info "App client IDs: TRADER_PORTAL_APP, OGA_PORTAL_APP_NPQS, OGA_PORTAL_APP_FCAU, OGA_PORTAL_APP_IRD, OGA_PORTAL_APP_CDA"
-log_info "M2M client IDs: NPQS_TO_NSW, FCAU_TO_NSW, IRD_TO_NSW, CDA_TO_NSW"
+log_info "Government users: npqs_user, fcau_user, ird_user, sltb_user, cda_user"
+log_info "App client IDs: TRADER_PORTAL_APP, OGA_PORTAL_APP_NPQS, OGA_PORTAL_APP_FCAU, OGA_PORTAL_APP_IRD, OGA_PORTAL_APP_SLTB, OGA_PORTAL_APP_CDA"
+log_info "M2M client IDs: NPQS_TO_NSW, FCAU_TO_NSW, IRD_TO_NSW, SLTB_TO_NSW, CDA_TO_NSW"
 log_info "M2M auth method: client_secret_basic"
 echo ""
 log_info "Resource servers (token audiences):"


### PR DESCRIPTION
## Changes
`s3_driver.go`: add a rewriteHost helper. When PublicURL is configured, it rewrites the host (and scheme) of the generated S3 presigned GET and PUT URLs, ensuring the browser reaches out to the storage-proxy while signature generation remains authentic against the backend tenant host
- `s3_driver_test.go`: verify URL hosts and schemes are correctly rewritten when a public proxy is supplied, and left untouched when not